### PR TITLE
added some nice constructors for selector and sequence

### DIFF
--- a/include/roboteam_ai/bt/Node.hpp
+++ b/include/roboteam_ai/bt/Node.hpp
@@ -39,6 +39,11 @@ class Node {
 
         using Ptr = std::shared_ptr<Node>;
 
+        /**
+         * The update function executes the node. This function is overwritten a lot, most interestingly in the Selector/Sequence/Inverter nodes,
+         * since these nodes can have children. Therefore the update function of these nodes ticks their children.
+         * @return Status result of the update (Running, Success, Failure)
+         */
         virtual Status update() = 0;
 
         Status NodeUpdate();

--- a/include/roboteam_ai/bt/composites/Selector.hpp
+++ b/include/roboteam_ai/bt/composites/Selector.hpp
@@ -6,6 +6,7 @@ namespace bt {
 
 class Selector : public Composite {
 public:
+    Selector(std::vector<std::shared_ptr<bt::Node>> childs);
     Status update() override;
     std::string node_name() override { return "Selector"; };
 };

--- a/include/roboteam_ai/bt/composites/Selector.hpp
+++ b/include/roboteam_ai/bt/composites/Selector.hpp
@@ -6,7 +6,7 @@ namespace bt {
 
 class Selector : public Composite {
 public:
-    Selector(std::vector<std::shared_ptr<bt::Node>> childs);
+    Selector(std::vector<std::shared_ptr<bt::Node>> children);
     Status update() override;
     std::string node_name() override { return "Selector"; };
 };

--- a/include/roboteam_ai/bt/composites/Sequence.hpp
+++ b/include/roboteam_ai/bt/composites/Sequence.hpp
@@ -6,6 +6,8 @@ namespace bt {
 
 class Sequence : public Composite {
 public:
+    Sequence(std::vector<std::shared_ptr<bt::Node>> children);
+
     Status update() override;
     std::string node_name() override { return "Sequence"; };
 };

--- a/src/bt/composites/Selector.cpp
+++ b/src/bt/composites/Selector.cpp
@@ -9,6 +9,17 @@
 
 namespace bt {
 
+    /**
+     * Use this constructor when you want to initialize the children of the selector using a vector.
+     * The children are added sequentially, so the first element in the array will be the leftmost child of the selector
+     * @param children vector of nodes that will be the children of this selector node
+     */
+    Selector::Selector(std::vector<std::shared_ptr<bt::Node>> children) {
+        for (int i = 0; i < children.size(); i++) {
+            this->addChild(children[i]);
+        }
+    }
+
 Node::Status Selector::update() {
     // Keep going until a child behavior says it's running.
     for (auto &child : children) {

--- a/src/bt/composites/Sequence.cpp
+++ b/src/bt/composites/Sequence.cpp
@@ -8,6 +8,16 @@
 #include "bt/composites/Sequence.hpp"
 
 namespace bt {
+    /**
+ * Use this constructor when you want to initialize the children of the sequence using a vector.
+ * The children are added sequentially, so the first element in the array will be the leftmost child of the sequence
+ * @param children vector of nodes that will be the children of this sequence node
+ */
+    Sequence::Sequence(std::vector<std::shared_ptr<bt::Node>> children) {
+        for (int i = 0; i < children.size(); i++) {
+            this->addChild(children[i]);
+        }
+    }
 
 Node::Status Sequence::update() {
     if (HasNoChildren()) {


### PR DESCRIPTION
Constructors for selector and sequence that make it clearer what the children are. Right now the order is set by the way you call "addChild(Node node)" but I think this adds too many lines of code and reduces readability. Therefore I made this constructor, which makes it clear what nodes are in what order. Examle usage would be:
Attack attack = new Attack(bla, blob);
GTP go = new GTP(here, there);
IsARobot isARobot = new IsARobot(this);

Selector select = new Selector(attack, go, isARobot);