### PR TITLE
IOManager updates

### DIFF
--- a/roboteam_ai/src/io/IOManager.cpp
+++ b/roboteam_ai/src/io/IOManager.cpp
@@ -62,7 +62,7 @@ void IOManager::subscribeToGeometryData() {
 
 void IOManager::subscribeToRobotFeedback() {
     roleFeedbackSubscriber = nodeHandle.subscribe<roboteam_msgs::RobotFeedback>(
-            rtt::TOPIC_ROLE_FEEDBACK,
+            "robot_feedback",
             100,
             &IOManager::handleRobotFeedback,
             this,

--- a/roboteam_ai/src/io/IOManager.h
+++ b/roboteam_ai/src/io/IOManager.h
@@ -6,7 +6,7 @@
 #include "roboteam_utils/constants.h"
 #include <roboteam_msgs/GeometryData.h>
 #include "roboteam_msgs/World.h"
-#include <roboteam_msgs/RoleFeedback.h>
+#include <roboteam_msgs/RobotFeedback.h>
 #include <roboteam_msgs/RobotCommand.h>
 #include "roboteam_msgs/RefereeData.h"
 #include <roboteam_msgs/DemoRobot.h>
@@ -25,7 +25,7 @@ private:
 
         roboteam_msgs::World worldMsg;
         roboteam_msgs::GeometryData geometryMsg;
-        roboteam_msgs::RoleFeedback roleFeedbackMsg;
+        roboteam_msgs::RobotFeedback robotFeedbackMsg;
         roboteam_msgs::RefereeData refDataMsg;
         roboteam_msgs::DemoRobot demoInfoMsg;
         ros::Subscriber worldSubscriber;
@@ -37,7 +37,7 @@ private:
         ros::Publisher robotCommandPublisher;
         void handleWorldState(const roboteam_msgs::WorldConstPtr &world);
         void handleGeometryData(const roboteam_msgs::GeometryDataConstPtr &geometry);
-        void handleRobotFeedback(const roboteam_msgs::RoleFeedbackConstPtr &rolefeedback);
+        void handleRobotFeedback(const roboteam_msgs::RobotFeedbackConstPtr &robotfeedback);
         void handleRefereeData(const roboteam_msgs::RefereeDataConstPtr &refData);
         void handleDemoInfo(const roboteam_msgs::DemoRobotConstPtr &demoInfo);
         rtt::ai::Pause* pause;
@@ -46,7 +46,7 @@ private:
         explicit IOManager(bool subscribe = false, bool advertise = false);
         void subscribeToWorldState();
         void subscribeToGeometryData();
-        void subscribeToRoleFeedback();
+        void subscribeToRobotFeedback();
         void subscribeToRefereeData();
         void subscribeToDemoInfo();
 
@@ -54,11 +54,16 @@ private:
 
         const roboteam_msgs::World &getWorldState();
         const roboteam_msgs::GeometryData &getGeometryData();
-        const roboteam_msgs::RoleFeedback &getRoleFeedback();
+        const roboteam_msgs::RobotFeedback &getRobotFeedback();
         const roboteam_msgs::RefereeData &getRefereeData();
         const roboteam_msgs::DemoRobot &getDemoInfo();
 
-        static std::mutex mutex;
+        static std::mutex worldStateMutex;
+        static std::mutex geometryMutex;
+        static std::mutex robotFeedbackMutex;
+        static std::mutex refereeMutex;
+        static std::mutex demoMutex;
+
 };
 
 } // io

--- a/roboteam_ai/test/UtilTests/IOTest.cpp
+++ b/roboteam_ai/test/UtilTests/IOTest.cpp
@@ -18,7 +18,7 @@ TEST(IOTest, it_subscribes) {
     ros::Rate rate(60);
     ros::NodeHandle nh;
     // subscribing
-    ros::Publisher roleFeedbackPub = nh.advertise<roboteam_msgs::RoleFeedback>(rtt::TOPIC_ROLE_FEEDBACK, 1);
+    ros::Publisher robotFeedbackPub = nh.advertise<roboteam_msgs::RobotFeedback>("robot_feedback", 1);
     ros::Publisher worldPub = nh.advertise<roboteam_msgs::World>(rtt::TOPIC_WORLD_STATE, 1);
     ros::Publisher geomPub = nh.advertise<roboteam_msgs::GeometryData>(rtt::TOPIC_GEOMETRY, 1);
     ros::Publisher refPub = nh.advertise<roboteam_msgs::RefereeData>("vision_refbox", 1);
@@ -46,9 +46,9 @@ TEST(IOTest, it_subscribes) {
     ros::spinOnce();
 
     // publish role feedback message
-    roboteam_msgs::RoleFeedback roleFeedbackMsg;
-    roleFeedbackMsg.status = 'X';
-    roleFeedbackPub.publish(roleFeedbackMsg);
+    roboteam_msgs::RobotFeedback robotFeedbackMsg;
+        robotFeedbackMsg.id = 12;
+    robotFeedbackPub.publish(robotFeedbackMsg);
 
     rate.sleep();
     ros::spinOnce();
@@ -64,7 +64,7 @@ TEST(IOTest, it_subscribes) {
     EXPECT_FLOAT_EQ(ioManager.getWorldState().ball.pos.x, 10.1);
     EXPECT_FLOAT_EQ(ioManager.getWorldState().ball.pos.y, 20.2);
     EXPECT_FLOAT_EQ(ioManager.getGeometryData().field.goal_depth, 30.3);
-    EXPECT_EQ(ioManager.getRoleFeedback().status, 'X');
+    EXPECT_EQ(ioManager.getRobotFeedback().id, 12);
 
     EXPECT_EQ(ioManager.getRefereeData().command.command, 3);
 


### PR DESCRIPTION
make iomanager faster by not using the same mutex for everything and make sure it uses robotfeedback instead of rolefeedback (feedback might be coming soon)