### PR TITLE
Solve pass strictness problem

### DIFF
--- a/src/coach/PassCoach.cpp
+++ b/src/coach/PassCoach.cpp
@@ -139,16 +139,6 @@ bool PassCoach::validReceiver(const RobotPtr& passer, const RobotPtr& receiver, 
         return false;
     }
 
-    if (!freeKick) {
-        if (receiver->pos.x < -RECEIVER_MAX_DISTANCE_INTO_OUR_SIDE) {
-            return false;
-        }
-        auto MIN_PASS_DISTANCE = std::max((double)world::field->get_field().goal_width() / 2, SMALLEST_MIN_PASS_DISTANCE);
-        if ((passer->pos - receiver->pos).length() < MIN_PASS_DISTANCE) {
-            return false;
-        }
-    }
-
     return true;
 }
 

--- a/src/skills/Keeper.cpp
+++ b/src/skills/Keeper.cpp
@@ -82,7 +82,7 @@ Vector2 Keeper::computeBlockPoint(const Vector2 &defendPos) {
         Vector2 u2 = (goalPos + Vector2(0.0, - goalwidth*0.5) - defendPos).normalize();
         double dist = (defendPos - goalPos).length();
         Vector2 blockLineStart = defendPos + (u1 + u2).stretchToLength(dist);
-        std::pair<std::optional<Vector2>, std::optional<Vector2>> intersections = blockCircle.intersectionWithLine(
+        std::pair<boost::optional<Vector2>, boost::optional<Vector2>> intersections = blockCircle.intersectionWithLine(
                 blockLineStart, defendPos);
 
         // go stand on the intersection of the lines. Pick the one that is closest to (0,0) if there are multiple


### PR DESCRIPTION
Solved issue #537 by removing the requirements that the ball can only be passed to robots across the midline and removed the minimum distance requirement for ball passes.  Created a new issue #716 regarding the passes between defenders (which unfortunately still does not happen).
