### PR TITLE
Hotfix/keeper claiming and fix defence area implementation

### DIFF
--- a/roboteam_ai/src/ApplicationManager.cpp
+++ b/roboteam_ai/src/ApplicationManager.cpp
@@ -114,7 +114,7 @@ void ApplicationManager::runOneLoopCycle() {
                 ai::robotDealer::RobotDealer::setKeeperID(ai::world::world->getUs().at(0).id);
             }
             keeperTree = BTFactory::getKeeperTree();
-            if (keeperTree) {
+            if (keeperTree && rtt::ai::robotDealer::RobotDealer::keeperExistsInWorld()) {
                 keeperTree->tick();
             }
         }

--- a/roboteam_ai/src/analysis/DecisionMaker.cpp
+++ b/roboteam_ai/src/analysis/DecisionMaker.cpp
@@ -14,8 +14,15 @@ namespace analysis {
 PlayStyle DecisionMaker::getRecommendedPlayStyle(BallPossession possession) {
     int amountOfRobots = world::world->getUs().size();
 
+    // if we use the keeper we should check if it is currently visible
+    // if it is not visible we should claim all robots visible in world
+    // otherwise we should subtract the keeper
+    bool keeperIsInWorld = std::find_if(world::world->getUs().begin(), world::world->getUs().end(), [](world::Robot robot) {
+        return robot.id == robotDealer::RobotDealer::getKeeperID();
+    }) != world::world->getUs().end();
+
     // subtract one robot if we need a keeper
-    if (robotDealer::RobotDealer::usesSeparateKeeper()) {
+    if (robotDealer::RobotDealer::usesSeparateKeeper() && keeperIsInWorld) {
         amountOfRobots = std::max(0, amountOfRobots-1);
     }
 

--- a/roboteam_ai/src/analysis/DecisionMaker.cpp
+++ b/roboteam_ai/src/analysis/DecisionMaker.cpp
@@ -17,15 +17,13 @@ PlayStyle DecisionMaker::getRecommendedPlayStyle(BallPossession possession) {
     // if we use the keeper we should check if it is currently visible
     // if it is not visible we should claim all robots visible in world
     // otherwise we should subtract the keeper
-    bool keeperIsInWorld = std::find_if(world::world->getUs().begin(), world::world->getUs().end(), [](world::Robot robot) {
-        return robot.id == robotDealer::RobotDealer::getKeeperID();
-    }) != world::world->getUs().end();
+
+
 
     // subtract one robot if we need a keeper
-    if (robotDealer::RobotDealer::usesSeparateKeeper() && keeperIsInWorld) {
+    if (robotDealer::RobotDealer::usesSeparateKeeper() && robotDealer::RobotDealer::keeperExistsInWorld()) {
         amountOfRobots = std::max(0, amountOfRobots-1);
     }
-
   PlayStyle styles[9][5]  = {
 
           {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}}, // 0

--- a/roboteam_ai/src/analysis/DecisionMaker.cpp
+++ b/roboteam_ai/src/analysis/DecisionMaker.cpp
@@ -14,13 +14,7 @@ namespace analysis {
 PlayStyle DecisionMaker::getRecommendedPlayStyle(BallPossession possession) {
     int amountOfRobots = world::world->getUs().size();
 
-    // if we use the keeper we should check if it is currently visible
-    // if it is not visible we should claim all robots visible in world
-    // otherwise we should subtract the keeper
-
-
-
-    // subtract one robot if we need a keeper
+    // subtract one robot if we have a keeper
     if (robotDealer::RobotDealer::usesSeparateKeeper() && robotDealer::RobotDealer::keeperExistsInWorld()) {
         amountOfRobots = std::max(0, amountOfRobots-1);
     }

--- a/roboteam_ai/src/bt/tactics/DefaultTactic.cpp
+++ b/roboteam_ai/src/bt/tactics/DefaultTactic.cpp
@@ -135,7 +135,7 @@ void bt::DefaultTactic::updateStyle() {
     else if (thisType == Offensive) {
         amountToTick = style.amountOfAttackers;
     }
-    else if (rtt::ai::robotDealer::RobotDealer::usesSeparateKeeper()) {
+    else if (rtt::ai::robotDealer::RobotDealer::usesSeparateKeeper() && rtt::ai::robotDealer::RobotDealer::keeperExistsInWorld()) {
         amountToTick = rtt::ai::world::world->getUs().size() - 1;
     } else {
         amountToTick = rtt::ai::world::world->getUs().size();

--- a/roboteam_ai/src/bt/tactics/DefaultTactic.cpp
+++ b/roboteam_ai/src/bt/tactics/DefaultTactic.cpp
@@ -27,7 +27,11 @@ bt::Node::Status bt::DefaultTactic::update() {
     }
 
     for (int i = 0; i < amountToTick; i ++) {
-        children.at(i)->tick();
+        if (children.size() > i && children.at(i)) {
+            children.at(i)->tick();
+        } else {
+            std::cerr << "trying to tick a non-existent robot!" << std::endl;
+        }
     }
 
     return status == Status::Success ? status : Status::Running;

--- a/roboteam_ai/src/coach/midField/HarassRobotCoach.cpp
+++ b/roboteam_ai/src/coach/midField/HarassRobotCoach.cpp
@@ -175,7 +175,9 @@ HarassRobotCoach::HarassTarget HarassRobotCoach::findRobotToHarass(const RobotPt
     }
 
     // can't get a robot to harass, remove my targetRobot if it was there
-    targetRobotsToHarass[myIndex] = RobotPtr(nullptr);
+    if (myIndex != -1) {
+        targetRobotsToHarass[myIndex] = RobotPtr(nullptr);
+    }
 
     harassTarget.harassRobot = -1;
     harassTarget.harassPosition = standInMidField(thisRobot, myIndex);

--- a/roboteam_ai/src/control/PositionUtils.cpp
+++ b/roboteam_ai/src/control/PositionUtils.cpp
@@ -118,7 +118,9 @@ std::vector<Vector2> PositionUtils::getFreeKickPositions(int number) {
     std::vector<Vector2> temp = {line1, def1, def2, line2, line3};
     std::vector<Vector2> res;
     for (int i = 0; i < number; i ++) {
-        res.emplace_back(temp.at(i));
+        if (temp.size() > i) {
+            res.emplace_back(temp.at(i));
+        }
     }
     return res;
 }
@@ -165,7 +167,9 @@ std::vector<Vector2> PositionUtils::getDefendPenaltyPositions(int number) {
 
     std::vector<Vector2> res;
     for (int i = 0; i < number; i ++) {
-        res.emplace_back(temp.at(i));
+        if (i < temp.size()) {
+            res.emplace_back(temp.at(i));
+        }
     }
     return res;
 }

--- a/roboteam_ai/src/interface/api/Input.cpp
+++ b/roboteam_ai/src/interface/api/Input.cpp
@@ -43,6 +43,9 @@ void Input::clearDrawings() {
     drawings = {};
 }
 
+Input::~Input() {
+    clearDrawings();
+}
 
 
 } // interface

--- a/roboteam_ai/src/interface/api/Input.h
+++ b/roboteam_ai/src/interface/api/Input.h
@@ -50,6 +50,9 @@ struct Drawing {
 class Input {
 public:
     explicit Input() = default;
+
+    virtual ~Input();
+
     static void clearDrawings();
     static const std::vector<Drawing> &getDrawings();
     static void drawData(Visual visual, std::vector<Vector2> points, QColor color, int robotId = -1, Drawing::DrawingMethod method = Drawing::DOTS, double width = 4.0, double height = 4.0, double strokeWidth = 2.0);

--- a/roboteam_ai/src/skills/formations/Formation.cpp
+++ b/roboteam_ai/src/skills/formations/Formation.cpp
@@ -61,7 +61,7 @@ void Formation::addRobotToFormation() {
 // remove robot from formation
 void Formation::removeRobotFromFormation() {
     for (unsigned int i = 0; i < robotsInFormationPtr()->size(); i++) {
-        if (robotsInFormationPtr()->at(i)->id == robot->id) {
+        if (robotsInFormationPtr()->at(i) && robotsInFormationPtr()->at(i)->id == robot->id) {
             robotsInFormationPtr()->erase(robotsInFormationPtr()->begin() + i);
         }
     }

--- a/roboteam_ai/src/skills/formations/KickOffUsFormation.cpp
+++ b/roboteam_ai/src/skills/formations/KickOffUsFormation.cpp
@@ -30,7 +30,9 @@ Vector2 KickOffUsFormation::getFormationPosition() {
     };
 
     for (auto const &robot : * robotsInFormation) {
-        robotIds.push_back(robot->id);
+        if (robot) {
+            robotIds.push_back(robot->id);
+        }
     }
 
     rtt::HungarianAlgorithm hungarian;

--- a/roboteam_ai/src/utilities/RobotDealer.cpp
+++ b/roboteam_ai/src/utilities/RobotDealer.cpp
@@ -321,7 +321,10 @@ std::string RobotDealer::getRoleNameForId(int ID) {
 }
 
 void RobotDealer::halt() {
-    robotOwners.clear();
+    {
+        std::lock_guard<std::mutex> lock(robotOwnersLock);
+        robotOwners.clear();
+    }
     RobotDealer::updateFromWorld();
     hasClaimedKeeper = false;
 }

--- a/roboteam_ai/src/utilities/RobotDealer.cpp
+++ b/roboteam_ai/src/utilities/RobotDealer.cpp
@@ -369,11 +369,12 @@ void RobotDealer::setUseSeparateKeeper(bool useSeparateKeeper) {
 }
 
 bool RobotDealer::keeperExistsInWorld() {
-    auto us = world::world->getUs();
-
-    return std::find_if(us.begin(), us.end(), [](world::Robot & robot) {
-        return robot.id == getKeeperID();
-    }) != us.end();
+    for (auto const &robot : world::world->getUs()) {
+        if (robot.id == getKeeperID()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 } // robotDealer

--- a/roboteam_ai/src/utilities/RobotDealer.cpp
+++ b/roboteam_ai/src/utilities/RobotDealer.cpp
@@ -367,6 +367,14 @@ void RobotDealer::setUseSeparateKeeper(bool useSeparateKeeper) {
     RobotDealer::useSeparateKeeper = useSeparateKeeper;
 }
 
+bool RobotDealer::keeperExistsInWorld() {
+    auto us = world::world->getUs();
+
+    return std::find_if(us.begin(), us.end(), [](world::Robot & robot) {
+        return robot.id == getKeeperID();
+    }) != us.end();
+}
+
 } // robotDealer
 } // ai
 } // rtt

--- a/roboteam_ai/src/utilities/RobotDealer.cpp
+++ b/roboteam_ai/src/utilities/RobotDealer.cpp
@@ -354,9 +354,7 @@ void RobotDealer::refresh() {
     if (BTFactory::getCurrentTree() != "NaN" && BTFactory::getTree(BTFactory::getCurrentTree())) {
         BTFactory::getTree(BTFactory::getCurrentTree())->terminate(bt::Node::Status::Success);
     }
-   // BTFactory::makeTrees();
-
-    if (useSeparateKeeper) claimKeeper();
+    if (useSeparateKeeper && keeperExistsInWorld()) claimKeeper();
 }
 
 bool RobotDealer::usesSeparateKeeper() {

--- a/roboteam_ai/src/utilities/RobotDealer.h
+++ b/roboteam_ai/src/utilities/RobotDealer.h
@@ -61,6 +61,7 @@ public:
     static void refresh();
 
     static bool usesSeparateKeeper();
+    static bool keeperExistsInWorld();
     static void setUseSeparateKeeper(bool useSeparateKeeper);
 
 };

--- a/roboteam_ai/src/world/Field.cpp
+++ b/roboteam_ai/src/world/Field.cpp
@@ -44,36 +44,33 @@ bool Field::pointIsInDefenceArea(const Vector2& point, bool isOurDefenceArea, fl
     double yTopBound;
     double yBottomBound;
     double xForwardBound = penaltyLine.begin.x;
-    double xBackBound = isOurDefenceArea ? field.field_length/-2.0 : field.field_length/2.0;
+    double xBackBound = isOurDefenceArea ? _field.field_length/-2.0 : _field.field_length/2.0;
     if (penaltyLine.begin.y < penaltyLine.end.y) {
         yBottomBound = penaltyLine.begin.y;
         yTopBound = penaltyLine.end.y;
-    }
-    else {
+    } else {
         yBottomBound = penaltyLine.end.y;
         yTopBound = penaltyLine.begin.y;
     }
     bool yIsWithinDefenceArea = point.y<(yTopBound + margin) && point.y>(yBottomBound - margin);
-    bool xIsWithinOurDefenceArea = point.x < (xForwardBound + margin) && point.x> (xBackBound-margin);
-    bool xIsWithinTheirDefenceArea = point.x > (xForwardBound - margin) && point.x<(xBackBound+margin);
+
+    bool xIsWithinOurDefenceArea;
+    bool xIsWithinTheirDefenceArea;
+    if (includeOutsideField) {
+        // if outside field are included then we don't need the back border
+        xIsWithinOurDefenceArea = point.x<(xForwardBound + margin);
+        xIsWithinTheirDefenceArea = point.x > (xForwardBound - margin);
+    } else {
+        xIsWithinOurDefenceArea = point.x<(xForwardBound + margin) && point.x>(xBackBound - margin);
+        xIsWithinTheirDefenceArea = point.x > (xForwardBound - margin) && point.x < (xBackBound + margin);
+    }
 
     if (isOurDefenceArea) {
-        if (includeOutsideField) {
-            return xIsWithinOurDefenceArea;
-        }
-        else {
-            return xIsWithinOurDefenceArea && yIsWithinDefenceArea;
-        }
+        return xIsWithinOurDefenceArea && yIsWithinDefenceArea;
     }
-    else {
-        if (includeOutsideField) {
-            return xIsWithinTheirDefenceArea;
-        }
-        else {
-            return yIsWithinDefenceArea && xIsWithinTheirDefenceArea;
-        }
-    }
+    return yIsWithinDefenceArea && xIsWithinTheirDefenceArea;
 }
+
 
 // the margin is pointed inside the field!
 bool Field::pointIsInField(const Vector2& point, float margin) {

--- a/roboteam_ai/src/world/Field.cpp
+++ b/roboteam_ai/src/world/Field.cpp
@@ -98,7 +98,12 @@ double Field::getTotalGoalAngle(bool ourGoal, const Vector2& point){
 
 }
 double Field::getPercentageOfGoalVisibleFromPoint(bool ourGoal, const Vector2& point, const WorldData &data) {
-    double goalWidth = field.goal_width;
+    roboteam_msgs::GeometryFieldSize _field;
+    {
+        std::lock_guard<std::mutex> lock(fieldMutex);
+        _field = field;
+    }
+    double goalWidth = _field.goal_width;
     double blockadeLength = 0;
     for (auto const &blockade : getBlockadesMappedToGoal(ourGoal, point,data)) {
         blockadeLength += blockade.first.dist(blockade.second);
@@ -314,30 +319,36 @@ Vector2 Field::getPenaltyPoint(bool ourGoal) {
 
 }
 std::shared_ptr<Vector2> Field::lineIntersectsWithDefenceArea(bool ourGoal, const Vector2& lineStart, const Vector2& lineEnd,double margin) {
+    roboteam_msgs::GeometryFieldSize _field;
+    {
+        std::lock_guard<std::mutex> lock(fieldMutex);
+        _field = field;
+    }
+
     Vector2 goalLinePos1,goalLinePos2,cornerPos1,cornerPos2;
     std::shared_ptr<Vector2> intersectPos= nullptr;
     if (ourGoal) {
-        goalLinePos1 = Vector2(- field.field_length*0.5, field.left_penalty_line.begin.y - margin);
-        goalLinePos2 = Vector2(- field.field_length*0.5, field.left_penalty_line.end.y + margin);
-        cornerPos1 = Vector2(margin, - margin) + field.left_penalty_line.begin;
-        cornerPos2 = Vector2(margin, margin) + field.left_penalty_line.end;
-        if (field.left_penalty_line.begin.y > field.left_penalty_line.end.y) {
-            goalLinePos1 = Vector2(- field.field_length*0.5, field.left_penalty_line.begin.y + margin);
-            goalLinePos2 = Vector2(- field.field_length*0.5, field.left_penalty_line.end.y - margin);
-            cornerPos1 = Vector2(margin, margin) + field.left_penalty_line.begin;
-            cornerPos2 = Vector2(margin, - margin) + field.left_penalty_line.end;
+        goalLinePos1 = Vector2(- _field.field_length*0.5, _field.left_penalty_line.begin.y - margin);
+        goalLinePos2 = Vector2(- _field.field_length*0.5, _field.left_penalty_line.end.y + margin);
+        cornerPos1 = Vector2(margin, - margin) + _field.left_penalty_line.begin;
+        cornerPos2 = Vector2(margin, margin) + _field.left_penalty_line.end;
+        if (_field.left_penalty_line.begin.y > _field.left_penalty_line.end.y) {
+            goalLinePos1 = Vector2(- _field.field_length*0.5, _field.left_penalty_line.begin.y + margin);
+            goalLinePos2 = Vector2(- _field.field_length*0.5, _field.left_penalty_line.end.y - margin);
+            cornerPos1 = Vector2(margin, margin) + _field.left_penalty_line.begin;
+            cornerPos2 = Vector2(margin, - margin) + _field.left_penalty_line.end;
         }
     }
     else{
-        goalLinePos1 = Vector2(field.field_length*0.5, field.right_penalty_line.begin.y - margin);
-        goalLinePos2 = Vector2(field.field_length*0.5, field.right_penalty_line.end.y + margin);
-        cornerPos1 = Vector2(-margin, - margin) + field.right_penalty_line.begin;
-        cornerPos2 = Vector2(-margin, margin) + field.right_penalty_line.end;
-        if (field.right_penalty_line.begin.y > field.right_penalty_line.end.y) {
-            goalLinePos1 = Vector2(field.field_length*0.5, field.right_penalty_line.begin.y + margin);
-            goalLinePos2 = Vector2(field.field_length*0.5, field.right_penalty_line.end.y - margin);
-            cornerPos1 = Vector2(-margin, margin) + field.right_penalty_line.begin;
-            cornerPos2 = Vector2(-margin, - margin) + field.right_penalty_line.end;
+        goalLinePos1 = Vector2(_field.field_length*0.5, _field.right_penalty_line.begin.y - margin);
+        goalLinePos2 = Vector2(_field.field_length*0.5, _field.right_penalty_line.end.y + margin);
+        cornerPos1 = Vector2(-margin, - margin) + _field.right_penalty_line.begin;
+        cornerPos2 = Vector2(-margin, margin) + _field.right_penalty_line.end;
+        if (_field.right_penalty_line.begin.y > _field.right_penalty_line.end.y) {
+            goalLinePos1 = Vector2(_field.field_length*0.5, _field.right_penalty_line.begin.y + margin);
+            goalLinePos2 = Vector2(_field.field_length*0.5, _field.right_penalty_line.end.y - margin);
+            cornerPos1 = Vector2(-margin, margin) + _field.right_penalty_line.begin;
+            cornerPos2 = Vector2(-margin, - margin) + _field.right_penalty_line.end;
         }
     }
     if (util::lineSegmentsIntersect(lineStart,lineEnd , goalLinePos1, cornerPos1)) {
@@ -353,10 +364,14 @@ std::shared_ptr<Vector2> Field::lineIntersectsWithDefenceArea(bool ourGoal, cons
 }
 
 std::vector<Vector2> Field::getDefenseArea(bool ourDefenseArea, double margin) {
-
+    roboteam_msgs::GeometryFieldSize _field;
+    {
+        std::lock_guard<std::mutex> lock(fieldMutex);
+        _field = field;
+    }
     if (ourDefenseArea) {
-        double length = field.field_length;
-        auto leftPenaltyLine = field.left_penalty_line;
+        double length = _field.field_length;
+        auto leftPenaltyLine = _field.left_penalty_line;
         Vector2 leftPenaltyLineLowerPoint = (Vector2)leftPenaltyLine.begin - margin;
         Vector2 leftPenaltyLineUpperPoint = (Vector2)leftPenaltyLine.end + margin;
         Vector2 backLineLowerPoint = {-0.5*length, leftPenaltyLineLowerPoint.y - margin};
@@ -364,8 +379,8 @@ std::vector<Vector2> Field::getDefenseArea(bool ourDefenseArea, double margin) {
         return {leftPenaltyLineLowerPoint, leftPenaltyLineUpperPoint, backLineUpperPoint, backLineLowerPoint};
     }
     else {
-        double length = field.field_length;
-        auto rightPenaltyLine = field.right_penalty_line;
+        double length = _field.field_length;
+        auto rightPenaltyLine = _field.right_penalty_line;
         Vector2 rightPenaltyLineLowerPoint = (Vector2)rightPenaltyLine.begin - margin;
         Vector2 rightPenaltyLineUpperPoint = (Vector2)rightPenaltyLine.end + margin;
         Vector2 backLineLowerPoint = {0.5*length, rightPenaltyLineLowerPoint.y - margin};

--- a/roboteam_ai/test/AnalysisTests/DecisionmakerTest.cpp
+++ b/roboteam_ai/test/AnalysisTests/DecisionmakerTest.cpp
@@ -20,7 +20,7 @@ TEST(DecisionMakerTest, all_setups_have_right_amounts_of_robots) {
     field.field_width = 9;
 
     // for all possible amounts of robots
-    for (int amountOfRobots = 0; amountOfRobots < 9; amountOfRobots++) {
+    for (int amountOfRobots = 1; amountOfRobots < 9; amountOfRobots++) {
 
         // set up a field
         roboteam_msgs::World worldmsg = testhelpers::WorldHelper::getWorldMsg(amountOfRobots, 0, false, field);
@@ -39,7 +39,19 @@ TEST(DecisionMakerTest, all_setups_have_right_amounts_of_robots) {
             int total = style.amountOfAttackers + style.amountOfMidfielders + style.amountOfDefenders;
             EXPECT_EQ(total, amountOfRobots);
 
+
+            // there is a keeper but it is not visible (the id is set to -1, and robot -1 is never seen, thus mimicking an invisible keeper)
             robotDealer::RobotDealer::setUseSeparateKeeper(true);
+            robotDealer::RobotDealer::setKeeperID(-1);
+
+            style = maker.getRecommendedPlayStyle(possession);
+            total = style.amountOfAttackers + style.amountOfMidfielders + style.amountOfDefenders;
+            EXPECT_EQ(total, std::max(0, amountOfRobots));
+
+            // there is a keeper
+            robotDealer::RobotDealer::setUseSeparateKeeper(true);
+            robotDealer::RobotDealer::setKeeperID(world::world->getUs().at(0).id);
+
             style = maker.getRecommendedPlayStyle(possession);
             total = style.amountOfAttackers + style.amountOfMidfielders + style.amountOfDefenders;
             EXPECT_EQ(total, std::max(0, amountOfRobots-1));

--- a/roboteam_ai/test/AnalysisTests/DecisionmakerTest.cpp
+++ b/roboteam_ai/test/AnalysisTests/DecisionmakerTest.cpp
@@ -26,7 +26,7 @@ TEST(DecisionMakerTest, all_setups_have_right_amounts_of_robots) {
         roboteam_msgs::World worldmsg = testhelpers::WorldHelper::getWorldMsg(amountOfRobots, 0, false, field);
         world::world->updateWorld(worldmsg);
 
-        // iterate over the ballplacement enum
+        // iterate over the ballPossession enum
         for (int fooInt = THEY_HAVE_BALL; fooInt != WE_HAVE_BALL; fooInt++ ) {
             auto possession = static_cast<BallPossession>(fooInt);
 

--- a/roboteam_ai/test/ConditionTests/BallInDefenseAreaAndStillTest.cpp
+++ b/roboteam_ai/test/ConditionTests/BallInDefenseAreaAndStillTest.cpp
@@ -24,6 +24,8 @@ TEST(DetectsDefenseArea, BallInDefenseAreaAndStill)
     EXPECT_FALSE(node.theirDefenceArea);
 
     roboteam_msgs::GeometryFieldSize field;
+    field.field_width = 8;
+    field.field_length = 12;
     field.left_penalty_line.begin.x = -1.0f;
     field.left_penalty_line.end.x = -1.0f;
 

--- a/roboteam_ai/test/ConditionTests/IsInDefenseAreaTest.cpp
+++ b/roboteam_ai/test/ConditionTests/IsInDefenseAreaTest.cpp
@@ -30,8 +30,8 @@ TEST(DetectsInOurDefenseArea, IsInDefenseAreaTest)
     EXPECT_EQ(node.update(), bt::Node::Status::Failure);
 
     roboteam_msgs::GeometryFieldSize field;
-    field.field_width = 12;
-    field.field_length = 8;
+    field.field_width = 8;
+    field.field_length = 12;
     field.left_penalty_line.begin.x = -1.0f;
     field.left_penalty_line.end.x = -1.0f;
 

--- a/roboteam_ai/test/ConditionTests/IsInDefenseAreaTest.cpp
+++ b/roboteam_ai/test/ConditionTests/IsInDefenseAreaTest.cpp
@@ -30,6 +30,8 @@ TEST(DetectsInOurDefenseArea, IsInDefenseAreaTest)
     EXPECT_EQ(node.update(), bt::Node::Status::Failure);
 
     roboteam_msgs::GeometryFieldSize field;
+    field.field_width = 12;
+    field.field_length = 8;
     field.left_penalty_line.begin.x = -1.0f;
     field.left_penalty_line.end.x = -1.0f;
 
@@ -97,6 +99,8 @@ TEST(DetectsInTheirDefenseArea, IsInDefenseAreaTest)
     EXPECT_EQ(node.update(), bt::Node::Status::Failure);
 
     roboteam_msgs::GeometryFieldSize field;
+    field.field_width = 12;
+    field.field_length = 8;
     field.left_penalty_line.begin.x = -1.0f;
     field.left_penalty_line.end.x = -1.0f;
 
@@ -149,6 +153,8 @@ TEST(DetectsBallInOurDefenceArea, IsInDefenceAreaTest)
     rtt::ai::world::world->updateWorld(worldMsg);
 
     roboteam_msgs::GeometryFieldSize field;
+    field.field_length = 12;
+    field.field_width = 8;
     field.left_penalty_line.begin.x = -1.0f;
     field.left_penalty_line.end.x = -1.0f;
 

--- a/roboteam_ai/test/TacticTests/DefaultTacticTest.cpp
+++ b/roboteam_ai/test/TacticTests/DefaultTacticTest.cpp
@@ -54,6 +54,13 @@ TEST(DefaultTacticTest, default_general_tactic_works) {
     EXPECT_EQ(tactic.amountToTick, static_cast<int>(rtt::ai::world::world->getUs().size()));
 
     rd::RobotDealer::setUseSeparateKeeper(true);
+    rd::RobotDealer::setKeeperID(-1); // set the keeper id to -1 to mimick a keeper that is not seen by cameras
+    tactic.updateStyle();
+    EXPECT_EQ(tactic.amountToTick, static_cast<int>(rtt::ai::world::world->getUs().size()));
+
+    // with a visible keeper we should subtract one robot to tick
+    // the first robot in our world is always visible so we always make that one the keeper
+    rd::RobotDealer::setKeeperID(rtt::ai::world::world->getUs().at(0).id);
     tactic.updateStyle();
     EXPECT_EQ(tactic.amountToTick, static_cast<int>(rtt::ai::world::world->getUs().size() - 1));
 
@@ -75,7 +82,9 @@ TEST(DefaultTacticTest, default_general_tactic_works) {
     EXPECT_EQ(tactic.getLastClaim().first, "general7");
 
     // now without a keeper: it should also claim the last robot
+    rd::RobotDealer::setKeeperID(-1);
     rd::RobotDealer::setUseSeparateKeeper(false);
+
     tactic.updateStyle();
     tactic.initialize();
     EXPECT_EQ(tactic.getLastClaim().first, "general8");

--- a/roboteam_ai/test/WorldTests/FieldTest.cpp
+++ b/roboteam_ai/test/WorldTests/FieldTest.cpp
@@ -54,6 +54,35 @@ TEST(FieldTest, it_gets_points_in_defence_area) {
         bool inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0);
         EXPECT_FALSE(inDefenceArea);
     }
+
+    // generate 100 random positions within defense area but outside field
+    for (int i = 0; i < 100; i ++) {
+        auto x = testhelpers::WorldHelper::getRandomValue(- 8, -6);
+        auto y = testhelpers::WorldHelper::getRandomValue(0, 8);
+
+        // it should be fine with includeOutsideField == true
+        bool inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0, true);
+        EXPECT_TRUE(inDefenceArea);
+
+        // otherwise it should fail.
+        inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0, false);
+        EXPECT_FALSE(inDefenceArea);
+    }
+
+    // generate 100 random positions within their defense area but outside field
+    for (int i = 0; i < 100; i ++) {
+        auto x = testhelpers::WorldHelper::getRandomValue(6, 8);
+        auto y = testhelpers::WorldHelper::getRandomValue(0, 8);
+
+        // it should be fine with includeOutsideField == true
+        bool inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), false, 0.0, true);
+        EXPECT_TRUE(inDefenceArea);
+
+        // otherwise it should fail.
+        inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), false, 0.0, false);
+        EXPECT_FALSE(inDefenceArea);
+    }
+
 }
 
 TEST(FieldTest, it_returns_proper_goal_centers) {

--- a/roboteam_ai/test/WorldTests/FieldTest.cpp
+++ b/roboteam_ai/test/WorldTests/FieldTest.cpp
@@ -81,6 +81,7 @@ TEST(FieldTest, it_gets_points_in_defence_area) {
         // otherwise it should fail.
         inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), false, 0.0, false);
         EXPECT_FALSE(inDefenceArea);
+
     }
 
 }

--- a/roboteam_ai/test/WorldTests/FieldTest.cpp
+++ b/roboteam_ai/test/WorldTests/FieldTest.cpp
@@ -16,8 +16,8 @@ TEST(FieldTest, it_gets_and_sets_the_field) {
 
 TEST(FieldTest, it_gets_points_in_defence_area) {
     roboteam_msgs::GeometryFieldSize field;
-    field.field_length = 8;
-    field.field_width = 12;
+    field.field_length = 12;
+    field.field_width = 8;
 
     // set the penalty lines
     field.left_penalty_line.begin = rtt::Vector2(- 4, 0);
@@ -25,14 +25,21 @@ TEST(FieldTest, it_gets_points_in_defence_area) {
     field.right_penalty_line.begin = rtt::Vector2(4, 0);
     field.right_penalty_line.end = rtt::Vector2(4, 8);
 
+    // all points should be in our defence area
+    rtt::ai::world::field->set_field(field);
+
     // generate 100 random positions in our defence area
     for (int i = 0; i < 100; i ++) {
         auto x = testhelpers::WorldHelper::getRandomValue(- 6, - 4);
         auto y = testhelpers::WorldHelper::getRandomValue(0, 8);
 
-        // all points should be in our defence area
-        rtt::ai::world::field->set_field(field);
         bool inOurDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0);
+
+        if (!inOurDefenceArea) {
+            std::cout << rtt::Vector2(x, y) << std::endl;
+            bool inOurDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0);
+
+        }
         EXPECT_TRUE(inOurDefenceArea);
 
         // the points should not be in their defence area
@@ -44,7 +51,6 @@ TEST(FieldTest, it_gets_points_in_defence_area) {
     for (int i = 0; i < 100; i ++) {
         auto x = testhelpers::WorldHelper::getRandomValue(- 4, 4);
         auto y = testhelpers::WorldHelper::getRandomValue(0, 8);
-        rtt::ai::world::field->set_field(field);
         bool inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0);
         EXPECT_FALSE(inDefenceArea);
     }

--- a/roboteam_ai/test/WorldTests/FieldTest.cpp
+++ b/roboteam_ai/test/WorldTests/FieldTest.cpp
@@ -34,12 +34,6 @@ TEST(FieldTest, it_gets_points_in_defence_area) {
         auto y = testhelpers::WorldHelper::getRandomValue(2, 6);
 
         bool inOurDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0);
-
-        if (!inOurDefenceArea) {
-            std::cout << rtt::Vector2(x, y) << std::endl;
-            bool inOurDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0);
-
-        }
         EXPECT_TRUE(inOurDefenceArea);
 
         // the points should not be in their defence area

--- a/roboteam_ai/test/WorldTests/FieldTest.cpp
+++ b/roboteam_ai/test/WorldTests/FieldTest.cpp
@@ -20,10 +20,10 @@ TEST(FieldTest, it_gets_points_in_defence_area) {
     field.field_width = 8;
 
     // set the penalty lines
-    field.left_penalty_line.begin = rtt::Vector2(- 4, 0);
-    field.left_penalty_line.end = rtt::Vector2(- 4, 8);
-    field.right_penalty_line.begin = rtt::Vector2(4, 0);
-    field.right_penalty_line.end = rtt::Vector2(4, 8);
+    field.left_penalty_line.begin = rtt::Vector2(- 4, 2);
+    field.left_penalty_line.end = rtt::Vector2(- 4, 6);
+    field.right_penalty_line.begin = rtt::Vector2(4, 2);
+    field.right_penalty_line.end = rtt::Vector2(4, 6);
 
     // all points should be in our defence area
     rtt::ai::world::field->set_field(field);
@@ -31,7 +31,7 @@ TEST(FieldTest, it_gets_points_in_defence_area) {
     // generate 100 random positions in our defence area
     for (int i = 0; i < 100; i ++) {
         auto x = testhelpers::WorldHelper::getRandomValue(- 6, - 4);
-        auto y = testhelpers::WorldHelper::getRandomValue(0, 8);
+        auto y = testhelpers::WorldHelper::getRandomValue(2, 6);
 
         bool inOurDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0);
 
@@ -47,18 +47,31 @@ TEST(FieldTest, it_gets_points_in_defence_area) {
         EXPECT_FALSE(inTheirDefenceArea);
     }
 
-    // generate 100 random positions outside our defence area
+    // generate 100 random positions outside our defence area ( wrong x value )
     for (int i = 0; i < 100; i ++) {
         auto x = testhelpers::WorldHelper::getRandomValue(- 4, 4);
-        auto y = testhelpers::WorldHelper::getRandomValue(0, 8);
+        auto y = testhelpers::WorldHelper::getRandomValue(2, 6);
         bool inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0);
         EXPECT_FALSE(inDefenceArea);
     }
 
+    // generate 100 random positions outside our defence area ( wrong y value )
+    for (int i = 0; i < 100; i ++) {
+        auto x = testhelpers::WorldHelper::getRandomValue(-6, -4);
+        auto y = testhelpers::WorldHelper::getRandomValue(0, 2);
+        bool inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0);
+        EXPECT_FALSE(inDefenceArea);
+
+        y = testhelpers::WorldHelper::getRandomValue(6, 10);
+        inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0);
+        EXPECT_FALSE(inDefenceArea);
+    }
+
+
     // generate 100 random positions within defense area but outside field
     for (int i = 0; i < 100; i ++) {
         auto x = testhelpers::WorldHelper::getRandomValue(- 8, -6);
-        auto y = testhelpers::WorldHelper::getRandomValue(0, 8);
+        auto y = testhelpers::WorldHelper::getRandomValue(2, 6);
 
         // it should be fine with includeOutsideField == true
         bool inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), true, 0.0, true);
@@ -72,7 +85,7 @@ TEST(FieldTest, it_gets_points_in_defence_area) {
     // generate 100 random positions within their defense area but outside field
     for (int i = 0; i < 100; i ++) {
         auto x = testhelpers::WorldHelper::getRandomValue(6, 8);
-        auto y = testhelpers::WorldHelper::getRandomValue(0, 8);
+        auto y = testhelpers::WorldHelper::getRandomValue(2, 6);
 
         // it should be fine with includeOutsideField == true
         bool inDefenceArea = rtt::ai::world::field->pointIsInDefenceArea(rtt::Vector2(x, y), false, 0.0, true);


### PR DESCRIPTION
Prevents the keeper problems we saw during the practice tournament.

Besides checking if we want to use a keeper we also need to check if the keeper is actually visible. otherwise just don't claim and don't tick it. 

and, if there is no keeper we need to claim ALL robots for the other strategies instead of ALL robots - 1 

I wrote tests for it. 

Besides that, I found some problems with defence areas. This has now been resolved (i think).
lastly, there was a segfault in the keeper as well, the fieldmutex was not always used, giving a sporadic segfault when assigning a keeper. 