### PR TITLE
Fixed an out-of-range bug

### DIFF
--- a/src/world_new/World.cpp
+++ b/src/world_new/World.cpp
@@ -26,9 +26,9 @@ void World::toHistory(WorldData &world) noexcept {
         history.emplace_back(std::move(world));
     } else {
         history[currentIndex] = std::move(world);
+        currentIndex++;
+        currentIndex %= HISTORY_SIZE;
     }
-    currentIndex++;
-    currentIndex %= HISTORY_SIZE;
 }
 
 std::optional<view::WorldDataView> World::getWorld() const noexcept {

--- a/src/world_new/World.cpp
+++ b/src/world_new/World.cpp
@@ -22,7 +22,7 @@ WorldData const &World::setWorld(WorldData &newWorld) noexcept {
 void World::toHistory(WorldData &world) noexcept {
 //    std::lock_guard mtx{ updateMutex };
     updateTickTime();
-    if (history.size() < HISTORY_SIZE && currentIndex < history.size()) {
+    if (history.size() < HISTORY_SIZE) {
         history.emplace_back(std::move(world));
     } else {
         history[currentIndex] = std::move(world);


### PR DESCRIPTION
In the beginning, `history.size()` equals 0. This causes the if-statement in line 25 to fail, since `currentIndex` is not smaller than 0. This means that `history[currentIndex] = std::move(world)` is called. This fails because history is empty, giving SIGABRT. 

Confirmed that it works with assertions
`assert(history.size() == HISTORY_SIZE);`
`assert(currentIndex < history.size());`
and with GrSim

Not sure why it doesn't give an std::out_of_range exception. Is it because of all the noexcept stuff?