### PR TITLE
Feature/battery stats and refresh

### DIFF
--- a/roboteam_ai/src/interface/widgets/MainControlsWidget.cpp
+++ b/roboteam_ai/src/interface/widgets/MainControlsWidget.cpp
@@ -55,6 +55,20 @@ MainControlsWidget::MainControlsWidget(QWidget * parent) {
     }
     select_ruleset->setStyleSheet(QString::fromUtf8("QComboBox:disabled" "{ color: gray }"));
 
+    auto refreshHButtonsLayout = new QHBoxLayout();
+
+    refreshBtn = new QPushButton("Soft refresh");
+    QObject::connect(refreshBtn, SIGNAL(clicked()), this, SLOT(refreshSignal()));
+    refreshHButtonsLayout->addWidget(refreshBtn);
+    refreshBtn->setStyleSheet("background-color: #0000cc;");
+
+    refreshJsonBtn = new QPushButton("Hard refresh");
+    QObject::connect(refreshJsonBtn, SIGNAL(clicked()), this, SLOT(refreshJSONSignal()));
+    refreshHButtonsLayout->addWidget(refreshJsonBtn);
+    refreshJsonBtn->setStyleSheet("background-color: #0000cc;");
+    vLayout->addLayout(refreshHButtonsLayout);
+
+
     auto hButtonsLayout = new QHBoxLayout();
 
     haltBtn = new QPushButton("Halt");
@@ -69,16 +83,6 @@ MainControlsWidget::MainControlsWidget(QWidget * parent) {
 
     spaceClick = new QShortcut(QKeySequence(Qt::Key_Space), this, SLOT(sendPauseSignal()));
     spaceClick->setAutoRepeat(false);
-
-    refreshBtn = new QPushButton("Soft refresh");
-    QObject::connect(refreshBtn, SIGNAL(clicked()), this, SLOT(refreshSignal()));
-    hButtonsLayout->addWidget(refreshBtn);
-    refreshBtn->setStyleSheet("background-color: #0000cc;");
-
-    refreshJsonBtn = new QPushButton("Hard refresh");
-    QObject::connect(refreshJsonBtn, SIGNAL(clicked()), this, SLOT(refreshJSONSignal()));
-    hButtonsLayout->addWidget(refreshJsonBtn);
-    refreshJsonBtn->setStyleSheet("background-color: #0000cc;");
 
     toggleColorBtn = new QPushButton("Color");
     QObject::connect(toggleColorBtn, SIGNAL(clicked()), this, SLOT(toggleOurColorParam()));

--- a/roboteam_ai/src/interface/widgets/MainControlsWidget.cpp
+++ b/roboteam_ai/src/interface/widgets/MainControlsWidget.cpp
@@ -70,10 +70,15 @@ MainControlsWidget::MainControlsWidget(QWidget * parent) {
     spaceClick = new QShortcut(QKeySequence(Qt::Key_Space), this, SLOT(sendPauseSignal()));
     spaceClick->setAutoRepeat(false);
 
-    refreshBtn = new QPushButton("Refresh");
+    refreshBtn = new QPushButton("Soft refresh");
     QObject::connect(refreshBtn, SIGNAL(clicked()), this, SLOT(refreshSignal()));
     hButtonsLayout->addWidget(refreshBtn);
     refreshBtn->setStyleSheet("background-color: #0000cc;");
+
+    refreshJsonBtn = new QPushButton("Hard refresh");
+    QObject::connect(refreshJsonBtn, SIGNAL(clicked()), this, SLOT(refreshJSONSignal()));
+    hButtonsLayout->addWidget(refreshJsonBtn);
+    refreshJsonBtn->setStyleSheet("background-color: #0000cc;");
 
     toggleColorBtn = new QPushButton("Color");
     QObject::connect(toggleColorBtn, SIGNAL(clicked()), this, SLOT(toggleOurColorParam()));
@@ -125,14 +130,6 @@ MainControlsWidget::MainControlsWidget(QWidget * parent) {
 
 void MainControlsWidget::setTimeOutTop(bool top) {
     Output::setTimeOutTop(top);
-}
-
-QString MainControlsWidget::getSelectStrategyText() const {
-    return select_strategy->currentText();
-}
-
-void MainControlsWidget::setSelectStrategyText(QString text) {
-    select_strategy->setCurrentText(text);
 }
 
 void MainControlsWidget::setUseReferee(bool useRef) {
@@ -213,6 +210,11 @@ void MainControlsWidget::setToggleSideBtnLayout() const {
 
 
 void MainControlsWidget::refreshSignal() {
+    robotDealer::RobotDealer::refresh();
+    emit treeHasChanged();
+}
+
+void MainControlsWidget::refreshJSONSignal() {
     BTFactory::makeTrees();
     robotDealer::RobotDealer::refresh();
     emit treeHasChanged();

--- a/roboteam_ai/src/interface/widgets/MainControlsWidget.h
+++ b/roboteam_ai/src/interface/widgets/MainControlsWidget.h
@@ -20,8 +20,6 @@ class MainControlsWidget : public QWidget {
 Q_OBJECT
 public:
     explicit MainControlsWidget(QWidget * parent = nullptr);
-    QString getSelectStrategyText() const;
-    void setSelectStrategyText(QString text);
 
 signals:
     void treeHasChanged();
@@ -30,6 +28,7 @@ private:
     QVBoxLayout* vLayout;
     QPushButton* pauseBtn;
     QPushButton* refreshBtn;
+    QPushButton* refreshJsonBtn;
     QPushButton* toggleColorBtn;
     QPushButton* toggleSideBtn;
     QPushButton* haltBtn;
@@ -54,6 +53,7 @@ public slots:
     void updatePause();
     void setUseReferee(bool useRef);
     void refreshSignal();
+    void refreshJSONSignal();
     void updateContents();
     void sendHaltSignal();
 };

--- a/roboteam_ai/src/interface/widgets/widget.cpp
+++ b/roboteam_ai/src/interface/widgets/widget.cpp
@@ -326,6 +326,9 @@ void Visualizer::drawRobot(QPainter &painter, Robot robot, bool ourTeam) {
         if (!robot.hasWorkingBallSensor()) {
             text += "BS ";
         }
+        if (robot.isBatteryLow()) {
+            text += "BATTERY LOW";
+        }
         painter.drawText(robotpos.x, ypos += 20, QString::fromStdString(text));
     }
 


### PR DESCRIPTION
Divide refresh into two butons: soft refresh (only robotdealer) and hard refresh (jsons and robotdealer). 

Also sets text "battery low" next to a robot when battery is low. 
