### PR TITLE
Make travis build twice as fast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,9 @@
 
 sudo: required
 cache:
-  - ccache
-  - apt
+  apt: true
+  directories:
+    - $HOME/.ccache
 
 # Build all valid Ubuntu/ROS combinations available on Travis VMs.
 language: generic
@@ -73,7 +74,8 @@ before_install:
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt update
   - sudo apt-get install dpkg
-  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-kinetic-ros-base cmake libprotobuf-dev protobuf-compiler lcov gcovr qtbase5-dev
+  - sudo apt-get install -y ccache python-catkin-pkg python-rosdep python-wstool ros-kinetic-ros-base cmake libprotobuf-dev protobuf-compiler lcov gcovr qtbase5-dev
+  - dpkg -L ccache
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init
@@ -116,6 +118,9 @@ before_script:
 script:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   - source ~/catkin_ws/devel/setup.bash
+  - ln -s $(which ccache) /usr/local/bin/gcc
+  - ln -s $(which ccache) /usr/local/bin/g++
+  - ln -s $(which ccache) /usr/local/bin/cc
   - catkin_make --pkg roboteam_msgs roboteam_utils
   - cd ~/catkin_ws/src/roboteam_ai
   - mkdir cmake-build-debug && cd cmake-build-debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@
 sudo: required
 cache:
   - apt
+  directories:
+    - /opt/ros/$ROS_DISTRO
 
 # Build all valid Ubuntu/ROS combinations available on Travis VMs.
 language: generic
@@ -73,6 +75,7 @@ before_install:
   - sudo apt update
   - sudo apt-get install dpkg
   - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-kinetic-ros-base cmake libprotobuf-dev protobuf-compiler lcov gcovr
+  - dpkg -L
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@
 
 sudo: required
 cache:
-  - apt
+  apt: true
   directories:
     - /opt/ros/$ROS_DISTRO
     - ~/catkin_ws/src/roboteam_msgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,17 +43,6 @@ sudo: required
 cache:
   ccache: true
   apt: true
-  directories:
-    - /opt/ros/$ROS_DISTRO
-    - ~/catkin_ws/src/roboteam_msgs
-    - ~/catkin_ws/devel/roboteam_msgs
-    - /usr/lib/python2.7
-    - /usr/bin/cmake
-    - /usr/include/google/protobuf
-    - /usr/share/doc/protobuf-compiler
-    - /usr/share/doc/lcov
-    - /usr/include/x86_64-linux-gnu/qt5
-    - /usr/lib/x86_64-linux-gnu/cmake
 
 # Build all valid Ubuntu/ROS combinations available on Travis VMs.
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,8 +119,9 @@ script:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   - source ~/catkin_ws/devel/setup.bash
   - export PATH="/usr/lib/ccache/bin/:$PATH"
-  - export CC="ccache gcc"
-  - export CXX="ccache g++"
+  - cp ccache /usr/bin/
+  - ln -s ccache /usr/bin/cc
+  - ln -s ccache /usr/bin/c++
   - catkin_make --pkg roboteam_msgs roboteam_utils
   - cd ~/catkin_ws/src/roboteam_ai
   - mkdir cmake-build-debug && cd cmake-build-debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,14 +41,22 @@
 
 sudo: required
 cache:
+  ccache: true
   apt: true
   directories:
     - /opt/ros/$ROS_DISTRO
     - ~/catkin_ws/src/roboteam_msgs
     - ~/catkin_ws/devel/roboteam_msgs
+    - /usr/lib/python2.7
+    - /usr/bin/cmake
+    - /usr/include/google/protobuf
+    - /usr/share/doc/protobuf-compiler
+    - /usr/share/doc/lcov
+    - /usr/include/x86_64-linux-gnu/qt5
+    - /usr/lib/x86_64-linux-gnu/cmake
 
 # Build all valid Ubuntu/ROS combinations available on Travis VMs.
-language: generic
+language: cpp
 matrix:
   include:
     - name: "Xenial kinetic"
@@ -87,7 +95,6 @@ before_install:
   - dpkg -L lcov
   - dpkg -L gcovr
   - dpkg -L qtbase5-dev
-  - dpkg -L libqt5-core
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,19 @@ sudo: required
 cache:
   ccache: true
   apt: true
+  directories:
+    - /opt/ros/$ROS_DISTRO
+    - ~/catkin_ws/src/roboteam_msgs
+    - ~/catkin_ws/devel/roboteam_msgs
+    - /usr/lib/python2.7
+    - /usr/include/google/protobuf
+    - /usr/share/doc/protobuf-compiler
+    - /usr/share/doc/lcov
+    - /usr/include/x86_64-linux-gnu/qt5
+    - /usr/lib/x86_64-linux-gnu/cmake
 
 # Build all valid Ubuntu/ROS combinations available on Travis VMs.
-language: cpp
+language: generic
 matrix:
   include:
     - name: "Xenial kinetic"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ cache:
   - apt
   directories:
     - /opt/ros/$ROS_DISTRO
+    - ~/catkin_ws/src/roboteam_msgs
+    - ~/catkin_ws/devel/roboteam_msgs
 
 # Build all valid Ubuntu/ROS combinations available on Travis VMs.
 language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@
 ################################################################################
 
 sudo: required
+notifications:
+  email: false
 cache:
   apt: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,9 +118,11 @@ before_script:
 script:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   - source ~/catkin_ws/devel/setup.bash
-  - ln -s $(which ccache) /usr/local/bin/gcc
-  - ln -s $(which ccache) /usr/local/bin/g++
-  - ln -s $(which ccache) /usr/local/bin/cc
+  - cp ccache /usr/local/bin/
+  - ln -s ccache /usr/local/bin/gcc
+  - ln -s ccache /usr/local/bin/g++
+  - ln -s ccache /usr/local/bin/cc
+  - ln -s ccache /usr/local/bin/c++
   - catkin_make --pkg roboteam_msgs roboteam_utils
   - cd ~/catkin_ws/src/roboteam_ai
   - mkdir cmake-build-debug && cd cmake-build-debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,18 @@ before_install:
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt update
   - sudo apt-get install dpkg
-  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-kinetic-ros-base cmake libprotobuf-dev protobuf-compiler lcov gcovr
-  - dpkg -L
+  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-kinetic-ros-base cmake libprotobuf-dev protobuf-compiler lcov gcovr qtbase5-dev libqt5-core
+  - dpkg -L python-catkin-pkg
+  - dpkg -L python-rosdep
+  - dpkg -L python-wstool
+  - dpkg -L ros-kinetic-ros-base
+  - dpkg -L cmake
+  - dpkg -L libprotobuf-dev
+  - dpkg -L protobuf-compiler
+  - dpkg -L lcov
+  - dpkg -L gcovr
+  - dpkg -L qtbase5-dev
+  - dpkg -L libqt5-core
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,16 +76,6 @@ before_install:
   - sudo apt update
   - sudo apt-get install dpkg
   - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-kinetic-ros-base cmake libprotobuf-dev protobuf-compiler lcov gcovr qtbase5-dev
-  - dpkg -L python-catkin-pkg
-  - dpkg -L python-rosdep
-  - dpkg -L python-wstool
-  - dpkg -L ros-kinetic-ros-base
-  - dpkg -L cmake
-  - dpkg -L libprotobuf-dev
-  - dpkg -L protobuf-compiler
-  - dpkg -L lcov
-  - dpkg -L gcovr
-  - dpkg -L qtbase5-dev
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,7 @@ before_script:
 script:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   - source ~/catkin_ws/devel/setup.bash
+  - export PATH="/usr/lib/ccache/bin/:$PATH"
   - cp ccache /usr/local/bin/
   - ln -s ccache /usr/local/bin/gcc
   - ln -s ccache /usr/local/bin/g++

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,11 +119,8 @@ script:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   - source ~/catkin_ws/devel/setup.bash
   - export PATH="/usr/lib/ccache/bin/:$PATH"
-  - cp ccache /usr/local/bin/
-  - ln -s ccache /usr/local/bin/gcc
-  - ln -s ccache /usr/local/bin/g++
-  - ln -s ccache /usr/local/bin/cc
-  - ln -s ccache /usr/local/bin/c++
+  - export CC="ccache gcc"
+  - export CXX="ccache g++"
   - catkin_make --pkg roboteam_msgs roboteam_utils
   - cd ~/catkin_ws/src/roboteam_ai
   - mkdir cmake-build-debug && cd cmake-build-debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ cache:
   ccache: true
   apt: true
   directories:
-    - /opt/ros/$ROS_DISTRO
     - ~/catkin_ws/devel/roboteam_msgs
     - /usr/lib/python2.7
     - /usr/include/google/protobuf

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_install:
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt update
   - sudo apt-get install dpkg
-  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-kinetic-ros-base cmake libprotobuf-dev protobuf-compiler lcov gcovr qtbase5-dev libqt5-core
+  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-kinetic-ros-base cmake libprotobuf-dev protobuf-compiler lcov gcovr qtbase5-dev
   - dpkg -L python-catkin-pkg
   - dpkg -L python-rosdep
   - dpkg -L python-wstool

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,6 @@ cache:
   apt: true
   directories:
     - ~/catkin_ws/devel/roboteam_msgs
-    - /usr/lib/python2.7
-    - /usr/include/google/protobuf
-    - /usr/share/doc/protobuf-compiler
-    - /usr/share/doc/lcov
-    - /usr/include/x86_64-linux-gnu/qt5
-    - /usr/lib/x86_64-linux-gnu/cmake
 
 # Build all valid Ubuntu/ROS combinations available on Travis VMs.
 language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ cache:
   apt: true
   directories:
     - /opt/ros/$ROS_DISTRO
-    - ~/catkin_ws/src/roboteam_msgs
     - ~/catkin_ws/devel/roboteam_msgs
     - /usr/lib/python2.7
     - /usr/include/google/protobuf

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,8 @@
 
 sudo: required
 cache:
-  ccache: true
-  apt: true
-  directories:
-    - ~/catkin_ws/devel/roboteam_msgs
+  - ccache
+  - apt
 
 # Build all valid Ubuntu/ROS combinations available on Travis VMs.
 language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,9 +119,8 @@ script:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   - source ~/catkin_ws/devel/setup.bash
   - export PATH="/usr/lib/ccache/bin/:$PATH"
-  - cp ccache /usr/bin/
-  - ln -s ccache /usr/bin/cc
-  - ln -s ccache /usr/bin/c++
+  - export CC="ccache gcc"
+  - export CXX="ccache g++"
   - catkin_make --pkg roboteam_msgs roboteam_utils
   - cd ~/catkin_ws/src/roboteam_ai
   - mkdir cmake-build-debug && cd cmake-build-debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,6 @@ before_install:
   - sudo apt update
   - sudo apt-get install dpkg
   - sudo apt-get install -y ccache python-catkin-pkg python-rosdep python-wstool ros-kinetic-ros-base cmake libprotobuf-dev protobuf-compiler lcov gcovr qtbase5-dev
-  - dpkg -L ccache
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init


### PR DESCRIPTION
By using better caching (ccache) for the CC/CXX compiler I managed to reduce build time with more than 50%! 

<img width="258" alt="screenshot 2019-01-11 at 10 19 26" src="https://user-images.githubusercontent.com/1770461/51025101-7b9c7780-158b-11e9-884b-3047955b3835.png">