### PR TITLE
removed boost in AI as well

### DIFF
--- a/src/skills/Keeper.cpp
+++ b/src/skills/Keeper.cpp
@@ -82,7 +82,7 @@ Vector2 Keeper::computeBlockPoint(const Vector2 &defendPos) {
         Vector2 u2 = (goalPos + Vector2(0.0, - goalwidth*0.5) - defendPos).normalize();
         double dist = (defendPos - goalPos).length();
         Vector2 blockLineStart = defendPos + (u1 + u2).stretchToLength(dist);
-        std::pair<boost::optional<Vector2>, boost::optional<Vector2>> intersections = blockCircle.intersectionWithLine(
+        std::pair<std::optional<Vector2>, std::optional<Vector2>> intersections = blockCircle.intersectionWithLine(
                 blockLineStart, defendPos);
 
         // go stand on the intersection of the lines. Pick the one that is closest to (0,0) if there are multiple


### PR DESCRIPTION
- [  ] The tests are passing
Tested on my laptop, grSim shows normal behaviour

### Summary
When testing Yuhanun PR in Roboteam Utils, I found the Keeper still uses boost. This fixes that too.

fixes Boost dependency

### Comments for the reviewer
If there are comments for the reviewer, leave them here

### Checklist for the reviewer
This acts as a guide to help you and/or the reviewer to analyze the code. 

**functionality**  
- Is the code is properly tested?
- Is the code working as expected
- Is the code is understandable and easy to read
- Are proper abstractions made? (no duplicate code, nice use of functions/objects)

**style**  
- Variables/objects/classes have proper names
- Proper use of variables: nu unused vars, no magic numbers
- No possible memory leaks. Mutexes properly used when multithreading? possible pointer issues?
- Are smart pointers used?
- unused variables?
- magic numbers?
- well documented?
- No unused imports?
- No leftover code / unused comments
- Proper indentation
- Proper use of namespaces
