### PR TITLE
Fix UB in worlddata.cpp for us and them vectors

### DIFF
--- a/src/world_new/WorldData.cpp
+++ b/src/world_new/WorldData.cpp
@@ -13,18 +13,21 @@ WorldData::WorldData(proto::World &protoMsg, rtt::Settings const &settings, std:
     auto &ours = settings.isYellow() ? protoMsg.yellow() : protoMsg.blue();
     auto &others = settings.isYellow() ? protoMsg.blue() : protoMsg.yellow();
 
+    /*
+     * Reserve the us and them vectors, making sure they are not being resized (which will invalidate the references)
+     */
+    auto amountUs = ours.size();
+    auto amountThem = others.size();
+    robots.reserve(amountUs + amountThem);
+    us.reserve(amountUs);
+    them.reserve(amountThem);
+    
     for (auto &each : ours) {
-        auto robot = new robot::Robot(feedback, each, Team::us);
-        robots.push_back(std::move(*robot));
-        us.emplace_back(robot);
+        us.emplace_back(&robots.emplace_back(feedback, each, Team::us));
     }
-
     for (auto &each : others) {
-        auto robot = new robot::Robot(feedback, each, Team::them);
-        robots.push_back(std::move(*robot));
-        them.emplace_back(robot);
+        them.emplace_back(&robots.emplace_back(feedback, each, Team::them));
     }
-
 
     if (protoMsg.has_ball()) {
         ball = ball::Ball{protoMsg.ball()};

--- a/src/world_new/WorldData.cpp
+++ b/src/world_new/WorldData.cpp
@@ -14,11 +14,19 @@ WorldData::WorldData(proto::World &protoMsg, rtt::Settings const &settings, std:
     auto &others = settings.isYellow() ? protoMsg.blue() : protoMsg.yellow();
 
     for (auto &each : ours) {
-        us.emplace_back(&robots.emplace_back(feedback, each, Team::us));
+        robots.emplace_back(feedback, each, Team::us);
     }
 
     for (auto &each : others) {
-        them.emplace_back(&robots.emplace_back(feedback, each, Team::them));
+        robots.emplace_back(feedback, each, Team::them);
+    }
+
+    for (auto &robot : robots) {
+        if (robot.getTeam() == Team::us) {
+            us.emplace_back(&robot);
+        } else if (robot.getTeam() == Team::them) {
+            them.emplace_back(&robot);
+        }
     }
 
     if (protoMsg.has_ball()) {

--- a/src/world_new/WorldData.cpp
+++ b/src/world_new/WorldData.cpp
@@ -14,20 +14,17 @@ WorldData::WorldData(proto::World &protoMsg, rtt::Settings const &settings, std:
     auto &others = settings.isYellow() ? protoMsg.blue() : protoMsg.yellow();
 
     for (auto &each : ours) {
-        robots.emplace_back(feedback, each, Team::us);
+        auto robot = new robot::Robot(feedback, each, Team::us);
+        robots.push_back(std::move(*robot));
+        us.emplace_back(robot);
     }
 
     for (auto &each : others) {
-        robots.emplace_back(feedback, each, Team::them);
+        auto robot = new robot::Robot(feedback, each, Team::them);
+        robots.push_back(std::move(*robot));
+        them.emplace_back(robot);
     }
 
-    for (auto &robot : robots) {
-        if (robot.getTeam() == Team::us) {
-            us.emplace_back(&robot);
-        } else if (robot.getTeam() == Team::them) {
-            them.emplace_back(&robot);
-        }
-    }
 
     if (protoMsg.has_ball()) {
         ball = ball::Ball{protoMsg.ball()};


### PR DESCRIPTION
While creating tests for dealer I got UB in one of my robots in 'us'. I traced it back to this line: ```us.emplace_back(&robots.emplace_back(feedback, r, Team::us)); ```
Where the contents of `robots` is okay, but the contents of `us` is not.

The problem was that the reference returned by `emplace_back` is invalidated when the vector resizes. 