### PR TITLE
make sure ros is properly used in world

### DIFF
--- a/roboteam_ai/src/io/IOManager.cpp
+++ b/roboteam_ai/src/io/IOManager.cpp
@@ -8,6 +8,8 @@
 #include <roboteam_msgs/DemoRobot.h>
 #include <roboteam_ai/src/demo/JoystickDemo.h>
 #include <roboteam_ai/src/utilities/Pause.h>
+#include <roboteam_ai/src/world/Field.h>
+#include <roboteam_ai/src/utilities/Referee.hpp>
 #include "IOManager.h"
 
 
@@ -86,13 +88,14 @@ void IOManager::subscribeToDemoInfo() {
 
 void IOManager::handleWorldState(const roboteam_msgs::WorldConstPtr &w) {
     std::lock_guard<std::mutex> lock(mutex);
-
     this->worldMsg = *w;
+    world::world->updateWorld(this->worldMsg);
 }
 
 void IOManager::handleGeometryData(const roboteam_msgs::GeometryDataConstPtr &geometry) {
     std::lock_guard<std::mutex> lock(mutex);
     this->geometryMsg = *geometry;
+    world::field->set_field(this->geometryMsg.field);
 }
 
 void IOManager::handleRobotFeedback(const roboteam_msgs::RoleFeedbackConstPtr &rolefeedback) {
@@ -108,6 +111,7 @@ void IOManager::handleDemoInfo(const roboteam_msgs::DemoRobotConstPtr &demoInfo)
 void IOManager::handleRefereeData(const roboteam_msgs::RefereeDataConstPtr &refData) {
     std::lock_guard<std::mutex> lock(mutex);
     this->refDataMsg = *refData;
+    Referee::setRefereeData(this->refDataMsg);
 }
 
 const roboteam_msgs::World &IOManager::getWorldState() {

--- a/roboteam_ai/src/world/WorldManager.cpp
+++ b/roboteam_ai/src/world/WorldManager.cpp
@@ -14,125 +14,15 @@ void WorldManager::setup() {
     IOManager = new io::IOManager(true, false);
 }
 
+// spin ROS at 4x our tick rate
 void WorldManager::loop() {
     ros::Rate rate(4.0 * ai::Constants::TICK_RATE());
-
-
     while (ros::ok()) {
         ros::spinOnce();
         rate.sleep();
-        unsigned char changes = updateROSData();
-        if (changes == 0b000) continue;
-        
-        if (changes & 0b001) updateReferee();
-        if (changes & 0b010) updateWorld();
-        if (changes & 0b100) updateGeometry();
     }
 }
 
-unsigned char WorldManager::updateROSData() {
-    // make ROS world_state and geometry data globally accessible
-    unsigned char anyMsgHasChanged = 0b000;
-
-    auto oldWorldMsg = worldMsg;
-    auto oldGeometryMsg = geometryMsg;
-    auto oldRefereeMsg = refereeMsg;
-
-    refereeMsg = IOManager->getRefereeData();
-    worldMsg = IOManager->getWorldState();
-    geometryMsg = IOManager->getGeometryData();
-
-    // refereeMsg:  0b001
-    anyMsgHasChanged = anyMsgHasChanged | refereeMsgChanged(oldRefereeMsg, refereeMsg);
-    // worldMsg:    0b010
-    anyMsgHasChanged = anyMsgHasChanged | worldMsgChanged(oldWorldMsg, worldMsg);
-    // geometryMsg: 0b100
-    anyMsgHasChanged = anyMsgHasChanged | geometryMsgChanged(worldMsg);
-
-    return anyMsgHasChanged;
-}
-
-void WorldManager::updateReferee() {
-    if (ai::interface::InterfaceValues::usesRefereeCommands()) {
-
-        ai::StrategyManager strategyManager;
-        // Warning, this means that the names in strategy manager needs to match one on one with the JSON names
-        // might want to build something that verifies this
-        auto oldStrategy = BTFactory::getCurrentTree();
-        std::string strategyName = strategyManager.getCurrentStrategyName(refereeMsg.command);
-        if (oldStrategy != strategyName) {
-            BTFactory::makeTrees();
-            BTFactory::setCurrentTree(strategyName);
-        }
-
-
-        auto oldKeeperTree = BTFactory::getKeeperTreeName();
-        std::string keeperTreeName = strategyManager.getCurrentKeeperTreeName(refereeMsg.command);
-        if (oldKeeperTree != keeperTreeName) {
-            std::cout << oldKeeperTree <<  "vs " << keeperTreeName << std::endl;
-            BTFactory::makeTrees();
-            BTFactory::setKeeperTree(keeperTreeName);
-        }
-
-
-        // if there is a referee, we always want to have a separate keeper tree.
-        robotDealer::RobotDealer::setUseSeparateKeeper(true);
-//        robotDealer::RobotDealer::setKeeperID(refereeMsg.us.goalie);
-    }
-}
-
-void WorldManager::updateWorld() {
-    world->updateWorld(worldMsg);
-}
-
-void WorldManager::updateGeometry() {
-    world::field->set_field(geometryMsg.field);
-}
-
-void WorldManager::updateGameAnalyzer(const WorldData &worldData) {
-    //TODO:
-}
-
-
-unsigned char WorldManager::refereeMsgChanged(roboteam_msgs::RefereeData oldR, roboteam_msgs::RefereeData newR) {
-    unsigned char bit = 0b000;
-
-    bool msgChanged = true;
-    msgChanged |= oldR.packet_timestamp != newR.packet_timestamp;
-    msgChanged |= oldR.command_timestamp != newR.command_timestamp;
-
-    if (msgChanged) bit = 0b001;
-
-    return bit;
-}
-
-unsigned char WorldManager::worldMsgChanged(roboteam_msgs::World oldW, roboteam_msgs::World newW) {
-    unsigned char bit = 0b000;
-
-    bool msgChanged = false;
-    msgChanged |= oldW.time != newW.time;
-    msgChanged |= (Vector2)oldW.ball.pos != newW.ball.pos;
-    msgChanged |= (Vector2)oldW.ball.vel != newW.ball.vel;
-
-    if (msgChanged) bit = 0b010;
-
-    return bit;
-}
-
-unsigned char WorldManager::geometryMsgChanged(roboteam_msgs::World newG) {
-    unsigned char bit = 0b000;
-
-    double updateEveryThisManySeconds = 1.0;
-    static double lastUpdatedTime = 0.0;
-    bool msgChanged = newG.time - lastUpdatedTime > updateEveryThisManySeconds;
-
-    if (msgChanged) {
-        lastUpdatedTime = newG.time;
-        bit = 0b100;
-    }
-
-    return bit;
-}
 
 }
 }

--- a/roboteam_ai/src/world/WorldManager.h
+++ b/roboteam_ai/src/world/WorldManager.h
@@ -19,23 +19,7 @@ namespace world {
 
 class WorldManager {
     private:
-
         io::IOManager* IOManager;
-        double lastWorldTime;
-        roboteam_msgs::World worldMsg;
-        roboteam_msgs::GeometryData geometryMsg;
-        roboteam_msgs::RefereeData refereeMsg;
-
-        unsigned char updateROSData();
-
-        void updateReferee();
-        void updateWorld();
-        void updateGeometry();
-        void updateGameAnalyzer(const WorldData &worldData);
-
-        unsigned char refereeMsgChanged(roboteam_msgs::RefereeData oldR, roboteam_msgs::RefereeData newR);
-        unsigned char worldMsgChanged(roboteam_msgs::World oldW, roboteam_msgs::World newW);
-        unsigned char geometryMsgChanged(roboteam_msgs::World newG);
 
     public:
         void setup();


### PR DESCRIPTION
While working on referee fixes I noticed that there was a lot of unused code in worldmanager.
Basically that whole thing was unnecessary, since it was checking if a message changed while ROS just notifies you on that. 

tested the performance with htop and it is about equal. 