### PR TITLE
cleanup iomanager

### DIFF
--- a/include/roboteam_ai/ApplicationManager.h
+++ b/include/roboteam_ai/ApplicationManager.h
@@ -45,10 +45,10 @@ class ApplicationManager {
     void start();
     void checkForShutdown();
     void checkForFreeRobots();
-    void updateCoaches() const;
+    void updateCoaches(const ai::world::Field & field) const;
     void updateTrees();
-    bt::Node::Status runStrategyTree();
-    void runKeeperTree();
+    bt::Node::Status runStrategyTree(const ai::world::Field & field);
+    void runKeeperTree(const ai::world::Field & field);
 };
 
 }  // namespace rtt

--- a/include/roboteam_ai/analysis/AnalysisReport.h
+++ b/include/roboteam_ai/analysis/AnalysisReport.h
@@ -17,18 +17,6 @@ namespace rtt::ai::analysis {
 // define some play styles to influence our decision making
 enum BallPossession : short { THEY_HAVE_BALL, DEFENSIVE_NEUTRAL, NEUTRAL, OFFENSIVE_NEUTRAL, WE_HAVE_BALL };
 
-struct AnalysisReport {
-    bool reportForUs = true;
-    std::vector<std::pair<world::Robot::RobotPtr, RobotDanger>> theirRobotSortedOnDanger;
-    std::vector<std::pair<world::Robot::RobotPtr, RobotDanger>> ourRobotsSortedOnDanger;
-
-    BallPossession ballPossession = NEUTRAL;
-    double ourDistanceToGoalAvg = 0.0;
-    double theirDistanceToGoalAvg = 0.0;
-
-    RobotDanger getRobotDangerForId(int id, bool ourTeam);
-};
-
 }  // namespace rtt::ai::analysis
 
 #endif  // ROBOTEAM_AI_ANALYSISREPORT_H

--- a/include/roboteam_ai/analysis/GameAnalyzer.h
+++ b/include/roboteam_ai/analysis/GameAnalyzer.h
@@ -1,40 +1,23 @@
-//
-// Created by mrlukasbos on 19-2-19.
-//
-
 #ifndef ROBOTEAM_AI_GAMEANALYZER_H
 #define ROBOTEAM_AI_GAMEANALYZER_H
 
+#include "world/BallPossession.h"
 #include "AnalysisReport.h"
 #include "gtest/gtest_prod.h"
-#include "world/BallPossession.h"
-#include "world/World.h"
-#include "world/WorldData.h"
+#include "world_new/views/RobotView.hpp"
+#include "world_new/views/WorldDataView.hpp"
 
 namespace rtt::ai::analysis {
+namespace v = world_new::view;
 
 class GameAnalyzer {
-    FRIEND_TEST(GameAnalyzerTest, it_works);
-
-   public:
-  GameAnalyzer();
-
-
-    std::shared_ptr<AnalysisReport> generateReportNow(const Field &field);
-
-   private:
-    using WorldData = world::WorldData;
-    using RobotPtr = world::World::RobotPtr;
-    using BallPtr = world::World::BallPtr;
-
-
-    std::vector<std::pair<RobotPtr, RobotDanger>> getRobotsSortedOnDanger(const Field &field, bool ourTeam);
-    BallPossession convertPossession(rtt::ai::BallPossession::Possession possession);
-    double getTeamDistanceToGoalAvg(const Field &field, bool ourTeam, WorldData simulatedWorld = world::world->getWorld());
-    RobotDanger evaluateRobotDangerScore(const Field &field, RobotPtr robot, bool ourTeam);
-    std::vector<std::pair<int, double>> getRobotsToPassTo(RobotPtr robot, bool ourTeam, WorldData simulatedWorld = world::world->getWorld());
-    double shortestDistToEnemyRobot(RobotPtr robot, bool ourTeam, WorldData simulatedWorld = world::world->getWorld());
-    bool isClosingInToGoal(const Field &field, RobotPtr robot, bool ourTeam);
+ public:
+    static std::vector<std::pair<v::RobotView, RobotDanger>> getRobotsSortedOnDanger(const Field &field, bool ourTeam, v::WorldDataView world);
+    static BallPossession convertPossession(rtt::ai::BallPossession::Possession possession);
+    static double getTeamDistanceToGoalAvg(const Field &field, bool ourGoal, std::vector<v::RobotView> robots);
+    static RobotDanger evaluateRobotDangerScore(const Field &field, v::RobotView robot, bool ourTeam, , v::WorldDataView world);
+    static std::vector<std::pair<int, double>> getRobotsToPassTo(v::RobotView robot, bool ourTeam, v::WorldDataView world);
+    static double shortestDistToEnemyRobot(v::RobotView robot, bool ourTeam, v::WorldDataView world);
 };
 
 }  // namespace rtt::ai::analysis

--- a/include/roboteam_ai/analysis/GameAnalyzer.h
+++ b/include/roboteam_ai/analysis/GameAnalyzer.h
@@ -15,7 +15,7 @@ class GameAnalyzer {
     static std::vector<std::pair<v::RobotView, RobotDanger>> getRobotsSortedOnDanger(const Field &field, bool ourTeam, v::WorldDataView world);
     static BallPossession convertPossession(rtt::ai::BallPossession::Possession possession);
     static double getTeamDistanceToGoalAvg(const Field &field, bool ourGoal, std::vector<v::RobotView> robots);
-    static RobotDanger evaluateRobotDangerScore(const Field &field, v::RobotView robot, bool ourTeam, , v::WorldDataView world);
+    static RobotDanger evaluateRobotDangerScore(const Field &field, v::RobotView robot, bool ourTeam, v::WorldDataView world);
     static std::vector<std::pair<int, double>> getRobotsToPassTo(v::RobotView robot, bool ourTeam, v::WorldDataView world);
     static double shortestDistToEnemyRobot(v::RobotView robot, bool ourTeam, v::WorldDataView world);
 };

--- a/include/roboteam_ai/analysis/GameAnalyzer.h
+++ b/include/roboteam_ai/analysis/GameAnalyzer.h
@@ -17,17 +17,9 @@ class GameAnalyzer {
     FRIEND_TEST(GameAnalyzerTest, it_works);
 
    public:
-    // It's a singleton; don't copy it.
-    GameAnalyzer(const GameAnalyzer &) = delete;
+  GameAnalyzer();
 
-    void operator=(const GameAnalyzer &) = delete;
 
-    static GameAnalyzer &getInstance();
-
-    void start(world::Field const & field, int iterationsPerSecond = Constants::GAME_ANALYSIS_TICK_RATE());
-    void stop();
-
-    std::shared_ptr<AnalysisReport> getMostRecentReport();
     std::shared_ptr<AnalysisReport> generateReportNow(const Field &field);
 
    private:
@@ -35,23 +27,11 @@ class GameAnalyzer {
     using RobotPtr = world::World::RobotPtr;
     using BallPtr = world::World::BallPtr;
 
-    GameAnalyzer();
-
-    // Threading
-    std::thread thread;
-    std::mutex mutex;
-    volatile bool running;
-    volatile bool stopping;
-    void loop(world::Field const & field, unsigned delayMillis);
-
-    std::shared_ptr<AnalysisReport> mostRecentReport;
 
     std::vector<std::pair<RobotPtr, RobotDanger>> getRobotsSortedOnDanger(const Field &field, bool ourTeam);
     BallPossession convertPossession(rtt::ai::BallPossession::Possession possession);
     double getTeamDistanceToGoalAvg(const Field &field, bool ourTeam, WorldData simulatedWorld = world::world->getWorld());
     RobotDanger evaluateRobotDangerScore(const Field &field, RobotPtr robot, bool ourTeam);
-    ;
-
     std::vector<std::pair<int, double>> getRobotsToPassTo(RobotPtr robot, bool ourTeam, WorldData simulatedWorld = world::world->getWorld());
     double shortestDistToEnemyRobot(RobotPtr robot, bool ourTeam, WorldData simulatedWorld = world::world->getWorld());
     bool isClosingInToGoal(const Field &field, RobotPtr robot, bool ourTeam);

--- a/include/roboteam_ai/analysis/GameAnalyzer.h
+++ b/include/roboteam_ai/analysis/GameAnalyzer.h
@@ -24,7 +24,7 @@ class GameAnalyzer {
 
     static GameAnalyzer &getInstance();
 
-    void start(int iterationsPerSecond = Constants::GAME_ANALYSIS_TICK_RATE());
+    void start(world::Field const & field, int iterationsPerSecond = Constants::GAME_ANALYSIS_TICK_RATE());
     void stop();
 
     std::shared_ptr<AnalysisReport> getMostRecentReport();
@@ -42,7 +42,7 @@ class GameAnalyzer {
     std::mutex mutex;
     volatile bool running;
     volatile bool stopping;
-    void loop(unsigned delayMillis);
+    void loop(world::Field const & field, unsigned delayMillis);
 
     std::shared_ptr<AnalysisReport> mostRecentReport;
 

--- a/include/roboteam_ai/coach/defence/DefencePositionCoach.h
+++ b/include/roboteam_ai/coach/defence/DefencePositionCoach.h
@@ -33,7 +33,7 @@ class DefencePositionCoach {
    public:
     double maxX(const Field &field);  // furthest point forwards the availableIDs can go
 
-    Vector2 getMostDangerousPos(const world::WorldData &world);
+    Vector2 getMostDangerousPos(world_new::view::WorldDataView world);
 
     DefenderBot createBlockBall(const Field &field, const Line &blockLine);
     DefenderBot createBlockToGoal(const Field &field, const PossiblePass &pass, double aggressionFactor, const Line &blockLine);
@@ -41,9 +41,9 @@ class DefencePositionCoach {
     DefenderBot createBlockPass(const Field &field, PossiblePass &pass, const Vector2 &blockPoint);
     DefenderBot createBlockOnLine(const Field &field, const PossiblePass &pass, const Vector2 &blockPos);
 
-    std::shared_ptr<Line> blockToGoalLine(const Field &field, const PossiblePass &pass, const world::WorldData &simulatedWorld);
-    std::shared_ptr<Line> blockBallLine(const Field &field, const world::WorldData &simulatedWorld);
-    std::shared_ptr<Vector2> blockOnDefenseAreaLine(const Field &field, const PossiblePass &pass, const world::WorldData &simulatedWorld);
+    std::shared_ptr<Line> blockToGoalLine(const Field &field, const PossiblePass &pass, world_new::view::WorldDataView world);
+    std::shared_ptr<Line> blockBallLine(const Field &field, world_new::view::WorldDataView world);
+    std::shared_ptr<Vector2> blockOnDefenseAreaLine(const Field &field, const PossiblePass &pass,world_new::view::WorldDataView world);
     std::shared_ptr<Line> getBlockLineSegment(const Field &field, const Line &openGoalSegment, const Vector2 &point,
                                               double collisionRadius = Constants::ROBOT_RADIUS() + Constants::BALL_RADIUS(), double margin = -1.0);
     std::shared_ptr<Vector2> blockOnDefenseLine(const Field &field, const Line &openGoalSegment, const Vector2 &point);
@@ -59,22 +59,21 @@ class DefencePositionCoach {
    private:
     const double defenceLineMargin = 0.15;        // min distance the points are from defence area. Should atleast be robotradius large.
     const double calculationCollisionRad = 0.15;  // distance at which our own robots are considered to be colliding in our calculation (prevents robots from stacking up too much)
-
+    world_new::view::WorldDataView simulatedWorld;
     const double searchPoints = 31.0;  // amount of points we search for when we check if we can find points on a line
-    world::WorldData simulatedWorld;
     std::vector<DefenderBot> defenders;
 
-    std::vector<PossiblePass> createPassesSortedByDanger(const Field &field, const world::WorldData &world);
+    std::vector<PossiblePass> createPassesSortedByDanger(const Field &field, world_new::view::WorldDataView world);
     std::vector<PossiblePass> sortPassesByDanger(std::vector<std::pair<PossiblePass, double>> &passesWithDanger);
-    std::vector<std::pair<PossiblePass, double>> createPassesAndDanger(const Field &field, const world::WorldData &world);
-    world::WorldData removeBotFromWorld(world::WorldData world, int id, bool ourTeam);
-    world::WorldData getTheirAttackers(const Field &field, const world::WorldData &world);
+    std::vector<std::pair<PossiblePass, double>> createPassesAndDanger(const Field &field, world_new::view::WorldDataView world);
+    world_new::view::WorldDataView removeBotFromWorld(world_new::view::WorldDataView world, int id, bool ourTeam);
+    world_new::view::WorldDataView getTheirAttackers(const Field &field, world_new::view::WorldDataView world);
 
-    bool validNewPosition(const Field &field, const Vector2 &position, const world::WorldData &world);
-    std::shared_ptr<double> pickNewPosition(const Field &field, const Line &line, const world::WorldData &world);
-    std::shared_ptr<Vector2> pickNewPosition(const Field &field, PossiblePass pass, const world::WorldData &world);
+    bool validNewPosition(const Field &field, const Vector2 &position, world_new::view::WorldDataView world);
+    std::shared_ptr<double> pickNewPosition(const Field &field, const Line &line, world_new::view::WorldDataView world);
+    std::shared_ptr<Vector2> pickNewPosition(const Field &field, PossiblePass pass, world_new::view::WorldDataView world);
 
-    world::WorldData setupSimulatedWorld(const Field &field);
+   world_new::view::WorldDataView setupSimulatedWorld(const Field &field);
     std::shared_ptr<DefenderBot> blockMostDangerousPos(const Field &field);
     std::shared_ptr<DefenderBot> blockPass(const Field &field, PossiblePass pass);
     void addDefender(DefenderBot defender);

--- a/include/roboteam_ai/coach/defence/DefencePositionCoach.h
+++ b/include/roboteam_ai/coach/defence/DefencePositionCoach.h
@@ -27,10 +27,10 @@ struct DefenderBot {
     bool validPosition(std::vector<world_new::view::RobotView> us);
 };
 class DefencePositionCoach {
-    FRIEND_TEST(defensive_coach, blockPoints)
-  DefencePositionCoach();
+    FRIEND_TEST(defensive_coach, blockPoints);
 
-   public:
+ public:
+    DefencePositionCoach() = default;
     double maxX(const Field &field);  // furthest point forwards the availableIDs can go
 
     Vector2 getMostDangerousPos();
@@ -63,10 +63,8 @@ class DefencePositionCoach {
     // we keep simulated versions of the data in this coach
     std::vector<world_new::view::RobotView> simulatedRobotsUs;
     std::vector<world_new::view::RobotView> simulatedRobotsThem;
-    world_new::view::BallView simulatedBall;
+    std::optional<world_new::view::BallView> simulatedBall;
 
- public:
-  DefencePositionCoach();
  private:
   const double searchPoints = 31.0;  // amount of points we search for when we check if we can find points on a line
     std::vector<DefenderBot> defenders;
@@ -82,7 +80,8 @@ class DefencePositionCoach {
     std::shared_ptr<Vector2> pickNewPosition(const Field &field, PossiblePass pass);
 
    void setupSimulatedWorld(const Field &field);
-    std::shared_ptr<DefenderBot> blockMostDangerousPos(const Field &field);
+ private:
+  std::shared_ptr<DefenderBot> blockMostDangerousPos(const Field &field);
     std::shared_ptr<DefenderBot> blockPass(const Field &field, PossiblePass pass);
     void addDefender(DefenderBot defender);
     void assignIDs(int lockedCount, std::vector<int> freeRobotIDs, const std::vector<DefenderBot> &oldDefenders);

--- a/include/roboteam_ai/coach/defence/DefencePositionCoach.h
+++ b/include/roboteam_ai/coach/defence/DefencePositionCoach.h
@@ -24,7 +24,6 @@ struct DefenderBot {
 
     int coveredCount = 0;
     const world_new::view::RobotView toRobot();
-    bool validPosition(std::vector<world_new::view::RobotView> us);
 };
 class DefencePositionCoach {
     FRIEND_TEST(defensive_coach, blockPoints);
@@ -65,7 +64,6 @@ class DefencePositionCoach {
     std::vector<world_new::view::RobotView> simulatedRobotsThem;
     std::optional<world_new::view::BallView> simulatedBall;
 
- private:
   const double searchPoints = 31.0;  // amount of points we search for when we check if we can find points on a line
     std::vector<DefenderBot> defenders;
 
@@ -79,13 +77,13 @@ class DefencePositionCoach {
     std::shared_ptr<double> pickNewPosition(const Field &field, const Line &line);
     std::shared_ptr<Vector2> pickNewPosition(const Field &field, PossiblePass pass);
 
-   void setupSimulatedWorld(const Field &field);
- private:
-  std::shared_ptr<DefenderBot> blockMostDangerousPos(const Field &field);
+    void setupSimulatedWorld(const Field &field);
+
+    std::shared_ptr<DefenderBot> blockMostDangerousPos(const Field &field);
     std::shared_ptr<DefenderBot> blockPass(const Field &field, PossiblePass pass);
     void addDefender(DefenderBot defender);
     void assignIDs(int lockedCount, std::vector<int> freeRobotIDs, const std::vector<DefenderBot> &oldDefenders);
-  std::vector<Line> simulatedVisibleGoalParts(const Field &field, const PossiblePass &pass) const;
+    std::vector<Line> simulatedVisibleGoalParts(const Field &field, const PossiblePass &pass) const;
 };
 extern DefencePositionCoach g_defensivePositionCoach;
 

--- a/include/roboteam_ai/coach/defence/DefencePositionCoach.h
+++ b/include/roboteam_ai/coach/defence/DefencePositionCoach.h
@@ -23,7 +23,7 @@ struct DefenderBot {
     botType type;
 
     int coveredCount = 0;
-    const world_new::view::RobotView toRobot();
+    world_new::view::RobotView toRobot();
 };
 class DefencePositionCoach {
     FRIEND_TEST(defensive_coach, blockPoints);

--- a/include/roboteam_ai/coach/defence/PossiblePass.h
+++ b/include/roboteam_ai/coach/defence/PossiblePass.h
@@ -6,6 +6,7 @@
 #define ROBOTEAM_AI_POSSIBLEPASS_H
 
 #include <roboteam_utils/Vector2.h>
+#include <include/roboteam_ai/world_new/views/RobotView.hpp>
 #include "utilities/Constants.h"
 #include "world/Field.h"
 #include "world/Robot.h"
@@ -16,23 +17,23 @@ using namespace rtt::ai::world;
 
 class PossiblePass {
    public:
-    world::Robot toBot;
+    world_new::view::RobotView toBot;
     Vector2 startPos;
     Vector2 endPos;
     const double distance();
     bool obstacleObstructsPath(const Vector2 &obstPos, double obstRadius = Constants::ROBOT_RADIUS() + Constants::BALL_RADIUS());
-    int amountOfBlockers(const world::WorldData &world);
-    PossiblePass(world::Robot _toBot, const Vector2 &ballPos);
-    double score(const Field &field, const world::WorldData &world);
+    int amountOfBlockers(std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them);
+    PossiblePass(world_new::view::RobotView _toBot, const Vector2 &ballPos);
+    double score(const Field &field, std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them);
     // scale from startPos to EndPos
     Vector2 posOnLine(double scale);
     double faceLine();
 
    private:
     Vector2 botReceivePos(const Vector2 &startPos, const Vector2 &botPos);
-    double penaltyForBlocks(const world::WorldData &world);
+    double penaltyForBlocks(std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them);
     double penaltyForDistance();
-    double scoreForGoalAngle(const Field &field, const world::WorldData &world);
+    double scoreForGoalAngle(const Field &field, std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them);
 };
 
 }  // namespace rtt::ai::coach

--- a/include/roboteam_ai/coach/defence/PossiblePass.h
+++ b/include/roboteam_ai/coach/defence/PossiblePass.h
@@ -1,16 +1,9 @@
-//
-// Created by rolf on 5-4-19.
-//
-
 #ifndef ROBOTEAM_AI_POSSIBLEPASS_H
 #define ROBOTEAM_AI_POSSIBLEPASS_H
 
 #include <roboteam_utils/Vector2.h>
 #include <include/roboteam_ai/world_new/views/RobotView.hpp>
 #include "utilities/Constants.h"
-#include "world/Field.h"
-#include "world/Robot.h"
-#include "world/WorldData.h"
 
 namespace rtt::ai::coach {
 using namespace rtt::ai::world;
@@ -20,7 +13,7 @@ class PossiblePass {
     world_new::view::RobotView toBot;
     Vector2 startPos;
     Vector2 endPos;
-    const double distance();
+    double distance();
     bool obstacleObstructsPath(const Vector2 &obstPos, double obstRadius = Constants::ROBOT_RADIUS() + Constants::BALL_RADIUS());
     int amountOfBlockers(std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them);
     PossiblePass(world_new::view::RobotView _toBot, const Vector2 &ballPos);
@@ -33,7 +26,7 @@ class PossiblePass {
     Vector2 botReceivePos(const Vector2 &startPos, const Vector2 &botPos);
     double penaltyForBlocks(std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them);
     double penaltyForDistance();
-    double scoreForGoalAngle(const Field &field, std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them);
+    double scoreForGoalAngle(const Field &field, std::vector<world_new::view::RobotView> us);
 };
 
 }  // namespace rtt::ai::coach

--- a/include/roboteam_ai/coach/heuristics/CoachHeuristics.h
+++ b/include/roboteam_ai/coach/heuristics/CoachHeuristics.h
@@ -9,6 +9,7 @@
 #include <world/Field.h>
 #include <world/World.h>
 #include <world/WorldData.h>
+#include <include/roboteam_ai/world_new/views/WorldDataView.hpp>
 
 namespace rtt::ai::coach {
 using namespace rtt::ai::world;
@@ -31,17 +32,17 @@ class CoachHeuristics {
 
    public:
     static double calculateCloseToGoalScore(const Field &field, const Vector2 &position);
-    static double calculateShotAtGoalScore(const Field &field, const Vector2 &position, const WorldData &world);
-    static double calculatePassLineScore(const Vector2 &position, const WorldData &world);
-    static double calculateBehindBallScore(const Vector2 &position, const WorldData &world);
-    static double calculatePassDistanceToBallScore(const Field &field, const Vector2 &position, const WorldData &world);
-    static double calculatePositionDistanceToBallScore(const Field &field, const Vector2 &position, const WorldData &world);
+    static double calculateShotAtGoalScore(const Field &field, const Vector2 &position, world_new::view::WorldDataView world);
+    static double calculatePassLineScore(const Vector2 &position, world_new::view::WorldDataView world);
+    static double calculateBehindBallScore(const Vector2 &position, world_new::view::WorldDataView world);
+    static double calculatePassDistanceToBallScore(const Field &field, const Vector2 &position, world_new::view::WorldDataView world);
+    static double calculatePositionDistanceToBallScore(const Field &field, const Vector2 &position, world_new::view::WorldDataView world);
     static double calculateAngleToGoalScore(const Field &field, const Vector2 &position);
 
     /// Currently not implemented, but might be again later
     static double calculateDistanceToOpponentsScore(const Vector2 &position);
     static double calculateDistanceToClosestTeamMateScore(const Vector2 &position, int thisRobotID = -1);
-    static double getClosestOpponentAngleToPassLine(const Vector2 &position, const WorldData &world, double smallestAngle = 999999);
+    static double getClosestOpponentAngleToPassLine(const Vector2 &position, world_new::view::WorldDataView world, double smallestAngle = 999999);
 };
 
 }  // namespace rtt::ai::coach

--- a/include/roboteam_ai/coach/heuristics/OffensiveScore.h
+++ b/include/roboteam_ai/coach/heuristics/OffensiveScore.h
@@ -26,7 +26,7 @@ class OffensiveScore {
 
    public:
     using WorldData = world::WorldData;
-    double calculateOffensivePositionScore(const Vector2 &zoneLocation, const Vector2 &position, const WorldData &world, const Field &field);
+    double calculateOffensivePositionScore(const Vector2 &zoneLocation, const Vector2 &position, world_new::view::WorldDataView world, const Field &field);
 };
 
 }  // namespace rtt::ai::coach

--- a/include/roboteam_ai/control/BasicPosControl.h
+++ b/include/roboteam_ai/control/BasicPosControl.h
@@ -16,8 +16,8 @@ class BasicPosControl : public PosController {
    public:
     BasicPosControl() = default;
     explicit BasicPosControl(double avoidBall, bool canMoveOutsideField, bool canMoveInDefenseArea);
-    RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &robot, const Vector2 &targetPos, const Angle &targetAngle) override;
-    RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &robot, const Vector2 &targetPos) override;
+    RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &robot, const Vector2 &targetPos, const Angle &targetAngle) override;
+    RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &robot, const Vector2 &targetPos) override;
 };
 
 }  // namespace rtt::ai::control

--- a/include/roboteam_ai/control/PosController.h
+++ b/include/roboteam_ai/control/PosController.h
@@ -8,8 +8,6 @@
 #include <utilities/Constants.h>
 #include "RobotCommand.h"
 #include "world/Field.h"
-//#include <control/controllers/PidController.h>
-//#include <control/controllers/PidTwoAxesController.h>
 #include "roboteam_utils/pid.h"
 #include "world/FieldComputations.h"
 #include "world/World.h"

--- a/include/roboteam_ai/control/PosController.h
+++ b/include/roboteam_ai/control/PosController.h
@@ -7,6 +7,7 @@
 
 #include <utilities/Constants.h>
 #include "RobotCommand.h"
+#include "world/Field.h"
 //#include <control/controllers/PidController.h>
 //#include <control/controllers/PidTwoAxesController.h>
 #include "roboteam_utils/pid.h"

--- a/include/roboteam_ai/control/PosController.h
+++ b/include/roboteam_ai/control/PosController.h
@@ -47,9 +47,9 @@ class PosController {
    public:
     PosController() = default;
     explicit PosController(double avoidBall, bool canMoveOutOfField, bool canMoveInDefenseArea);
-    virtual RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &robot, const Vector2 &targetPos, const Angle &targetAngle) = 0;
+    virtual RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &robot, const Vector2 &targetPos, const Angle &targetAngle) = 0;
 
-    virtual RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &robot, const Vector2 &targetPos) = 0;
+    virtual RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &robot, const Vector2 &targetPos) = 0;
 
     bool getCanMoveOutOfField(int robotID) const;
     void setCanMoveOutOfField(bool canMoveOutOfField);

--- a/include/roboteam_ai/control/ball-handling/BallHandlePosControl.h
+++ b/include/roboteam_ai/control/ball-handling/BallHandlePosControl.h
@@ -84,9 +84,9 @@ class BallHandlePosControl : public NumTreePosControl {
     void setMaxVelocity(double maxV);
     void setMaxForwardsVelocity(double maxV);
     void setMaxBackwardsVelocity(double maxV);
-    RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &r, const Vector2 &targetP, const Angle &targetA) override;
-    RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &r, const Vector2 &targetP, const Angle &targetA, TravelStrategy travelStrategy);
-    RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &r, const Vector2 &targetP) override;
+    RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &r, const Vector2 &targetP, const Angle &targetA) override;
+    RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &r, const Vector2 &targetP, const Angle &targetA, TravelStrategy travelStrategy);
+    RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &r, const Vector2 &targetP) override;
 
    private:
     bool isCrashingIntoOpponentRobot(const LineSegment &driveLine);

--- a/include/roboteam_ai/control/numtrees/NumTreePosControl.h
+++ b/include/roboteam_ai/control/numtrees/NumTreePosControl.h
@@ -56,7 +56,7 @@ class NumTreePosControl : public BasicPosControl {
 
    protected:
     world::World *world = nullptr;
-    const Field *field = nullptr;
+    const world::Field *field = nullptr;
 
    private:
     bool allowIllegalPositions = false;
@@ -83,10 +83,10 @@ class NumTreePosControl : public BasicPosControl {
 
     void clear();
 
-    RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &robotPtr, const Vector2 &targetPos) override;
-    RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &robotPtr, const Vector2 &targetPos, bool illegalPositions);
-    RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &robotPtr, const Vector2 &targetPos, const Angle &targetAngle) override;
-    RobotCommand getRobotCommand(world::World *world, const Field *field, const RobotPtr &robotPtr, const Vector2 &targetPos, const Angle &targetAngle, bool illegalPositions);
+    RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &robotPtr, const Vector2 &targetPos) override;
+    RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &robotPtr, const Vector2 &targetPos, bool illegalPositions);
+    RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &robotPtr, const Vector2 &targetPos, const Angle &targetAngle) override;
+    RobotCommand getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &robotPtr, const Vector2 &targetPos, const Angle &targetAngle, bool illegalPositions);
 
     bool checkChangeInMaxRobotVel();
 };

--- a/include/roboteam_ai/control/shot-controllers/ShotController.h
+++ b/include/roboteam_ai/control/shot-controllers/ShotController.h
@@ -55,7 +55,7 @@ class ShotController {
     std::pair<Vector2, Vector2> shiftLineForGeneva(const std::pair<Vector2, Vector2> &line, int genevaState);
 
     // RobotCommand calculation
-    RobotCommand goToPlaceBehindBall(const Field &field, const world::Robot &robot, const Vector2 &robotTargetPosition, const std::pair<Vector2, Vector2> &driveLine, int geneva);
+    RobotCommand goToPlaceBehindBall(const world::Field &field, const world::Robot &robot, const Vector2 &robotTargetPosition, const std::pair<Vector2, Vector2> &driveLine, int geneva);
     RobotCommand moveStraightToBall(world::Robot robot, const std::pair<Vector2, Vector2> &lineToDriveOver);
     RobotCommand shoot(RobotCommand shotData, const world::Robot &robot, const std::pair<Vector2, Vector2> &driveLine, const Vector2 &shotTarget, bool chip,
                        BallSpeed desiredBallSpeed);
@@ -64,7 +64,7 @@ class ShotController {
 
    public:
     explicit ShotController() = default;
-    RobotCommand getRobotCommand(const Field &field, world::Robot robot, const Vector2 &shotTarget, bool chip = false, BallSpeed ballspeed = MAX_SPEED, bool useAutoGeneva = true,
+    RobotCommand getRobotCommand(const world::Field &field, world::Robot robot, const Vector2 &shotTarget, bool chip = false, BallSpeed ballspeed = MAX_SPEED, bool useAutoGeneva = true,
                                  ShotPrecision precision = MEDIUM, int genevaState = 0);
 };
 

--- a/include/roboteam_ai/utilities/IOManager.h
+++ b/include/roboteam_ai/utilities/IOManager.h
@@ -27,13 +27,13 @@ using namespace rtt::ai::world;
 
 class IOManager {
    private:
-    Field field;
-
     proto::World worldMsg;
     proto::SSL_GeometryData geometryMsg;
     proto::RobotFeedback robotFeedbackMsg;
     proto::SSL_Referee refDataMsg;
     proto::DemoRobot demoInfoMsg;
+
+    std::unordered_map<int, proto::RobotFeedback> feedbackMap;
 
     proto::Subscriber<proto::World> *worldSubscriber;
     void handleWorldState(proto::World &world);
@@ -56,8 +56,7 @@ class IOManager {
     explicit IOManager() = default;
     void publishRobotCommand(proto::RobotCommand cmd);
     void publishSettings(proto::Setting setting);
-    void init();
-    const Field &getField();
+    void init(int teamId);
     const proto::World &getWorldState();
     const proto::SSL_GeometryData &getGeometryData();
     const proto::RobotFeedback &getRobotFeedback();

--- a/include/roboteam_ai/world/FieldComputations.h
+++ b/include/roboteam_ai/world/FieldComputations.h
@@ -7,19 +7,22 @@
 #ifndef ROBOTEAM_AI_FIELDCOMPUTATIONS_H
 #define ROBOTEAM_AI_FIELDCOMPUTATIONS_H
 
-#include <include/roboteam_ai/world/Field.h>
+#include "world/Field.h"
 #include <roboteam_utils/Polygon.h>
 #include <cmath>
-#include <include/roboteam_ai/world_new/views/WorldDataView.hpp>
 #include "mutex"
 #include "roboteam_proto/GeometryFieldSize.pb.h"
 #include "roboteam_proto/messages_robocup_ssl_geometry.pb.h"
 
+namespace rtt::world_new::view {
+class WorldDataView;
+}
+
 namespace rtt::ai {
-namespace world {
-class WorldData;
-}  // namespace world
+
 using namespace rtt::ai::world;
+
+
 
 class FieldComputations {
    public:
@@ -28,7 +31,7 @@ class FieldComputations {
     static double getPercentageOfGoalVisibleFromPoint(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world, int id = -1, bool ourTeam = false);
     static std::vector<Line> getBlockadesMappedToGoal(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world, int id = -1, bool ourTeam = false);
     static std::vector<Line> mergeBlockades(std::vector<Line> blockades);
-    static std::vector<Line> getVisiblePartsOfGoal(const Field &field, bool ourGoal, const Vector2 &point, const world::WorldData &world);
+    static std::vector<Line> getVisiblePartsOfGoal(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world);
     static Line getGoalSides(const Field &field, bool ourGoal);
     static double getDistanceToGoal(const Field &field, bool ourGoal, const Vector2 &point);
     static Vector2 getPenaltyPoint(const Field &field, bool ourGoal);

--- a/include/roboteam_ai/world/FieldComputations.h
+++ b/include/roboteam_ai/world/FieldComputations.h
@@ -10,20 +10,18 @@
 #include "world/Field.h"
 #include <roboteam_utils/Polygon.h>
 #include <cmath>
-#include <include/roboteam_ai/world_new/views/RobotView.hpp>
 #include "mutex"
 #include "roboteam_proto/GeometryFieldSize.pb.h"
 #include "roboteam_proto/messages_robocup_ssl_geometry.pb.h"
 
 namespace rtt::world_new::view {
 class WorldDataView;
+class RobotView;
 }
 
 namespace rtt::ai {
 
 using namespace rtt::ai::world;
-
-
 
 class FieldComputations {
    public:

--- a/include/roboteam_ai/world/FieldComputations.h
+++ b/include/roboteam_ai/world/FieldComputations.h
@@ -10,6 +10,7 @@
 #include "world/Field.h"
 #include <roboteam_utils/Polygon.h>
 #include <cmath>
+#include <include/roboteam_ai/world_new/views/RobotView.hpp>
 #include "mutex"
 #include "roboteam_proto/GeometryFieldSize.pb.h"
 #include "roboteam_proto/messages_robocup_ssl_geometry.pb.h"
@@ -29,9 +30,12 @@ class FieldComputations {
     static bool pointIsInDefenceArea(const Field &field, const Vector2 &point, bool isOurDefenceArea = true, double margin = 0.0, bool includeOutsideField = false);
     static bool pointIsInField(const Field &field, const Vector2 &point, double margin = 0.0);  // TODO: Remove margin hack
     static double getPercentageOfGoalVisibleFromPoint(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world, int id = -1, bool ourTeam = false);
-    static std::vector<Line> getBlockadesMappedToGoal(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world, int id = -1, bool ourTeam = false);
+    static std::vector<Line> getBlockadesMappedToGoal(const Field &field, bool ourGoal, const Vector2 &point, std::vector<world_new::view::RobotView> robots, int id = -1, bool ourTeam = false);
     static std::vector<Line> mergeBlockades(std::vector<Line> blockades);
+
     static std::vector<Line> getVisiblePartsOfGoal(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world);
+    static std::vector<Line> getVisiblePartsOfGoalByObstacles(const Field &field, bool ourGoal, const Vector2 &point, const std::vector<world_new::view::RobotView>& robots);
+
     static Line getGoalSides(const Field &field, bool ourGoal);
     static double getDistanceToGoal(const Field &field, bool ourGoal, const Vector2 &point);
     static Vector2 getPenaltyPoint(const Field &field, bool ourGoal);

--- a/include/roboteam_ai/world/FieldComputations.h
+++ b/include/roboteam_ai/world/FieldComputations.h
@@ -10,6 +10,7 @@
 #include <include/roboteam_ai/world/Field.h>
 #include <roboteam_utils/Polygon.h>
 #include <cmath>
+#include <include/roboteam_ai/world_new/views/WorldDataView.hpp>
 #include "mutex"
 #include "roboteam_proto/GeometryFieldSize.pb.h"
 #include "roboteam_proto/messages_robocup_ssl_geometry.pb.h"
@@ -24,8 +25,8 @@ class FieldComputations {
    public:
     static bool pointIsInDefenceArea(const Field &field, const Vector2 &point, bool isOurDefenceArea = true, double margin = 0.0, bool includeOutsideField = false);
     static bool pointIsInField(const Field &field, const Vector2 &point, double margin = 0.0);  // TODO: Remove margin hack
-    static double getPercentageOfGoalVisibleFromPoint(const Field &field, bool ourGoal, const Vector2 &point, const world::WorldData &world, int id = -1, bool ourTeam = false);
-    static std::vector<Line> getBlockadesMappedToGoal(const Field &field, bool ourGoal, const Vector2 &point, const world::WorldData &world, int id = -1, bool ourTeam = false);
+    static double getPercentageOfGoalVisibleFromPoint(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world, int id = -1, bool ourTeam = false);
+    static std::vector<Line> getBlockadesMappedToGoal(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world, int id = -1, bool ourTeam = false);
     static std::vector<Line> mergeBlockades(std::vector<Line> blockades);
     static std::vector<Line> getVisiblePartsOfGoal(const Field &field, bool ourGoal, const Vector2 &point, const world::WorldData &world);
     static Line getGoalSides(const Field &field, bool ourGoal);

--- a/include/roboteam_ai/world/World.h
+++ b/include/roboteam_ai/world/World.h
@@ -34,6 +34,7 @@ class World {
     std::mutex worldMutex;
     History *history;
     FutureWorld *futureWorld;
+    Field field;
     unsigned long worldNumber = 0;
     const RobotPtr getRobotClosestToPoint(const Vector2 &point, const std::vector<RobotPtr> &robots);
     void updateRobotsFromData(Team team, const std::vector<proto::WorldRobot> &robotsFromMsg, std::vector<RobotPtr> &robots, const BallPtr &ball, unsigned long worldNumber) const;
@@ -41,7 +42,7 @@ class World {
    public:
     explicit World();
     ~World();
-    void updateWorld(const Field &field, const proto::World &world);
+    void updateWorld(const proto::SSL_GeometryFieldSize &fieldMessage, const proto::World &worldMessage);
     bool weHaveRobots();
     double getTimeDifference();
     double getTime();

--- a/include/roboteam_ai/world_new/World.hpp
+++ b/include/roboteam_ai/world_new/World.hpp
@@ -85,16 +85,24 @@ class World {
     void updateWorld(proto::World &protoWorld);
 
     /**
+    * Updates the currentField
+    * @param field Field to construct currentField from
+    */
+    void updateField(proto::SSL_GeometryFieldSize &protoField);
+
+    /**
      * Gets the current world
      * @return std::nullopt if there is no currentWorld, otherwise Some with the value
      */
     [[nodiscard]] std::optional<view::WorldDataView> getWorld() const noexcept;
 
-    /**
-     * Gets a certain world from history
-     * @param ticksAgo Ticks ago to fetch from
-     * @return Returns the world at index currentIndex - ticksAgo
-     */
+    [[nodiscard]] std::optional<ai::world::Field> getField() const noexcept;
+
+      /**
+       * Gets a certain world from history
+       * @param ticksAgo Ticks ago to fetch from
+       * @return Returns the world at index currentIndex - ticksAgo
+       */
     [[nodiscard]] view::WorldDataView getHistoryWorld(size_t ticksAgo) const noexcept;
 
     /**
@@ -183,6 +191,9 @@ class World {
      * Some if a world is valid
      */
     std::optional<WorldData> currentWorld;
+
+
+    std::optional<ai::world::Field> currentField;
 
     /**
      * Timestamp of the last tick

--- a/include/roboteam_ai/world_new/World.hpp
+++ b/include/roboteam_ai/world_new/World.hpp
@@ -56,7 +56,7 @@ class World {
     /**
      * Amount of ticks to store in history
      */
-    constexpr static size_t HISTORY_SIZE = 20;
+    constexpr static size_t HISTORY_SIZE = 200;
 
     /**
      * Constructs a World from settings

--- a/include/roboteam_ai/world_new/WorldData.hpp
+++ b/include/roboteam_ai/world_new/WorldData.hpp
@@ -51,17 +51,17 @@ class WorldData {
     /**
      * Non owning vector of views
      */
-    std::vector<view::RobotView> robotsNonOwning;
+    std::vector<view::RobotView> robotsNonOwning = {};
 
     /**
      * Non-owning container of Robot const* const's (aka RobotView) for our team
      */
-    std::vector<view::RobotView> us;
+    std::vector<view::RobotView> us = {};
 
     /**
      * Non-owning container of RobotViews of the enemy team
      */
-    std::vector<view::RobotView> them;
+    std::vector<view::RobotView> them = {};
 
     /**
      * Optional ball, None variant if not visible

--- a/include/roboteam_ai/world_new/views/RobotView.hpp
+++ b/include/roboteam_ai/world_new/views/RobotView.hpp
@@ -10,7 +10,7 @@
 #include <include/roboteam_ai/world_new/Robot.hpp>
 
 namespace rtt::world_new::robot {
-class RobotControllers;
+    class RobotControllers;
 }
 namespace rtt::world_new::view {
 

--- a/include/roboteam_ai/world_new/views/RobotView.hpp
+++ b/include/roboteam_ai/world_new/views/RobotView.hpp
@@ -5,10 +5,13 @@
 #ifndef RTT_ROBOT_VIEW_HPP
 #define RTT_ROBOT_VIEW_HPP
 
+#include <roboteam_utils/Vector2.h>
 #include <include/roboteam_ai/utilities/Constants.h>
-#include "world_new/Robot.hpp"
-#include "world_new/RobotControllers.hpp"
+#include <include/roboteam_ai/world_new/Robot.hpp>
 
+namespace rtt::world_new::robot {
+class RobotControllers;
+}
 namespace rtt::world_new::view {
 
 /**

--- a/include/roboteam_ai/world_new/views/WorldDataView.hpp
+++ b/include/roboteam_ai/world_new/views/WorldDataView.hpp
@@ -6,7 +6,6 @@
 #define RTT_WORLD_DATA_VIEW_HPP
 
 #include <vector>
-
 #include "BallView.hpp"
 #include "RobotView.hpp"
 #include "utilities/Constants.h"

--- a/include/roboteam_ai/world_new/views/WorldDataView.hpp
+++ b/include/roboteam_ai/world_new/views/WorldDataView.hpp
@@ -68,7 +68,7 @@ class WorldDataView {
      */
     [[nodiscard]] std::vector<view::RobotView> const &getThem() const noexcept;
 
-    /**
+  /**
      * Gets all the robots in the owning container
      * @return data->getRobots();
      */

--- a/include/roboteam_ai/world_new/views/WorldDataView.hpp
+++ b/include/roboteam_ai/world_new/views/WorldDataView.hpp
@@ -10,8 +10,8 @@
 #include "RobotView.hpp"
 #include "utilities/Constants.h"
 #include "world_new/Ball.hpp"
-#include "world_new/Robot.hpp"
 #include "world_new/Team.hpp"
+#include "world_new/Robot.hpp"
 
 namespace rtt::world_new {
 class WorldData;

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -70,11 +70,11 @@ void ApplicationManager::runOneLoopCycle() {
             this->notifyTreeStatus(status);
         } else {
             std::cout << "[ApplicationManager::runOneLoopCycle] No robots from our team in world yet" << std::endl;
-            std::this_thread::sleep_for(std::chrono::milliseconds (1000));
+            std::this_thread::sleep_for(std::chrono::milliseconds (100));
         }
     } else {
         std::cout << "[ApplicationManager::runOneLoopCycle] No field yet" << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds (1000));
+        std::this_thread::sleep_for(std::chrono::milliseconds (100));
     }
     /*
      * This is a hack performed at the robocup.

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -1,7 +1,3 @@
-//
-// Created by mrlukasbos on 14-1-19.
-//
-
 #include <ApplicationManager.h>
 #include <bt/Node.h>
 #include <coach/GetBallCoach.h>

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -35,8 +35,7 @@ void ApplicationManager::start() {
             t.limit([&]() {
                     ai::interface::Input::setFps(amountOfCycles * fpsUpdateRate);
                     amountOfCycles = 0;
-                },
-                fpsUpdateRate);
+                }, fpsUpdateRate);
 
             // publish settings, but limit this function call to only run 1 times/s at most
             t.limit([&]() { io::io.publishSettings(SETTINGS.toMessage()); }, 1);

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -54,28 +54,13 @@ void ApplicationManager::runOneLoopCycle() {
     if (io::io.hasReceivedGeom) {
         auto fieldMessage = io::io.getGeometryData().field();
         auto worldMessage = io::io.getWorldState();
-        auto refMessage = io::io.getRefereeData();
-h
+
         if (!SETTINGS.isLeft()) {
          //   roboteam_utils::rotate(&fieldMessage);
             roboteam_utils::rotate(&worldMessage);
-            roboteam_utils::rotate(&refMessage);
         }
 
-        // Our name as specified by ssl-refbox : https://github.com/RoboCup-SSL/ssl-refbox/blob/master/referee.conf
-        std::string ROBOTEAM_TWENTE = "RoboTeam Twente";
-        if (refMessage.yellow().name() == ROBOTEAM_TWENTE) {
-            SETTINGS.setYellow(true);
-        } else if (refMessage.blue().name() == ROBOTEAM_TWENTE) {
-            SETTINGS.setYellow(false);
-        }
 
-        if (refMessage.blueteamonpositivehalf() ^ SETTINGS.isYellow()) {
-            SETTINGS.setLeft(false);
-        } else {
-            SETTINGS.setLeft(true);
-        }
-        ai::GameStateManager::setRefereeData(refMessage);
 
         world->updateWorld(fieldMessage, worldMessage); // this one needs to be removed
 

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -50,27 +50,31 @@ void ApplicationManager::start() {
 /// Run everything with regard to behaviour trees
 void ApplicationManager::runOneLoopCycle() {
 
-
-    if (weHaveRobots && io::io.hasReceivedGeom) {
-
+    if (io::io.hasReceivedGeom) {
         auto fieldMessage = io::io.getGeometryData().field();
         auto worldMessage = io::io.getWorldState();
-
         world->updateWorld(fieldMessage, worldMessage); // this one needs to be removed
-        world_new::World::instance()->updateWorld(worldMessage);
-        world_new::World::instance()->updateField(fieldMessage);
-        auto field = world_new::World::instance()->getField().value();
 
-        decidePlay(world, field);
-        updateTrees();
-        updateCoaches(field);
-        runKeeperTree(field);
-        Status status = runStrategyTree(field);
-        this->notifyTreeStatus(status);
+        if (!world->getUs().empty()) {
+            std::cout << "cycle" << std::endl;
+
+            world_new::World::instance()->updateWorld(worldMessage);
+            world_new::World::instance()->updateField(fieldMessage);
+            auto field = world_new::World::instance()->getField().value();
+
+            decidePlay(world, field);
+            updateTrees();
+            updateCoaches(field);
+            runKeeperTree(field);
+            Status status = runStrategyTree(field);
+            this->notifyTreeStatus(status);
+        } else {
+            std::cout << "[ApplicationManager::runOneLoopCycle] No robots from our team in world yet" << std::endl;
+            std::this_thread::sleep_for(std::chrono::microseconds(100000));
+        }
     } else {
-        std::this_thread::sleep_for(std::chrono::microseconds(100000));
+        std::cout << "[ApplicationManager::runOneLoopCycle] No field yet" << std::endl;
     }
-    weHaveRobots = ai::world::world->weHaveRobots();
     /*
      * This is a hack performed at the robocup.
      * It does a soft refresh when robots are not properly claimed by robotdealer.

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -66,7 +66,6 @@ void ApplicationManager::runOneLoopCycle() {
         world_new::World::instance()->updateField(fieldMessage);
         auto field = world_new::World::instance()->getField().value();
 
-        ai::analysis::GameAnalyzer::getInstance().start(field);
         decidePlay(world, field);
         updateTrees();
         updateCoaches(field);
@@ -147,7 +146,6 @@ void ApplicationManager::checkForShutdown() {
     if (strategy->getStatus() == Status::Running) {
         strategy->terminate(Status::Running);
     }
-    ai::analysis::GameAnalyzer::getInstance().stop();
 }
 
 // Robotdealer hack to prevent robots from staying 'free' during play

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -27,16 +27,12 @@ void ApplicationManager::start() {
     int amountOfCycles = 0;
     roboteam_utils::Timer t;
     t.loop([&]() {
-
-            // This function runs the behaviour trees
             runOneLoopCycle();
-
-            amountOfCycles++;
+             amountOfCycles++;
 
             // update the measured FPS, but limit this function call to only run 5 times/s at most
             int fpsUpdateRate = 5;
-            t.limit(
-                [&]() {
+            t.limit([&]() {
                     ai::interface::Input::setFps(amountOfCycles * fpsUpdateRate);
                     amountOfCycles = 0;
                 },
@@ -50,7 +46,6 @@ void ApplicationManager::start() {
 
 /// Run everything with regard to behaviour trees
 void ApplicationManager::runOneLoopCycle() {
-
     if (io::io.hasReceivedGeom) {
         auto fieldMessage = io::io.getGeometryData().field();
         auto worldMessage = io::io.getWorldState();
@@ -59,8 +54,6 @@ void ApplicationManager::runOneLoopCycle() {
          //   roboteam_utils::rotate(&fieldMessage);
             roboteam_utils::rotate(&worldMessage);
         }
-
-
 
         world->updateWorld(fieldMessage, worldMessage); // this one needs to be removed
 

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -10,6 +10,7 @@
 #include <world/World.h>
 #include <utilities/GameStateManager.hpp>
 #include "utilities/Constants.h"
+#include "roboteam_utils/normalize.h"
 
 namespace io = rtt::ai::io;
 namespace ai = rtt::ai;
@@ -53,7 +54,14 @@ void ApplicationManager::runOneLoopCycle() {
     if (io::io.hasReceivedGeom) {
         auto fieldMessage = io::io.getGeometryData().field();
         auto worldMessage = io::io.getWorldState();
+
+        if (!SETTINGS.isLeft()) {
+            roboteam_utils::rotate(&fieldMessage);
+            roboteam_utils::rotate(&worldMessage);
+        }
+
         world->updateWorld(fieldMessage, worldMessage); // this one needs to be removed
+
 
         if (!world->getUs().empty()) {
             std::cout << "cycle" << std::endl;

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -54,11 +54,28 @@ void ApplicationManager::runOneLoopCycle() {
     if (io::io.hasReceivedGeom) {
         auto fieldMessage = io::io.getGeometryData().field();
         auto worldMessage = io::io.getWorldState();
-
+        auto refMessage = io::io.getRefereeData();
+h
         if (!SETTINGS.isLeft()) {
-            roboteam_utils::rotate(&fieldMessage);
+         //   roboteam_utils::rotate(&fieldMessage);
             roboteam_utils::rotate(&worldMessage);
+            roboteam_utils::rotate(&refMessage);
         }
+
+        // Our name as specified by ssl-refbox : https://github.com/RoboCup-SSL/ssl-refbox/blob/master/referee.conf
+        std::string ROBOTEAM_TWENTE = "RoboTeam Twente";
+        if (refMessage.yellow().name() == ROBOTEAM_TWENTE) {
+            SETTINGS.setYellow(true);
+        } else if (refMessage.blue().name() == ROBOTEAM_TWENTE) {
+            SETTINGS.setYellow(false);
+        }
+
+        if (refMessage.blueteamonpositivehalf() ^ SETTINGS.isYellow()) {
+            SETTINGS.setLeft(false);
+        } else {
+            SETTINGS.setLeft(true);
+        }
+        ai::GameStateManager::setRefereeData(refMessage);
 
         world->updateWorld(fieldMessage, worldMessage); // this one needs to be removed
 

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -3,7 +3,6 @@
 //
 
 #include <ApplicationManager.h>
-#include <analysis/GameAnalyzer.h>
 #include <bt/Node.h>
 #include <coach/GetBallCoach.h>
 #include <coach/OffensiveCoach.h>

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -76,10 +76,11 @@ void ApplicationManager::runOneLoopCycle() {
             this->notifyTreeStatus(status);
         } else {
             std::cout << "[ApplicationManager::runOneLoopCycle] No robots from our team in world yet" << std::endl;
-            std::this_thread::sleep_for(std::chrono::microseconds(100000));
+            std::this_thread::sleep_for(std::chrono::milliseconds (1000));
         }
     } else {
         std::cout << "[ApplicationManager::runOneLoopCycle] No field yet" << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds (1000));
     }
     /*
      * This is a hack performed at the robocup.

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -62,9 +62,7 @@ void ApplicationManager::runOneLoopCycle() {
 
         world->updateWorld(fieldMessage, worldMessage); // this one needs to be removed
 
-
         if (!world->getUs().empty()) {
-            std::cout << "cycle" << std::endl;
 
             world_new::World::instance()->updateWorld(worldMessage);
             world_new::World::instance()->updateField(fieldMessage);

--- a/src/analysis/AnalysisReport.cpp
+++ b/src/analysis/AnalysisReport.cpp
@@ -6,17 +6,4 @@
 
 namespace rtt::ai::analysis {
 
-RobotDanger AnalysisReport::getRobotDangerForId(int id, bool ourTeam) {
-    auto robotDangers = ourTeam ? ourRobotsSortedOnDanger : theirRobotSortedOnDanger;
-
-    if (!robotDangers.empty()) {
-        for (auto const &dangerPair : robotDangers) {
-            if (dangerPair.first->id == id) {
-                return dangerPair.second;
-            }
-        }
-    }
-
-    return {};
-}
 }  // namespace rtt::ai::analysis

--- a/src/analysis/GameAnalyzer.cpp
+++ b/src/analysis/GameAnalyzer.cpp
@@ -3,8 +3,6 @@
 #include <world/BallPossession.h>
 #include "analysis/RobotDanger.h"
 #include "world/FieldComputations.h"
-#include "world/Robot.h"
-#include "world/World.h"
 
 namespace rtt::ai::analysis {
 

--- a/src/analysis/GameAnalyzer.cpp
+++ b/src/analysis/GameAnalyzer.cpp
@@ -8,25 +8,6 @@
 
 namespace rtt::ai::analysis {
 
-GameAnalyzer::GameAnalyzer() {}
-
-/// Generate a report with the game analysis
-std::shared_ptr<AnalysisReport> GameAnalyzer::generateReportNow(const Field &field) {
-    if (world::world->weHaveRobots()) {
-        std::shared_ptr<AnalysisReport> report = std::make_shared<AnalysisReport>();
-
-        report->ballPossession = convertPossession(ballPossessionPtr->getPossession());
-        report->ourDistanceToGoalAvg = getTeamDistanceToGoalAvg(field, true);
-        report->theirDistanceToGoalAvg = getTeamDistanceToGoalAvg(field, false);
-        report->theirRobotSortedOnDanger = getRobotsSortedOnDanger(field, false);
-        report->ourRobotsSortedOnDanger = getRobotsSortedOnDanger(field, true);
-
-        return report;
-    }
-    std::cout << "NOT A WORLD YET" << std::endl;
-    return {};
-}
-
 BallPossession GameAnalyzer::convertPossession(rtt::ai::BallPossession::Possession possession) {
     switch (possession) {
         default:
@@ -48,28 +29,26 @@ BallPossession GameAnalyzer::convertPossession(rtt::ai::BallPossession::Possessi
 }
 
 /// Get the average of the distances of robots to their opponents goal
-double GameAnalyzer::getTeamDistanceToGoalAvg(const Field &field, bool ourTeam, WorldData simulatedWorld) {
-    auto robots = ourTeam ? simulatedWorld.us : simulatedWorld.them;
+double GameAnalyzer::getTeamDistanceToGoalAvg(const Field &field, bool ourGoal, std::vector<v::RobotView> robots) {
     double total = 0.0;
     for (auto robot : robots) {
-        total += FieldComputations::getDistanceToGoal(field, ourTeam, robot->pos);
+        total += FieldComputations::getDistanceToGoal(field, ourGoal, robot->getPos());
     }
     return (total / robots.size());
 }
 
 /// returns a danger score
-RobotDanger GameAnalyzer::evaluateRobotDangerScore(const Field &field, RobotPtr robot, bool ourTeam) {
+RobotDanger GameAnalyzer::evaluateRobotDangerScore(const Field &field, v::RobotView robot, bool ourTeam, v::WorldDataView world) {
     Vector2 goalCenter = ourTeam ? field.getOurGoalCenter() : field.getTheirGoalCenter();
 
     RobotDanger danger;
     danger.ourTeam = ourTeam;
-    danger.id = robot->id;
-    danger.distanceToGoal = FieldComputations::getDistanceToGoal(field, ourTeam, robot->pos);
-    danger.shortestDistToEnemy = shortestDistToEnemyRobot(robot, ourTeam);
-    danger.goalVisionPercentage = FieldComputations::getPercentageOfGoalVisibleFromPoint(field, !ourTeam, robot->pos, world::world->getWorld());
-    danger.robotsToPassTo = getRobotsToPassTo(robot, ourTeam);
-    danger.closingInToGoal = isClosingInToGoal(field, robot, ourTeam);
-    danger.aimedAtGoal = control::ControlUtils::robotIsAimedAtPoint(robot->id, ourTeam, goalCenter);
+    danger.id = robot->getId();
+    danger.distanceToGoal = FieldComputations::getDistanceToGoal(field, ourTeam, robot->getPos());
+    danger.shortestDistToEnemy = shortestDistToEnemyRobot(robot, ourTeam, world);
+    danger.goalVisionPercentage = FieldComputations::getPercentageOfGoalVisibleFromPoint(field, !ourTeam, robot->getPos(), world);
+    danger.robotsToPassTo = getRobotsToPassTo(robot, ourTeam, world);
+    danger.aimedAtGoal = control::ControlUtils::robotIsAimedAtPoint(robot->getId(), ourTeam, goalCenter);
 
     return danger;
 }
@@ -77,15 +56,15 @@ RobotDanger GameAnalyzer::evaluateRobotDangerScore(const Field &field, RobotPtr 
 /// Check with distanceToLineWithEnds if there are obstructions
 /// Returns all robots that can be passed to, along with the distance
 /// we return robot ids instead of robot object because the objects are incorrect (because of simulated world)
-std::vector<std::pair<int, double>> GameAnalyzer::getRobotsToPassTo(RobotPtr robot, bool ourTeam, WorldData simulatedWorld) {
-    auto ourRobots = ourTeam ? simulatedWorld.us : simulatedWorld.them;
-    auto enemyRobots = ourTeam ? simulatedWorld.them : simulatedWorld.us;
+std::vector<std::pair<int, double>> GameAnalyzer::getRobotsToPassTo(v::RobotView robot, bool ourTeam, v::WorldDataView world) {
+    auto ourRobots = ourTeam ? world.getUs() : world.getThem();
+    auto enemyRobots = ourTeam ? world.getThem() : world.getUs();
 
     std::vector<std::pair<int, double>> robotsToPassTo;
     for (auto ourRobot : ourRobots) {
         bool canPassToThisRobot = true;
         for (auto theirRobot : enemyRobots) {
-            auto distToLine = control::ControlUtils::distanceToLineWithEnds(theirRobot->pos, Vector2(robot->pos), Vector2(ourRobot->pos));
+            auto distToLine = control::ControlUtils::distanceToLineWithEnds(theirRobot->pos, Vector2(robot->getPos()), Vector2(ourRobot->getPos()));
             if (distToLine < (Constants::ROBOT_RADIUS_MAX() + Constants::BALL_RADIUS())) {
                 canPassToThisRobot = false;
                 break;
@@ -101,42 +80,26 @@ std::vector<std::pair<int, double>> GameAnalyzer::getRobotsToPassTo(RobotPtr rob
 
 /// get the shortest distance to an enemy robot
 /// this is useful to check if a robot stands free
-double GameAnalyzer::shortestDistToEnemyRobot(RobotPtr robot, bool ourTeam, WorldData simulatedWorld) {
-    auto enemyRobots = ourTeam ? simulatedWorld.them : simulatedWorld.us;
-    Vector2 robotPos = robot->pos;
+double GameAnalyzer::shortestDistToEnemyRobot(v::RobotView robot, bool ourTeam, v::WorldDataView world) {
+    auto enemyRobots = ourTeam ? world.getThem() : world.getThem();
+    Vector2 robotPos = robot->getPos();
     double shortestDist = INT_MAX;
     for (auto opponent : enemyRobots) {
-        shortestDist = std::min(robotPos.dist(opponent->pos), shortestDist);
+        shortestDist = std::min(robotPos.dist(opponent->getPos()), shortestDist);
     }
     return shortestDist;
 }
 
-/// check if a robot is closing in to our goal.
-bool GameAnalyzer::isClosingInToGoal(const Field &field, RobotPtr robot, bool ourTeam) {
-    double distanceToGoal = FieldComputations::getDistanceToGoal(field, ourTeam, robot->pos);
-
-    WorldData futureWorld = world::world->getFutureWorld(0.2);
-    auto enemyRobots = ourTeam ? futureWorld.them : futureWorld.us;
-
-    // find the robot in the future and look if it is closer than before
-    for (auto futureRobot : enemyRobots) {
-        if (futureRobot->id == robot->id && FieldComputations::getDistanceToGoal(field, ourTeam, futureRobot->pos) < distanceToGoal) {
-            return true;
-        }
-    }
-    return false;
-}
-
-std::vector<std::pair<GameAnalyzer::RobotPtr, RobotDanger>> GameAnalyzer::getRobotsSortedOnDanger(const Field &field, bool ourTeam) {
+std::vector<std::pair<v::RobotView, RobotDanger>> GameAnalyzer::getRobotsSortedOnDanger(const Field &field, bool ourTeam, v::WorldDataView world) {
     auto robots = ourTeam ? world::world->getUs() : world::world->getThem();
-    std::vector<std::pair<RobotPtr, RobotDanger>> robotDangers;
+    std::vector<std::pair<v::RobotView, RobotDanger>> robotDangers;
 
     for (auto robot : robots) {
         robotDangers.emplace_back(robot, evaluateRobotDangerScore(field, robot, ourTeam));
     }
 
     std::sort(robotDangers.begin(), robotDangers.end(),
-              [&field](std::pair<RobotPtr, RobotDanger> a, std::pair<RobotPtr, RobotDanger> b) { return a.second.getTotalDanger(field) > b.second.getTotalDanger(field); });
+              [&field](std::pair<v::RobotView, RobotDanger> a, std::pair<v::RobotView, RobotDanger> b) { return a.second.getTotalDanger(field) > b.second.getTotalDanger(field); });
 
     return robotDangers;
 }

--- a/src/analysis/GameAnalyzer.cpp
+++ b/src/analysis/GameAnalyzer.cpp
@@ -3,6 +3,8 @@
 #include <world/BallPossession.h>
 #include "analysis/RobotDanger.h"
 #include "world/FieldComputations.h"
+#include "world_new/views/RobotView.hpp"
+#include "world_new/views/WorldDataView.hpp"
 
 namespace rtt::ai::analysis {
 
@@ -62,15 +64,15 @@ std::vector<std::pair<int, double>> GameAnalyzer::getRobotsToPassTo(v::RobotView
     for (auto ourRobot : ourRobots) {
         bool canPassToThisRobot = true;
         for (auto theirRobot : enemyRobots) {
-            auto distToLine = control::ControlUtils::distanceToLineWithEnds(theirRobot->pos, Vector2(robot->getPos()), Vector2(ourRobot->getPos()));
+            auto distToLine = control::ControlUtils::distanceToLineWithEnds(theirRobot->getPos(), Vector2(robot->getPos()), Vector2(ourRobot->getPos()));
             if (distToLine < (Constants::ROBOT_RADIUS_MAX() + Constants::BALL_RADIUS())) {
                 canPassToThisRobot = false;
                 break;
             }
         }
         if (canPassToThisRobot) {
-            double distToRobot = (Vector2(ourRobot->pos) - Vector2(robot->pos)).length();
-            robotsToPassTo.emplace_back(std::make_pair(ourRobot->id, distToRobot));
+            double distToRobot = (Vector2(ourRobot->getPos()) - Vector2(robot->getPos())).length();
+            robotsToPassTo.emplace_back(std::make_pair(ourRobot->getId(), distToRobot));
         }
     }
     return robotsToPassTo;
@@ -89,11 +91,11 @@ double GameAnalyzer::shortestDistToEnemyRobot(v::RobotView robot, bool ourTeam, 
 }
 
 std::vector<std::pair<v::RobotView, RobotDanger>> GameAnalyzer::getRobotsSortedOnDanger(const Field &field, bool ourTeam, v::WorldDataView world) {
-    auto robots = ourTeam ? world::world->getUs() : world::world->getThem();
+    auto robots = ourTeam ? world.getUs() : world.getThem();
     std::vector<std::pair<v::RobotView, RobotDanger>> robotDangers;
 
     for (auto robot : robots) {
-        robotDangers.emplace_back(robot, evaluateRobotDangerScore(field, robot, ourTeam));
+        robotDangers.emplace_back(robot, evaluateRobotDangerScore(field, robot, ourTeam, world));
     }
 
     std::sort(robotDangers.begin(), robotDangers.end(),

--- a/src/analysis/GameAnalyzer.cpp
+++ b/src/analysis/GameAnalyzer.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<AnalysisReport> GameAnalyzer::generateReportNow(const Field &fie
         return report;
     }
     std::cout << "NOT A WORLD YET" << std::endl;
-    start(30);
+    start(field, 30);
     return {};
 }
 
@@ -145,12 +145,12 @@ bool GameAnalyzer::isClosingInToGoal(const Field &field, RobotPtr robot, bool ou
     return false;
 }
 
-void GameAnalyzer::start(int iterationsPerSecond) {
+void GameAnalyzer::start(world::Field const & field, int iterationsPerSecond) {
     if (!running && world::world->weHaveRobots()) {
         std::cout << "GameAnalyzer: "
                   << "Starting at " << iterationsPerSecond << " iterations per second" << std::endl;
         auto delay = (unsigned)(1000.0 / iterationsPerSecond);
-        thread = std::thread(&GameAnalyzer::loop, this, delay);
+        thread = std::thread(&GameAnalyzer::loop, this, field, delay);
         running = true;
     }
 }
@@ -170,10 +170,9 @@ void GameAnalyzer::stop() {
     }
 }
 
-void GameAnalyzer::loop(unsigned delayMillis) {
+void GameAnalyzer::loop(world::Field const & field, unsigned delayMillis) {
     std::chrono::milliseconds delay(delayMillis);
     while (!stopping) {
-        const Field &field = io::io.getField();
         generateReportNow(field);
         std::this_thread::sleep_for(delay);
     }

--- a/src/coach/OffensiveCoach.cpp
+++ b/src/coach/OffensiveCoach.cpp
@@ -7,7 +7,8 @@
 #include <interface/api/Input.h>
 #include <interface/widgets/widget.h>
 #include <world/FieldComputations.h>
-#include <world/World.h>
+#include "world_new/views/WorldDataView.hpp"
+#include <include/roboteam_ai/world_new/World.hpp>
 
 namespace rtt::ai::coach {
 
@@ -60,7 +61,7 @@ std::vector<Vector2> OffensiveCoach::getZoneLocations(const Field &field) {
 }
 
 void OffensiveCoach::updateOffensivePositions(const Field &field) {
-    auto world = world::world->getWorld();
+    auto world = world_new::World::instance()->getWorld().value();
     std::vector<Vector2> zoneLocations = getZoneLocations(field);
 
     if (offensivePositions.size() != zoneLocations.size()) {
@@ -136,8 +137,10 @@ std::vector<Vector2> OffensiveCoach::getOffensivePositions(int numberOfRobots) {
 
 /// this function decides what point in the goal to aim at from a position on which the ball will be/where the robot is
 Vector2 OffensiveCoach::getShootAtGoalPoint(const Field &field, const Vector2 &fromPoint) {
+    auto worldOpt = world_new::World::instance()->getWorld();
+
     // get the longest line section op the visible part of the goal
-    std::vector<Line> openSegments = FieldComputations::getVisiblePartsOfGoal(field, false, fromPoint, world::world->getWorld());
+    std::vector<Line> openSegments = FieldComputations::getVisiblePartsOfGoal(field, false, fromPoint, worldOpt.value());
     if (openSegments.empty()) return field.getTheirGoalCenter();
     auto bestSegment = getLongestSegment(openSegments);
 
@@ -189,7 +192,7 @@ const Line &OffensiveCoach::getLongestSegment(const std::vector<Line> &openSegme
 OffensiveCoach::OffensivePosition OffensiveCoach::findBestOffensivePosition(const Field &field, const std::vector<Vector2> &positions,
                                                                             const OffensiveCoach::OffensivePosition &currentBestPosition, const Vector2 &zoneLocation) {
     // get world & field
-    auto world = world::world->getWorld();
+    auto world = world_new::World::instance()->getWorld().value();
 
     OffensivePosition bestPosition = currentBestPosition;
     bestPosition.score = offensiveScore.calculateOffensivePositionScore(zoneLocation, bestPosition.position, world, field);

--- a/src/coach/defence/DefenceDealer.cpp
+++ b/src/coach/defence/DefenceDealer.cpp
@@ -4,7 +4,6 @@
 
 #include "coach/defence/DefenceDealer.h"
 #include <include/roboteam_ai/world/Field.h>
-
 #include "interface/api/Input.h"
 
 namespace rtt::ai::coach {

--- a/src/coach/defence/DefencePositionCoach.cpp
+++ b/src/coach/defence/DefencePositionCoach.cpp
@@ -2,7 +2,6 @@
 #include "world_new/World.hpp"
 #include "coach/defence/DefencePositionCoach.h"
 #include "control/ControlUtils.h"
-#include "utilities/RobotDealer.h"
 #include "world/Field.h"
 #include "world/FieldComputations.h"
 
@@ -122,6 +121,7 @@ void DefencePositionCoach::removeBotFromWorld(int id, bool ourTeam) {
 }
 
 Vector2 DefencePositionCoach::getMostDangerousPos() {
+    if (!simulatedBall.has_value()) return {};
     if (simulatedBall.value()->getVelocity().length() > 0.5) {
         return simulatedBall.value()->getPos() + simulatedBall.value()->getVelocity() * 0.3;
     }
@@ -129,6 +129,8 @@ Vector2 DefencePositionCoach::getMostDangerousPos() {
 }
 
 std::vector<std::pair<PossiblePass, double>> DefencePositionCoach::createPassesAndDanger(const Field &field) {
+    if (!simulatedBall.has_value()) return {};
+
     std::vector<std::pair<PossiblePass, double>> passWithScore;
     // check the passes from the robot towards every other bot and calculate their danger
     for (const auto &theirBot : simulatedRobotsThem) {

--- a/src/coach/defence/DefencePositionCoach.cpp
+++ b/src/coach/defence/DefencePositionCoach.cpp
@@ -12,7 +12,7 @@ using util = control::ControlUtils;
 
 DefencePositionCoach g_defensivePositionCoach;
 
-const world_new::view::RobotView DefenderBot::toRobot() {
+world_new::view::RobotView DefenderBot::toRobot() {
     proto::WorldRobot fakeRobot;
     fakeRobot.set_id(-1);
     fakeRobot.mutable_pos()->set_x(targetPos.x);
@@ -202,9 +202,7 @@ std::shared_ptr<Vector2> DefencePositionCoach::blockOnDefenseAreaLine(const Fiel
     return nullptr;
 }
 std::vector<Line> DefencePositionCoach::simulatedVisibleGoalParts(const Field &field, const PossiblePass &pass) const {// create a vector with all robots
-    std::vector<world_new::view::RobotView> allSimulatedRobots = simulatedRobotsUs;
-    allSimulatedRobots.insert(allSimulatedRobots.end(), simulatedRobotsThem.begin(), simulatedRobotsThem.end());
-    auto visibleParts = FieldComputations::getVisiblePartsOfGoalByObstacles(field, true, pass.endPos, allSimulatedRobots);
+    auto visibleParts = FieldComputations::getVisiblePartsOfGoalByObstacles(field, true, pass.endPos, simulatedRobotsUs);
     return visibleParts;
 }
 /// checks for a given pass in a simulatedWorld if we can block it's receiver shot to goal and returns a line on which to stand if this is the case
@@ -307,9 +305,7 @@ std::shared_ptr<Vector2> DefencePositionCoach::pickNewPosition(const Field &fiel
 }
 
 void DefencePositionCoach::setupSimulatedWorld(const Field &field) {
-    auto us = world_new::World::instance()->getWorld()->getUs();
     auto them = world_new::World::instance()->getWorld()->getThem();
-
     simulatedBall = world_new::World::instance()->getWorld()->getBall();
     simulatedRobotsUs = {};
     simulatedRobotsThem = getTheirAttackers(field, them);

--- a/src/coach/defence/DefencePositionCoach.cpp
+++ b/src/coach/defence/DefencePositionCoach.cpp
@@ -42,7 +42,9 @@ Vector2 DefencePositionCoach::getPosOnLine(const Line &line, double aggressionFa
     return line.end + (line.start - line.end) * aggressionFactor;
 }
 // get the direction facing towards the end of the Line
-double DefencePositionCoach::getOrientation(const Line &line) { return (line.start - line.end).angle(); }
+double DefencePositionCoach::getOrientation(const Line &line) {
+    return (line.start - line.end).angle();
+}
 
 // computes a line segment on which the entirety of openGoalSegment is blocked as seen from point with robots with radius collissionRadius
 std::shared_ptr<Line> DefencePositionCoach::getBlockLineSegment(const Field &field, const Line &openGoalSegment, const Vector2 &point, double collisionRadius, double margin) {
@@ -109,7 +111,6 @@ Line DefencePositionCoach::shortenLineForDefenseArea(const Field &field, const V
 }
 
 void DefencePositionCoach::removeBotFromWorld(int id, bool ourTeam) {
-
     if (ourTeam) {
         simulatedRobotsUs.erase(std::remove_if(simulatedRobotsUs.begin(),
                                                simulatedRobotsUs.end(),
@@ -235,6 +236,7 @@ std::shared_ptr<Line> DefencePositionCoach::blockBallLine(const Field &field) {
     if (FieldComputations::pointIsInField(field, mostDangerousPos, -0.1)) {
         return getBlockLineSegment(field, FieldComputations::getGoalSides(field, true), mostDangerousPos);
     }
+    return nullptr;
 }
 
 DefenderBot DefencePositionCoach::createBlockBall(const Field &field, const Line &blockLine) {

--- a/src/coach/defence/DefencePositionCoach.cpp
+++ b/src/coach/defence/DefencePositionCoach.cpp
@@ -1,9 +1,5 @@
-
-//
-// Created by rolf on 18-2-19.
-//
-
-#include <include/roboteam_ai/world_new/views/WorldDataView.hpp>
+#include "world_new/views/WorldDataView.hpp"
+#include "world_new/World.hpp"
 #include "coach/defence/DefencePositionCoach.h"
 #include "control/ControlUtils.h"
 #include "utilities/RobotDealer.h"
@@ -17,21 +13,25 @@ using util = control::ControlUtils;
 
 DefencePositionCoach g_defensivePositionCoach;
 
-bool DefenderBot::validPosition(world_new::view::WorldDataView world) {
-    for (const auto &bot : world.getUs()) {
-        if ((bot->pos - targetPos).length() < 2 * Constants::ROBOT_RADIUS()) {
+bool DefenderBot::validPosition(std::vector<world_new::view::RobotView> us) {
+    for (const auto &bot : us) {
+        if ((bot->getPos() - targetPos).length() < 2 * Constants::ROBOT_RADIUS()) {
             return false;
         }
     }
     return true;
 }
 
-const world::Robot::RobotPtr DefenderBot::toRobot() {
-    world::Robot::RobotPtr robot = std::make_shared<world::Robot>(world::Robot());
-    robot->id = -1;
-    robot->pos = targetPos;
-    robot->angle = orientation;
-    return robot;
+const world_new::view::RobotView DefenderBot::toRobot() {
+    proto::WorldRobot fakeRobot;
+    fakeRobot.set_id(-1);
+    fakeRobot.mutable_pos()->set_x(targetPos.x);
+    fakeRobot.mutable_pos()->set_y(targetPos.y);
+    fakeRobot.set_angle(orientation);
+    std::unordered_map<uint8_t, proto::RobotFeedback> emptyFeedback;
+    auto  robot = new world_new::robot::Robot(emptyFeedback, fakeRobot);
+    world_new::view::RobotView robotView(robot);
+    return robotView;
 }
 // pick position on the line depending on how aggressive we want to play. aggression factor 1 is very in your face, whilst 0 is as close as possible to the goal
 Vector2 DefencePositionCoach::getPosOnLine(const Line &line, double aggressionFactor) {
@@ -108,56 +108,73 @@ Line DefencePositionCoach::shortenLineForDefenseArea(const Field &field, const V
     }
     return line;
 }
-world_new::view::WorldDataView DefencePositionCoach::removeBotFromWorld(world_new::view::WorldDataView world, int id, bool ourTeam) {
-    auto robots = ourTeam ? world.getUs() : world.getThem();
-    robots.erase(std::remove_if(robots.begin(), robots.end(), [id](world::Robot::RobotPtr robot) { return robot->id == id; }));
-    ourTeam ? world.us = robots : world.getThem() = robots;
-    return world;
+
+void DefencePositionCoach::removeBotFromWorld(int id, bool ourTeam) {
+
+    if (ourTeam) {
+        simulatedRobotsUs.erase(std::remove_if(simulatedRobotsUs.begin(),
+                                               simulatedRobotsUs.end(),
+                                               [id](auto robot) { return robot->getId() ==id; }));
+    } else {
+        simulatedRobotsThem.erase(std::remove_if(simulatedRobotsThem.begin(), simulatedRobotsThem.end(), [id](auto robot) { return robot->getId() == id; }));
+    };
+
 }
-Vector2 DefencePositionCoach::getMostDangerousPos(world_new::view::WorldDataView world) {
-    auto ball = world.getBall().value();
-    if (ball->getVelocity().length() > 0.5) {
-        return ball->getPos() + ball->getVelocity() * 0.3;
+
+Vector2 DefencePositionCoach::getMostDangerousPos() {
+    if (simulatedBall->getVelocity().length() > 0.5) {
+        return simulatedBall->getPos() + simulatedBall->getVelocity() * 0.3;
     }
-    return ball->getPos();
+    return simulatedBall->getPos();
 }
-std::vector<std::pair<PossiblePass, double>> DefencePositionCoach::createPassesAndDanger(const Field &field, const world::WorldData &world) {
+
+std::vector<std::pair<PossiblePass, double>> DefencePositionCoach::createPassesAndDanger(const Field &field) {
     std::vector<std::pair<PossiblePass, double>> passWithScore;
     // check the passes from the robot towards every other bot and calculate their danger
-    for (const auto &theirBot : world.them) {
+    for (const auto &theirBot : simulatedRobotsThem) {
         // TODO: perhaps ignore robots we have already covered here. The score should be gutted regardless.
-        PossiblePass pass(*theirBot, world.ball->getPos());
-        double danger = pass.score(field, world);  // check how dangerous the pass is in our simulated world
+        PossiblePass pass(theirBot, simulatedBall->getPos());
+        double danger = pass.score(field, simulatedRobotsUs, simulatedRobotsThem);  // check how dangerous the pass is in our simulated world
         std::pair<PossiblePass, double> passPair = std::make_pair(pass, danger);
         passWithScore.push_back(passPair);
     }
     return passWithScore;
 }
+
+
 std::vector<PossiblePass> DefencePositionCoach::sortPassesByDanger(std::vector<std::pair<PossiblePass, double>> &passWithScore) {
     // order passes from most dangerous to least
-    std::sort(passWithScore.begin(), passWithScore.end(), [](std::pair<PossiblePass, double> &left, std::pair<PossiblePass, double> &right) { return left.second > right.second; });
+    std::sort(passWithScore.begin(), passWithScore.end(), [](std::pair<PossiblePass, double> &left, std::pair<PossiblePass, double> &right) {
+        return left.second > right.second;
+    });
     std::vector<PossiblePass> passes;
     for (const auto &passScore : passWithScore) {
         passes.push_back(passScore.first);
     }
     return passes;
 }
-std::vector<PossiblePass> DefencePositionCoach::createPassesSortedByDanger(const Field &field, const rtt::ai::world::WorldData &world) {
-    auto passes = createPassesAndDanger(field, world);
+
+
+std::vector<PossiblePass> DefencePositionCoach::createPassesSortedByDanger(const Field &field) {
+    auto passes = createPassesAndDanger(field);
     return sortPassesByDanger(passes);
 }
+
+
 DefenderBot DefencePositionCoach::createBlockToGoal(const Field &field, const PossiblePass &pass, double aggressionFactor, const Line &blockLine) {
     DefenderBot bot;
     bot.type = botType::BLOCKTOGOAL;
-    bot.blockFromID = pass.toBot.id;
+    bot.blockFromID = pass.toBot->getId();
     bot.targetPos = getPosOnLine(blockLine, aggressionFactor);
     bot.orientation = getOrientation(blockLine);
     return bot;
 }
+
+
 DefenderBot DefencePositionCoach::createBlockToGoal(const Field &field, const PossiblePass &pass, const Vector2 &position, const Line &blockLine) {
     DefenderBot bot;
     bot.type = botType::BLOCKTOGOAL;
-    bot.blockFromID = pass.toBot.id;
+    bot.blockFromID = pass.toBot->getId();
     bot.targetPos = position;
     bot.orientation = getOrientation(blockLine);
     return bot;
@@ -165,7 +182,7 @@ DefenderBot DefencePositionCoach::createBlockToGoal(const Field &field, const Po
 DefenderBot DefencePositionCoach::createBlockOnLine(const Field &field, const PossiblePass &pass, const Vector2 &blockPos) {
     DefenderBot bot;
     bot.type = botType::BLOCKONLINE;
-    bot.blockFromID = pass.toBot.id;
+    bot.blockFromID = pass.toBot->getId();
     bot.targetPos = blockPos;
     // draw a line for easy orientation computation
     Line line = Line(pass.endPos, blockPos);
@@ -175,13 +192,15 @@ DefenderBot DefencePositionCoach::createBlockOnLine(const Field &field, const Po
 DefenderBot DefencePositionCoach::createBlockPass(const Field &field, PossiblePass &pass, const Vector2 &blockPoint) {
     DefenderBot bot;
     bot.type = botType::BLOCKPASS;
-    bot.blockFromID = pass.toBot.id;
+    bot.blockFromID = pass.toBot->getId();
     bot.targetPos = blockPoint;
     bot.orientation = pass.faceLine();
     return bot;
 }
-std::shared_ptr<Vector2> DefencePositionCoach::blockOnDefenseAreaLine(const Field &field, const PossiblePass &pass, world_new::view::WorldDataView world) {
-    auto visibleParts = FieldComputations::getVisiblePartsOfGoal(field, true, pass.endPos, world);
+
+std::shared_ptr<Vector2> DefencePositionCoach::blockOnDefenseAreaLine(const Field &field, const PossiblePass &pass) {
+    std::vector<Line> visibleParts = simulatedVisibleGoalParts(field, pass);
+
     // get the largest segment
     std::sort(visibleParts.begin(), visibleParts.end(), [](const Line &a, const Line &b) { return abs(a.end.y - a.start.y) > abs(b.end.y - b.start.y); });
     if (!visibleParts.empty()) {
@@ -189,10 +208,16 @@ std::shared_ptr<Vector2> DefencePositionCoach::blockOnDefenseAreaLine(const Fiel
     }
     return nullptr;
 }
+std::vector<Line> DefencePositionCoach::simulatedVisibleGoalParts(const Field &field, const PossiblePass &pass) const {// create a vector with all robots
+    std::vector<world_new::view::RobotView> allSimulatedRobots = simulatedRobotsUs;
+    allSimulatedRobots.insert(allSimulatedRobots.end(), simulatedRobotsThem.begin(), simulatedRobotsThem.end());
+    auto visibleParts = FieldComputations::getVisiblePartsOfGoalByObstacles(field, true, pass.endPos, allSimulatedRobots);
+    return visibleParts;
+}
 /// checks for a given pass in a simulatedWorld if we can block it's receiver shot to goal and returns a line on which to stand if this is the case
-std::shared_ptr<Line> DefencePositionCoach::blockToGoalLine(const Field &field, const PossiblePass &pass, world_new::view::WorldDataView world) {
-    // get the blockLine segment from the ending position of the pass
-    auto visibleParts = FieldComputations::getVisiblePartsOfGoal(field, true, pass.endPos, world);
+std::shared_ptr<Line> DefencePositionCoach::blockToGoalLine(const Field &field, const PossiblePass &pass) {
+    std::vector<Line> visibleParts = simulatedVisibleGoalParts(field, pass);
+
     // get the largest segment (sort by size)
     std::sort(visibleParts.begin(), visibleParts.end(), [](const Line &a, const Line &b) { return abs(a.end.y - a.start.y) > abs(b.end.y - b.start.y); });
     if (!visibleParts.empty()) {
@@ -203,14 +228,11 @@ std::shared_ptr<Line> DefencePositionCoach::blockToGoalLine(const Field &field, 
 }
 
 /// searches the most dangerous position and then gets the segment which blocks that (if it exists/is possible)
-std::shared_ptr<Line> DefencePositionCoach::blockBallLine(const Field &field, world_new::view::WorldDataView world) {
-    if (world.getBall().has_value()) {
-        Vector2 mostDangerousPos = getMostDangerousPos(world);
-        if (FieldComputations::pointIsInField(field, mostDangerousPos, -0.1)) {
-            return getBlockLineSegment(field, FieldComputations::getGoalSides(field, true), mostDangerousPos);
-        }
+std::shared_ptr<Line> DefencePositionCoach::blockBallLine(const Field &field) {
+    Vector2 mostDangerousPos = getMostDangerousPos();
+    if (FieldComputations::pointIsInField(field, mostDangerousPos, -0.1)) {
+        return getBlockLineSegment(field, FieldComputations::getGoalSides(field, true), mostDangerousPos);
     }
-    return nullptr;
 }
 
 DefenderBot DefencePositionCoach::createBlockBall(const Field &field, const Line &blockLine) {
@@ -237,34 +259,34 @@ Vector2 DefencePositionCoach::findPositionForBlockBall(const Field &field, const
 }
 double DefencePositionCoach::maxX(const Field &field) { return field.getFieldLength() / 10.0 * -1.0; }
 
-world::WorldData DefencePositionCoach::getTheirAttackers(const Field &field, world_new::view::WorldDataView world) {
-    std::vector<world::Robot::RobotPtr> theirAttackers;
-    for (auto &robot : world.them) {
+std::vector<world_new::view::RobotView> DefencePositionCoach::getTheirAttackers(const Field &field, std::vector<world_new::view::RobotView> them) {
+    std::vector<world_new::view::RobotView> theirAttackers;
+    for (auto &robot : them) {
         // we remove any attackers that are outside of the field or in our defence area
-        if (!FieldComputations::pointIsInDefenceArea(field, robot->pos, true, 0.04) && FieldComputations::pointIsInField(field, robot->pos, -0.1)) {
+        if (!FieldComputations::pointIsInDefenceArea(field, robot->getPos(), true, 0.04) && FieldComputations::pointIsInField(field, robot->getPos(), -0.1)) {
             theirAttackers.push_back(robot);
         }
     }
-    world::WorldData newWorld = world;
-    newWorld.them = theirAttackers;
-    return newWorld;
+    return theirAttackers;
 }
-bool DefencePositionCoach::validNewPosition(const Field &field, const Vector2 &position, world_new::view::WorldDataView world) {
+
+bool DefencePositionCoach::validNewPosition(const Field &field, const Vector2 &position) {
     if (position.x > maxX(field)) {
         return false;
     }
     double collisionRadius = calculationCollisionRad;  // a little smaller than 2 robot radii so that we can make solid walls still
-    for (const auto &robot : world.getUs()) {
-        if ((robot->pos - position).length() < collisionRadius) {
+    for (const auto &robot : simulatedRobotsUs) {
+        if ((robot->getPos() - position).length() < collisionRadius) {
             return false;
         }
     }
     return true;
 }
-std::shared_ptr<double> DefencePositionCoach::pickNewPosition(const Field &field, const Line &line, world_new::view::WorldDataView world) {
+
+std::shared_ptr<double> DefencePositionCoach::pickNewPosition(const Field &field, const Line &line) {
     // search a position on the line on which we can position.
     for (int aggresionFactor = 0; aggresionFactor <= searchPoints; ++aggresionFactor) {
-        if (validNewPosition(field, getPosOnLine(line, aggresionFactor / searchPoints), world)) {
+        if (validNewPosition(field, getPosOnLine(line, aggresionFactor / searchPoints))) {
             std::shared_ptr<double> point = std::make_shared<double>(aggresionFactor);
             return point;
         }
@@ -273,33 +295,36 @@ std::shared_ptr<double> DefencePositionCoach::pickNewPosition(const Field &field
     return nullptr;
 }
 
-std::shared_ptr<Vector2> DefencePositionCoach::pickNewPosition(const Field &field, PossiblePass pass, world_new::view::WorldDataView world) {
+std::shared_ptr<Vector2> DefencePositionCoach::pickNewPosition(const Field &field, PossiblePass pass) {
     std::shared_ptr<Vector2> point = nullptr;
     double segments = 30.0;
     // we pick new points on which we can defend preferably as close as possible to the middle of the pass.
     for (int j = 0; j <= segments * 0.5; ++j) {
         Vector2 forwardPosition = pass.posOnLine(0.5 + j / segments);
-        if (validNewPosition(field, forwardPosition, world) && !FieldComputations::pointIsInDefenceArea(field, forwardPosition, true, defenceLineMargin)) {
+        if (validNewPosition(field, forwardPosition) && !FieldComputations::pointIsInDefenceArea(field, forwardPosition, true, defenceLineMargin)) {
             return std::make_shared<Vector2>(forwardPosition);
         }
         Vector2 backwardPosition = pass.posOnLine(0.5 - j / segments);
-        if (validNewPosition(field, backwardPosition, world) && !FieldComputations::pointIsInDefenceArea(field, forwardPosition, true, defenceLineMargin)) {
+        if (validNewPosition(field, backwardPosition) && !FieldComputations::pointIsInDefenceArea(field, forwardPosition, true, defenceLineMargin)) {
             return std::make_shared<Vector2>(backwardPosition);
         }
     }
     return nullptr;
 }
 
-world_new::view::WorldDataView DefencePositionCoach::setupSimulatedWorld(const Field &field) {
-    auto sWorld = world::
-    sWorld.us.clear();
-    sWorld = getTheirAttackers(field, sWorld);  // we select only the relevant robots
-    return sWorld;
+void DefencePositionCoach::setupSimulatedWorld(const Field &field) {
+    auto us = world_new::World::instance()->getWorld()->getUs();
+    auto them = world_new::World::instance()->getWorld()->getThem();
+
+    simulatedBall = world_new::World::instance()->getWorld()->getBall().value();
+    simulatedRobotsUs = {};
+    simulatedRobotsThem = getTheirAttackers(field, them);
 }
+
 std::shared_ptr<DefenderBot> DefencePositionCoach::blockMostDangerousPos(const Field &field) {
     // block the most dangerous position to the goal completely if possible.
     // check if it is possible to find a position that is legal
-    auto crucialBlock = blockBallLine(field, simulatedWorld);
+    auto crucialBlock = blockBallLine(field);
     if (crucialBlock) {
         DefenderBot crucialDefender = createBlockBall(field, *crucialBlock);  // if so, create a defender
         return std::make_shared<DefenderBot>(crucialDefender);
@@ -310,10 +335,10 @@ std::shared_ptr<DefenderBot> DefencePositionCoach::blockMostDangerousPos(const F
 std::shared_ptr<DefenderBot> DefencePositionCoach::blockPass(const Field &field, PossiblePass pass) {
     // this function tries multiple ways to block a pass. Returns true if it succeeded, false if it fails.
     // first try blocking the goal vision of the robot being passed to
-    auto blockLine = blockToGoalLine(field, pass, simulatedWorld);
+    auto blockLine = blockToGoalLine(field, pass);
     if (blockLine) {
         // try to find a position on the line that is valid
-        auto aggressionFactor = pickNewPosition(field, *blockLine, simulatedWorld);
+        auto aggressionFactor = pickNewPosition(field, *blockLine);
         if (aggressionFactor) {
             DefenderBot defender = createBlockToGoal(field, pass, *aggressionFactor, *blockLine);
             return std::make_shared<DefenderBot>(defender);
@@ -325,21 +350,21 @@ std::shared_ptr<DefenderBot> DefencePositionCoach::blockPass(const Field &field,
         Vector2 bottomLine(maxX(field) - 0.0001, -fieldWidth * 0.5);
         Vector2 topLine(maxX(field) - 0.0001, fieldWidth * 0.5);
         Vector2 intersectPos = control::ControlUtils::twoLineIntersection(blockLine->start, blockLine->end, bottomLine, topLine);
-        if (validNewPosition(field, intersectPos, simulatedWorld)) {
+        if (validNewPosition(field, intersectPos)) {
             DefenderBot defender = createBlockToGoal(field, pass, intersectPos, *blockLine);
             return std::make_shared<DefenderBot>(defender);
         }
     }
     // then try blocking on the defense line (closer to the line) if that is possible
-    auto blockPos = blockOnDefenseAreaLine(field, pass, simulatedWorld);
+    auto blockPos = blockOnDefenseAreaLine(field, pass);
     if (blockPos) {
-        if (validNewPosition(field, *blockPos, simulatedWorld)) {
+        if (validNewPosition(field, *blockPos)) {
             DefenderBot defender = createBlockOnLine(field, pass, *blockPos);
             return std::make_shared<DefenderBot>(defender);
         }
     }
     // then try to intercept the pass, we try to find a spot along the pass where we can stand
-    auto passBlock = pickNewPosition(field, pass, simulatedWorld);
+    auto passBlock = pickNewPosition(field, pass);
     if (passBlock) {
         DefenderBot defender = createBlockPass(field, pass, *passBlock);
         return std::make_shared<DefenderBot>(defender);
@@ -348,7 +373,7 @@ std::shared_ptr<DefenderBot> DefencePositionCoach::blockPass(const Field &field,
 }
 // if we add a defender we want to both add it to simulation and our stored defender array for return
 void DefencePositionCoach::addDefender(DefenderBot defender) {
-    simulatedWorld.us.push_back(defender.toRobot());
+    simulatedRobotsUs.push_back(defender.toRobot());
     defenders.push_back(defender);
 }
 
@@ -359,7 +384,7 @@ std::vector<DefenderBot> DefencePositionCoach::decidePositions(const Field &fiel
     if (defenderAmount <= 0) {
         return defenders;
     }  // we don't actually need to calculate now.
-    simulatedWorld = setupSimulatedWorld(field);
+    setupSimulatedWorld(field);
     // handle all the locked robots
     std::tuple<bool, int, std::vector<int>> temp = decideLockedPositions(field, lockedDefenders, freeRobots);
 
@@ -374,19 +399,19 @@ std::vector<DefenderBot> DefencePositionCoach::decidePositions(const Field &fiel
         }
     }
     // for the remainder we look at the possiblePasses and block the most dangerous bots
-    std::vector<PossiblePass> passes = createPassesSortedByDanger(field, simulatedWorld);
+    std::vector<PossiblePass> passes = createPassesSortedByDanger(field);
     while ((defenders.size()) != defenderAmount && !passes.empty()) {
         auto foundNewDefender = blockPass(field, passes[0]);  // we try to cover the most dangerous pass in multiple ways
         // if we find a defender we need to recalculate the danger of our passes to reflect the new robot.
         if (!foundNewDefender) {
             // if we cannot find a way to cover it, we remove the attacker from the simulated world (otherwise we get 'stuck')
-            simulatedWorld = removeBotFromWorld(simulatedWorld, passes[0].toBot.id, false);
+            removeBotFromWorld(passes[0].toBot->getId(), false);
             // this should pretty much never happen.
-            std::cerr << "Pass to robot" << passes[0].toBot.id << " removed in defensiveCoach!" << std::endl;
+            std::cerr << "Pass to robot" << passes[0].toBot->getId() << " removed in defensiveCoach!" << std::endl;
         } else {
             addDefender(*foundNewDefender);
         }
-        passes = createPassesSortedByDanger(field, simulatedWorld);  // recalculate the danger after the new position
+        passes = createPassesSortedByDanger(field);  // recalculate the danger after the new position
     }
     // TODO: find a procedure if we cannot really cover all of the robots off, e.g. default positions or such
     assignIDs(lockedCount, freeRobots, oldDefenders);  // divide the ID's of the last robots over the remaining available ID's.
@@ -397,12 +422,12 @@ std::tuple<bool, int, std::vector<int>> DefencePositionCoach::decideLockedPositi
                                                                                     std::vector<int> freeRobots) {
     bool blockedMostDangerousPos = false;
     int lockedCount = 0;
-    std::vector<PossiblePass> passes = createPassesSortedByDanger(field, simulatedWorld);
+    std::vector<PossiblePass> passes = createPassesSortedByDanger(field);
     for (const auto &lockedDefender : lockedDefenders) {
         bool replacedDefender = false;
         if (lockedDefender.type != BLOCKBALL) {
             for (const auto &pass : passes) {
-                if (pass.toBot.id == lockedDefender.blockFromID) {
+                if (pass.toBot->getId() == lockedDefender.blockFromID) {
                     auto newDefender = blockPass(field, pass);
                     if (newDefender) {
                         lockedCount++;
@@ -463,4 +488,5 @@ void DefencePositionCoach::assignIDs(int lockedCount, std::vector<int> freeRobot
         }
     }
 }
+
 }  // namespace rtt::ai::coach

--- a/src/coach/defence/DefencePositionCoach.cpp
+++ b/src/coach/defence/DefencePositionCoach.cpp
@@ -122,10 +122,10 @@ void DefencePositionCoach::removeBotFromWorld(int id, bool ourTeam) {
 }
 
 Vector2 DefencePositionCoach::getMostDangerousPos() {
-    if (simulatedBall->getVelocity().length() > 0.5) {
-        return simulatedBall->getPos() + simulatedBall->getVelocity() * 0.3;
+    if (simulatedBall.value()->getVelocity().length() > 0.5) {
+        return simulatedBall.value()->getPos() + simulatedBall.value()->getVelocity() * 0.3;
     }
-    return simulatedBall->getPos();
+    return simulatedBall.value()->getPos();
 }
 
 std::vector<std::pair<PossiblePass, double>> DefencePositionCoach::createPassesAndDanger(const Field &field) {
@@ -133,7 +133,7 @@ std::vector<std::pair<PossiblePass, double>> DefencePositionCoach::createPassesA
     // check the passes from the robot towards every other bot and calculate their danger
     for (const auto &theirBot : simulatedRobotsThem) {
         // TODO: perhaps ignore robots we have already covered here. The score should be gutted regardless.
-        PossiblePass pass(theirBot, simulatedBall->getPos());
+        PossiblePass pass(theirBot, simulatedBall.value()->getPos());
         double danger = pass.score(field, simulatedRobotsUs, simulatedRobotsThem);  // check how dangerous the pass is in our simulated world
         std::pair<PossiblePass, double> passPair = std::make_pair(pass, danger);
         passWithScore.push_back(passPair);
@@ -316,7 +316,7 @@ void DefencePositionCoach::setupSimulatedWorld(const Field &field) {
     auto us = world_new::World::instance()->getWorld()->getUs();
     auto them = world_new::World::instance()->getWorld()->getThem();
 
-    simulatedBall = world_new::World::instance()->getWorld()->getBall().value();
+    simulatedBall = world_new::World::instance()->getWorld()->getBall();
     simulatedRobotsUs = {};
     simulatedRobotsThem = getTheirAttackers(field, them);
 }

--- a/src/coach/defence/DefencePositionCoach.cpp
+++ b/src/coach/defence/DefencePositionCoach.cpp
@@ -12,15 +12,6 @@ using util = control::ControlUtils;
 
 DefencePositionCoach g_defensivePositionCoach;
 
-bool DefenderBot::validPosition(std::vector<world_new::view::RobotView> us) {
-    for (const auto &bot : us) {
-        if ((bot->getPos() - targetPos).length() < 2 * Constants::ROBOT_RADIUS()) {
-            return false;
-        }
-    }
-    return true;
-}
-
 const world_new::view::RobotView DefenderBot::toRobot() {
     proto::WorldRobot fakeRobot;
     fakeRobot.set_id(-1);
@@ -117,8 +108,7 @@ void DefencePositionCoach::removeBotFromWorld(int id, bool ourTeam) {
                                                [id](auto robot) { return robot->getId() ==id; }));
     } else {
         simulatedRobotsThem.erase(std::remove_if(simulatedRobotsThem.begin(), simulatedRobotsThem.end(), [id](auto robot) { return robot->getId() == id; }));
-    };
-
+    }
 }
 
 Vector2 DefencePositionCoach::getMostDangerousPos() {

--- a/src/coach/defence/PossiblePass.cpp
+++ b/src/coach/defence/PossiblePass.cpp
@@ -1,11 +1,11 @@
 #include "coach/defence/PossiblePass.h"
 #include <control/ControlUtils.h>
+#include <utility>
 #include "world/FieldComputations.h"
-#include "world/WorldData.h"
 
 namespace rtt::ai::coach {
 
-const double PossiblePass::distance() {
+double PossiblePass::distance() {
     return (endPos - startPos).length();
 }
 
@@ -38,16 +38,14 @@ Vector2 PossiblePass::botReceivePos(const Vector2 &_startPos, const Vector2 &bot
 }
 double PossiblePass::score(const Field &field, std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them) {
     double score = 1.0;
-    score *= scoreForGoalAngle(field, us, them);
-    score *= penaltyForBlocks(us, them);
+    score *= scoreForGoalAngle(field, us);
+    score *= penaltyForBlocks(us, std::move(them));
     score *= penaltyForDistance();
     return score;
 }
 
-double PossiblePass::scoreForGoalAngle(const Field &field, std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them) {
-    std::vector<world_new::view::RobotView> allSimulatedRobots = us;
-    allSimulatedRobots.insert(allSimulatedRobots.end(), them.begin(), them.end());
-    std::vector<Line> visibleParts = FieldComputations::getVisiblePartsOfGoalByObstacles(field, true, endPos, allSimulatedRobots);
+double PossiblePass::scoreForGoalAngle(const Field &field, std::vector<world_new::view::RobotView> us) {
+    std::vector<Line> visibleParts = FieldComputations::getVisiblePartsOfGoalByObstacles(field, true, endPos, us);
 
     // find the largest open angle in the world
     std::sort(visibleParts.begin(), visibleParts.end(), [](const Line &a, const Line &b) { return abs(a.end.y - a.start.y) > abs(b.end.y - b.start.y); });

--- a/src/coach/defence/PossiblePass.cpp
+++ b/src/coach/defence/PossiblePass.cpp
@@ -1,47 +1,55 @@
-//
-// Created by rolf on 5-4-19.
-//
-
 #include "coach/defence/PossiblePass.h"
 #include <control/ControlUtils.h>
 #include "world/FieldComputations.h"
 #include "world/WorldData.h"
 
 namespace rtt::ai::coach {
-const double PossiblePass::distance() { return (endPos - startPos).length(); }
+
+const double PossiblePass::distance() {
+    return (endPos - startPos).length();
+}
+
 bool PossiblePass::obstacleObstructsPath(const Vector2 &obstPos, double obstRadius) {
     return control::ControlUtils::distanceToLineWithEnds(obstPos, startPos, endPos) <= obstRadius;
 }
-int PossiblePass::amountOfBlockers(const world::WorldData &world) {
+
+int PossiblePass::amountOfBlockers(std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them) {
     int total = 0;
-    for (const auto &bot : world.them) {
-        if (obstacleObstructsPath(bot->pos)) {
+    for (const auto &bot : them) {
+        if (obstacleObstructsPath(bot->getPos())) {
             total++;
         }
     }
-    for (const auto &bot : world.us) {
-        if (obstacleObstructsPath(bot->pos)) {
+    for (const auto &bot : us) {
+        if (obstacleObstructsPath(bot->getPos())) {
             total++;
         }
     }
     return total;
 }
 
-PossiblePass::PossiblePass(world::Robot _toBot, const Vector2 &ballPos) : toBot(_toBot), startPos(ballPos) { endPos = botReceivePos(ballPos, _toBot.pos); }
+PossiblePass::PossiblePass(world_new::view::RobotView _toBot, const Vector2 &ballPos) : toBot(_toBot), startPos(ballPos) {
+    endPos = botReceivePos(ballPos, _toBot->getPos());
+}
+
 Vector2 PossiblePass::botReceivePos(const Vector2 &_startPos, const Vector2 &botPos) {
     Vector2 receivePos = botPos + (_startPos - botPos).stretchToLength(Constants::CENTRE_TO_FRONT() + Constants::BALL_RADIUS());
     return receivePos;
 }
-double PossiblePass::score(const Field &field, const world::WorldData &world) {
+double PossiblePass::score(const Field &field, std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them) {
     double score = 1.0;
-    score *= scoreForGoalAngle(field, world);
-    score *= penaltyForBlocks(world);
+    score *= scoreForGoalAngle(field, us, them);
+    score *= penaltyForBlocks(us, them);
     score *= penaltyForDistance();
     return score;
 }
-double PossiblePass::scoreForGoalAngle(const Field &field, const world::WorldData &world) {
+
+double PossiblePass::scoreForGoalAngle(const Field &field, std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them) {
+    std::vector<world_new::view::RobotView> allSimulatedRobots = us;
+    allSimulatedRobots.insert(allSimulatedRobots.end(), them.begin(), them.end());
+    std::vector<Line> visibleParts = FieldComputations::getVisiblePartsOfGoalByObstacles(field, true, endPos, allSimulatedRobots);
+
     // find the largest open angle in the world
-    std::vector<Line> visibleParts = FieldComputations::getVisiblePartsOfGoal(field, true, endPos, world);
     std::sort(visibleParts.begin(), visibleParts.end(), [](const Line &a, const Line &b) { return abs(a.end.y - a.start.y) > abs(b.end.y - b.start.y); });
     // set the largest open angle, we use a minimum of 0.05 of the goal angle
     double largestOpenGoalAngle;
@@ -55,10 +63,11 @@ double PossiblePass::scoreForGoalAngle(const Field &field, const world::WorldDat
 
     return largestOpenGoalAngle;
 }
+
 // Half the score for every robot that blocks the ball
-double PossiblePass::penaltyForBlocks(const world::WorldData &world) {
+double PossiblePass::penaltyForBlocks(std::vector<world_new::view::RobotView> us, std::vector<world_new::view::RobotView> them) {
     double obstacleFactor = 0.5;
-    return pow(obstacleFactor, amountOfBlockers(world));
+    return pow(obstacleFactor, amountOfBlockers(us, them));
 }
 double PossiblePass::penaltyForDistance() {
     // we use a ramp function has it's zero at goodUntilPassDist and is 1 and impossible Passdist as a penalty
@@ -69,6 +78,13 @@ double PossiblePass::penaltyForDistance() {
     }
     return 1.0;
 }
-Vector2 PossiblePass::posOnLine(double scale) { return startPos + (endPos - startPos) * scale; }
-double PossiblePass::faceLine() { return (startPos - endPos).angle(); }
+
+Vector2 PossiblePass::posOnLine(double scale) {
+    return startPos + (endPos - startPos) * scale;
+}
+
+double PossiblePass::faceLine() {
+    return (startPos - endPos).angle();
+}
+
 }  // namespace rtt::ai::coach

--- a/src/coach/heuristics/OffensiveScore.cpp
+++ b/src/coach/heuristics/OffensiveScore.cpp
@@ -12,7 +12,7 @@ namespace rtt::ai::coach {
 OffensiveScore g_offensiveScore;
 
 /// Calculates a total score based on all the sub-scores
-double OffensiveScore::calculateOffensivePositionScore(const Vector2 &zoneLocation, const Vector2 &position, const WorldData &world, const Field &field) {
+double OffensiveScore::calculateOffensivePositionScore(const Vector2 &zoneLocation, const Vector2 &position, world_new::view::WorldDataView world, const Field &field) {
     if (!positionIsValid(field, zoneLocation, position)) return 0.0;
     double closeToGoalScore = CoachHeuristics::calculateCloseToGoalScore(field, position);
     double passLineScore = CoachHeuristics::calculatePassLineScore(position, world);

--- a/src/coach/heuristics/PassScore.cpp
+++ b/src/coach/heuristics/PassScore.cpp
@@ -2,6 +2,7 @@
 // Created by robzelluf on 4/17/19.
 //
 
+#include <include/roboteam_ai/world_new/World.hpp>
 #include "coach/heuristics/PassScore.h"
 #include "roboteam_proto/GeometryFieldSize.pb.h"
 #include "world/FieldComputations.h"
@@ -10,7 +11,13 @@
 namespace rtt::ai::coach {
 
 double PassScore::calculatePassScore(const Field &field, const Vector2 &position) {
-    WorldData world = world::world->getWorld();
+    auto worldOpt = world_new::World::instance()->getWorld();
+    if (!worldOpt.has_value()) {
+        std::cout << "[PassScore.cpp: calculatePassScore] No world available!" << std::endl;
+        return 0;
+    }
+    auto world = worldOpt.value();
+
     double closeToGoalScore = CoachHeuristics::calculateCloseToGoalScore(field, position);
     double shotAtGoalScore = CoachHeuristics::calculateShotAtGoalScore(field, position, world);
     double passLineScore = CoachHeuristics::calculatePassLineScore(position, world);

--- a/src/coach/midfield/MidFieldCoach.cpp
+++ b/src/coach/midfield/MidFieldCoach.cpp
@@ -3,10 +3,8 @@
 //
 
 #include "coach/midfield/MidFieldCoach.h"
-#include <world/WorldData.h>
 #include <include/roboteam_ai/world_new/World.hpp>
 #include "world/Ball.h"
-#include "world/Robot.h"
 
 namespace rtt::ai::coach {
 

--- a/src/coach/midfield/MidFieldCoach.cpp
+++ b/src/coach/midfield/MidFieldCoach.cpp
@@ -4,6 +4,7 @@
 
 #include "coach/midfield/MidFieldCoach.h"
 #include <world/WorldData.h>
+#include <include/roboteam_ai/world_new/World.hpp>
 #include "world/Ball.h"
 #include "world/Robot.h"
 
@@ -213,7 +214,7 @@ MidFieldCoach::Target MidFieldCoach::getBall(RobotPtr &thisRobot, const RobotPtr
 }
 
 double MidFieldCoach::calculateStandingFreeScore(const Field &field, const Vector2 &position, const RobotPtr &thisRobot) {
-    WorldData world = world::world->getWorld();
+    auto world = world_new::World::instance()->getWorld().value();
 
     double passLineScore = CoachHeuristics::calculatePassLineScore(position, world);
     double distanceToUsScore = CoachHeuristics::calculateDistanceToClosestTeamMateScore(position, thisRobot->id);

--- a/src/conditions/HasClearShot.cpp
+++ b/src/conditions/HasClearShot.cpp
@@ -12,6 +12,7 @@
 #include <world/FieldComputations.h>
 #include <world/World.h>
 #include <world/WorldData.h>
+#include <include/roboteam_ai/world_new/World.hpp>
 #include "conditions/HasClearShot.h"
 
 namespace rtt::ai {
@@ -36,7 +37,8 @@ HasClearShot::Status HasClearShot::onUpdate() {
     }
 
     // return success if there is a clear line to their goal
-    bool hasClearShot = FieldComputations::getPercentageOfGoalVisibleFromPoint((*field), false, ball->getPos(), world->getWorld(), robot->id, true) > minViewAtGoal * 100;
+    auto world = world_new::World::instance()->getWorld().value();
+    bool hasClearShot = FieldComputations::getPercentageOfGoalVisibleFromPoint((*field), false, ball->getPos(), world, robot->id, true) > minViewAtGoal * 100;
 
     return hasClearShot ? Status::Success : Status::Failure;
 }

--- a/src/control/ball-handling/BallHandlePosControl.cpp
+++ b/src/control/ball-handling/BallHandlePosControl.cpp
@@ -25,14 +25,14 @@ BallHandlePosControl::BallHandlePosControl(bool canMoveInDefenseArea) {
     setAvoidBallDistance(MAX_BALL_DISTANCE * 0.92);
 }
 
-RobotCommand BallHandlePosControl::getRobotCommand(world::World *world, const Field *field, const RobotPtr &r, const Vector2 &targetP) {
+RobotCommand BallHandlePosControl::getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &r, const Vector2 &targetP) {
     this->world = world;
     this->field = field;
     Angle defaultAngle = lockedAngle;
     return BallHandlePosControl::getRobotCommand(world, field, r, targetP, defaultAngle);
 }
 
-RobotCommand BallHandlePosControl::getRobotCommand(world::World *world, const Field *field, const RobotPtr &r, const Vector2 &targetP, const Angle &targetA,
+RobotCommand BallHandlePosControl::getRobotCommand(world::World *world, const world::Field *field, const RobotPtr &r, const Vector2 &targetP, const Angle &targetA,
                                                    TravelStrategy travelStrategy) {
     this->world = world;
     this->field = field;

--- a/src/interface/widgets/RobotsWidget.cpp
+++ b/src/interface/widgets/RobotsWidget.cpp
@@ -28,7 +28,7 @@ RobotsWidget::RobotsWidget(QWidget *parent) : QWidget(parent) {
 }
 
 void RobotsWidget::updateContents(Visualizer *visualizer, rtt::world_new::view::WorldDataView world) {
-    auto const &field = world->getField().value();
+    auto const &field = world_new::World::instance()->getField().value();
     auto us =world->getUs();
 
     // reload the widgets completely if a robot is added or removed

--- a/src/interface/widgets/RobotsWidget.cpp
+++ b/src/interface/widgets/RobotsWidget.cpp
@@ -7,6 +7,7 @@
 #include <QScrollArea>
 #include <QtWidgets/QGroupBox>
 #include <QtWidgets/QLabel>
+#include <include/roboteam_ai/world_new/World.hpp>
 #include "analysis/GameAnalyzer.h"
 #include "interface/widgets/mainWindow.h"
 #include "roboteam_proto/WorldRobot.pb.h"
@@ -27,7 +28,7 @@ RobotsWidget::RobotsWidget(QWidget *parent) : QWidget(parent) {
 }
 
 void RobotsWidget::updateContents(Visualizer *visualizer) {
-    auto const &field = io::io.getField();
+    auto const &field = world_new::World::instance()->getField().value();
     auto us = rtt::ai::world::world->getUs();
 
     // reload the widgets completely if a robot is added or removed

--- a/src/interface/widgets/RobotsWidget.cpp
+++ b/src/interface/widgets/RobotsWidget.cpp
@@ -86,18 +86,6 @@ QVBoxLayout *RobotsWidget::createRobotGroupItem(const Field &field, Robot robot)
     wLabel->setFixedWidth(250);
     vbox->addWidget(wLabel);
 
-    auto report = rtt::ai::analysis::GameAnalyzer::getInstance().getMostRecentReport();
-    if (report) {
-        analysis::RobotDanger danger = report->getRobotDangerForId(robot.id, true);
-
-        auto dangerTotalLabel = new QLabel("danger total: " + QString::number(danger.getTotalDanger(field), 'g', 3));
-        dangerTotalLabel->setFixedWidth(250);
-        vbox->addWidget(dangerTotalLabel);
-
-        auto goalVisionLabel = new QLabel("goalvision: " + QString::number(danger.goalVisionPercentage, 'g', 3));
-        goalVisionLabel->setFixedWidth(250);
-        vbox->addWidget(goalVisionLabel);
-    }
 
     return vbox;
 }

--- a/src/interface/widgets/mainWindow.cpp
+++ b/src/interface/widgets/mainWindow.cpp
@@ -123,7 +123,7 @@ MainWindow::MainWindow(const rtt::world_new::World &worldManager, QWidget *paren
     // update mainwindow and field visualization
     auto *timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(update()));
-    timer->start(40);  // 25fps
+    timer->start(200);  // 5fps
 
     connect(mainControlsWidget, SIGNAL(treeHasChanged()), treeWidget, SLOT(invalidateTree()));
     connect(mainControlsWidget, SIGNAL(treeHasChanged()), keeperTreeWidget, SLOT(invalidateTree()));

--- a/src/interface/widgets/mainWindow.cpp
+++ b/src/interface/widgets/mainWindow.cpp
@@ -1,18 +1,9 @@
-//
-// Created by mrlukasbos on 27-11-18.
-//
-
 #include "interface/widgets/mainWindow.h"
-
-#include <interface/api/Input.h>
 #include <interface/widgets/GraphWidget.h>
 #include <interface/widgets/SettingsWidget.h>
 #include <treeinterp/BTFactory.h>
-
 #include <QSplitter>
 #include <QtWidgets/QMenuBar>
-
-#include "interface/api/Output.h"
 #include "interface/widgets/MainControlsWidget.h"
 #include "interface/widgets/ManualControlWidget.h"
 #include "interface/widgets/PidsWidget.h"

--- a/src/interface/widgets/mainWindow.cpp
+++ b/src/interface/widgets/mainWindow.cpp
@@ -137,7 +137,7 @@ MainWindow::MainWindow(const rtt::world_new::World &worldManager, QWidget *paren
     connect(robotsTimer, SIGNAL(timeout()), this, SLOT(updateRobotsWidget()));  // we need to pass the visualizer so thats why a seperate function is used
     connect(robotsTimer, SIGNAL(timeout()), mainControlsWidget, SLOT(updatePause()));
     connect(robotsTimer, SIGNAL(timeout()), mainControlsWidget, SLOT(updateContents()));
-    robotsTimer->start(200);  // 5fps
+    robotsTimer->start(40);  // 25fps
 
     auto *graphTimer = new QTimer(this);
     connect(graphTimer, SIGNAL(timeout()), graphWidget, SLOT(updateContents()));

--- a/src/interface/widgets/widget.cpp
+++ b/src/interface/widgets/widget.cpp
@@ -35,7 +35,7 @@ void Visualizer::paintEvent(QPaintEvent *event) {
         return;
     }
 
-    const Field &field = io::io.getField();
+    auto field = worldManager.getField();
 
     calculateFieldSizeFactor(field);
     drawBackground(painter);

--- a/src/interface/widgets/widget.cpp
+++ b/src/interface/widgets/widget.cpp
@@ -8,6 +8,7 @@
 #include <roboteam_utils/Line.h>
 #include <utilities/RobotDealer.h>
 #include <utilities/GameStateManager.hpp>
+#include <include/roboteam_ai/world_new/World.hpp>
 #include "analysis/GameAnalyzer.h"
 #include "interface/api/Input.h"
 #include "interface/api/Output.h"
@@ -25,8 +26,8 @@ Visualizer::Visualizer(QWidget *parent) : QWidget(parent) {}
 void Visualizer::paintEvent(QPaintEvent *event) {
     QPainter painter(this);
 
-    const Field &field = io::io.getField();
-    if (rtt::ai::world::world->weHaveRobots()) {
+    if (rtt::ai::world::world->weHaveRobots() && io::io.hasReceivedGeom) {
+        const Field &field = world_new::World::instance()->getField().value();
         calculateFieldSizeFactor(field);
         drawBackground(painter);
         drawFieldHints(field, painter);

--- a/src/interface/widgets/widget.cpp
+++ b/src/interface/widgets/widget.cpp
@@ -35,7 +35,7 @@ void Visualizer::paintEvent(QPaintEvent *event) {
         return;
     }
 
-    auto field = worldManager.getField();
+    auto field = worldManager.getField().value();
 
     calculateFieldSizeFactor(field);
     drawBackground(painter);

--- a/src/interface/widgets/widget.cpp
+++ b/src/interface/widgets/widget.cpp
@@ -4,18 +4,14 @@
 
 #include "interface/widgets/widget.h"
 #include <coach/PassCoach.h>
-#include <include/roboteam_ai/utilities/IOManager.h>
 #include <roboteam_utils/Line.h>
 #include <utilities/RobotDealer.h>
 #include <include/roboteam_ai/world_new/World.hpp>
 #include <utilities/GameStateManager.hpp>
-#include <include/roboteam_ai/world_new/World.hpp>
 #include "analysis/GameAnalyzer.h"
 #include "interface/api/Input.h"
 #include "interface/api/Output.h"
 #include "world/FieldComputations.h"
-
-#include "roboteam_proto/GeometryFieldSize.pb.h"
 #include "world/Field.h"
 
 namespace io = rtt::ai::io;
@@ -26,11 +22,9 @@ Visualizer::Visualizer(const rtt::world_new::World &worldManager, QWidget *paren
 /// The update loop of the field widget. Invoked by widget->update();
 void Visualizer::paintEvent(QPaintEvent *event) {
     QPainter painter(this);
-
-
     std::optional<rtt::world_new::view::WorldDataView> world = worldManager.getWorld();
 
-    if (!world.has_value()) {
+    if (!world.has_value() || !world.value()->weHaveRobots()) {
         painter.drawText(24, 24, "Waiting for incoming world state");
         return;
     }
@@ -46,8 +40,8 @@ void Visualizer::paintEvent(QPaintEvent *event) {
     s.fromStdString("We have " + std::to_string(world->getUs().size()) + " robots");
     painter.drawText(24, 48, s.fromStdString("We have " + std::to_string(world->getUs().size()) + " robots"));
 
-    drawRobots(painter, *world);
-    if (world->getBall().has_value()) drawBall(painter, *world->getBall());
+    drawRobots(painter, world.value());
+    if (world->getBall().has_value()) drawBall(painter, world->getBall().value());
 
     // draw the drawings from the input
     auto drawings = Input::getDrawings();
@@ -264,12 +258,12 @@ void Visualizer::drawBall(QPainter &painter, rtt::world_new::view::BallView ball
 // draw the robots
 void Visualizer::drawRobots(QPainter &painter, rtt::world_new::view::WorldDataView world) {
     // draw us
-    for (rtt::world_new::view::RobotView robot : world->getUs()) {
+    for (auto const & robot : world->getUs()) {
         drawRobot(painter, robot, true);
     }
 
     // draw them
-    for (rtt::world_new::view::RobotView robot : world->getThem()) {
+    for (auto  const & robot : world->getThem()) {
         drawRobot(painter, robot, false);
     }
 }

--- a/src/roboteam_ai.cpp
+++ b/src/roboteam_ai.cpp
@@ -1,10 +1,8 @@
-#include <include/roboteam_ai/utilities/Settings.h>
+#include "utilities/Settings.h"
 #include <utilities/Constants.h>
-
 #include <QApplication>
 #include <QStyleFactory>
 #include <include/roboteam_ai/world_new/World.hpp>
-
 #include "ApplicationManager.h"
 #include "interface/widgets/mainWindow.h"
 

--- a/src/roboteam_ai.cpp
+++ b/src/roboteam_ai.cpp
@@ -66,7 +66,7 @@ int main(int argc, char *argv[]) {
     rtt::SETTINGS.setRobothubSendIp("127.0.0.1");
     rtt::SETTINGS.setRobothubSendPort(20011);
 
-    rtt::ai::io::io.init();
+    rtt::ai::io::io.init(rtt::SETTINGS.getId());
 
     BTFactory::makeTrees();
     while (!BTFactory::hasMadeTrees())

--- a/src/treeinterp/tactics/DefaultTactic.cpp
+++ b/src/treeinterp/tactics/DefaultTactic.cpp
@@ -122,7 +122,9 @@ void DefaultTactic::parseType(const std::string &typee) {
 }
 
 void DefaultTactic::updateStyle() {
-    auto reportPtr = rtt::ai::analysis::GameAnalyzer::getInstance().getMostRecentReport();
+    rtt::ai::analysis::GameAnalyzer analyzer;
+    auto reportPtr = analyzer.generateReportNow(*field);
+
     rtt::ai::analysis::PlayStyle style;
     if (reportPtr) {
         rtt::ai::analysis::AnalysisReport report = *reportPtr;

--- a/src/treeinterp/tactics/DefaultTactic.cpp
+++ b/src/treeinterp/tactics/DefaultTactic.cpp
@@ -123,10 +123,6 @@ void DefaultTactic::parseType(const std::string &typee) {
 }
 
 void DefaultTactic::updateStyle() {
-
-    // of course the whole idea of an analysis report is a waste of resources...
-    // here we only use ballpossesion
-
     analysis::BallPossession possession = analysis::GameAnalyzer::convertPossession(ballPossessionPtr->getPossession());
     analysis::PlayStyle style = maker.getRecommendedPlayStyle(possession);
 

--- a/src/treeinterp/tactics/DefaultTactic.cpp
+++ b/src/treeinterp/tactics/DefaultTactic.cpp
@@ -1,5 +1,5 @@
 #include "treeinterp/tactics/DefaultTactic.h"
-
+#include "world/BallPossession.h"
 #include <analysis/GameAnalyzer.h>
 #include <world/World.h>
 #include <world/WorldData.h>
@@ -7,6 +7,7 @@
 #include "utilities/RobotDealer.h"
 
 using dealer = rtt::ai::robotDealer::RobotDealer;
+using namespace rtt::ai;
 
 namespace bt {
 
@@ -122,17 +123,13 @@ void DefaultTactic::parseType(const std::string &typee) {
 }
 
 void DefaultTactic::updateStyle() {
-    rtt::ai::analysis::GameAnalyzer analyzer;
-    auto reportPtr = analyzer.generateReportNow(*field);
 
-    rtt::ai::analysis::PlayStyle style;
-    if (reportPtr) {
-        rtt::ai::analysis::AnalysisReport report = *reportPtr;
-        rtt::ai::analysis::BallPossession possession = report.ballPossession;
-        style = maker.getRecommendedPlayStyle(possession);
-    } else {
-        style = maker.getRecommendedPlayStyle(rtt::ai::analysis::BallPossession::NEUTRAL);
-    }
+    // of course the whole idea of an analysis report is a waste of resources...
+    // here we only use ballpossesion
+
+    analysis::BallPossession possession = analysis::GameAnalyzer::convertPossession(ballPossessionPtr->getPossession());
+    analysis::PlayStyle style = maker.getRecommendedPlayStyle(possession);
+
     if (thisType == Defensive) {
         amountToTick = style.amountOfDefenders;
     } else if (thisType == Middle) {

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -48,6 +48,7 @@ void IOManager::handleWorldState(proto::World &world) {
 void IOManager::handleGeometry(proto::SSL_GeometryData &geometryData) {
     std::lock_guard<std::mutex> lock(geometryMutex);
     this->geometryMsg = geometryData;
+    hasReceivedGeom = true;
 }
 
 void IOManager::handleReferee(proto::SSL_Referee &refData) {

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -56,6 +56,7 @@ void IOManager::handleReferee(proto::SSL_Referee &refData) {
 }
 
 void IOManager::handleFeedback(proto::RobotFeedback &feedback) {
+    std::lock_guard<std::mutex> lock(robotFeedbackMutex);
     feedbackMap.insert({feedback.id(), feedback});
 }
 
@@ -67,11 +68,6 @@ const proto::World &IOManager::getWorldState() {
 const proto::SSL_GeometryData &IOManager::getGeometryData() {
     std::lock_guard<std::mutex> lock(geometryMutex);
     return this->geometryMsg;
-}
-
-const proto::RobotFeedback &IOManager::getRobotFeedback() {
-    std::lock_guard<std::mutex> lock(robotFeedbackMutex);
-    return this->robotFeedbackMsg;
 }
 
 const proto::SSL_Referee &IOManager::getRefereeData() {

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -1,5 +1,6 @@
 #include <utilities/IOManager.h>
 #include <utilities/Settings.h>
+#include <include/roboteam_ai/utilities/GameStateManager.hpp>
 #include "roboteam_proto/DemoRobot.pb.h"
 #include "roboteam_proto/RobotFeedback.pb.h"
 #include "roboteam_proto/messages_robocup_ssl_geometry.pb.h"
@@ -54,6 +55,24 @@ void IOManager::handleGeometry(proto::SSL_GeometryData &geometryData) {
 void IOManager::handleReferee(proto::SSL_Referee &refData) {
     std::lock_guard<std::mutex> lock(refereeMutex);
     this->refDataMsg = refData;
+
+    roboteam_utils::rotate(&refData);
+
+    // Our name as specified by ssl-refbox : https://github.com/RoboCup-SSL/ssl-refbox/blob/master/referee.conf
+    std::string ROBOTEAM_TWENTE = "RoboTeam Twente";
+    if (refData.yellow().name() == ROBOTEAM_TWENTE) {
+        SETTINGS.setYellow(true);
+    } else if (refData.blue().name() == ROBOTEAM_TWENTE) {
+        SETTINGS.setYellow(false);
+    }
+
+    if (refData.blueteamonpositivehalf() ^ SETTINGS.isYellow()) {
+        SETTINGS.setLeft(false);
+    } else {
+        SETTINGS.setLeft(true);
+    }
+    ai::GameStateManager::setRefereeData(refData);
+
 }
 
 void IOManager::handleFeedback(proto::RobotFeedback &feedback) {

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -140,8 +140,9 @@ const proto::DemoRobot &IOManager::getDemoInfo() {
 }
 
 
-void IOManager::publishSettings(proto::Setting setting) { settingsPublisher->send(setting); }
-
+void IOManager::publishSettings(proto::Setting setting) {
+    settingsPublisher->send(setting); 
+}
 
 
 }  // namespace rtt::ai::io

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -42,7 +42,7 @@ void IOManager::init(int teamId) {
 //////////////////////
 void IOManager::handleWorldState(proto::World &world) {
     std::lock_guard<std::mutex> lock(worldStateMutex);
-    this->worldMsg = world;
+    this->worldMsg.CopyFrom(world);
 }
 
 void IOManager::handleGeometry(proto::SSL_GeometryData &geometryData) {
@@ -63,17 +63,23 @@ void IOManager::handleFeedback(proto::RobotFeedback &feedback) {
 
 const proto::World &IOManager::getWorldState() {
     std::lock_guard<std::mutex> lock(worldStateMutex);
-    return this->worldMsg;
+    auto msg = new proto::World();
+    msg->CopyFrom(this->worldMsg);
+    return *msg;
 }
 
 const proto::SSL_GeometryData &IOManager::getGeometryData() {
     std::lock_guard<std::mutex> lock(geometryMutex);
-    return this->geometryMsg;
+    auto msg = new proto::SSL_GeometryData();
+    msg->CopyFrom(this->geometryMsg);
+    return *msg;
 }
 
 const proto::SSL_Referee &IOManager::getRefereeData() {
     std::lock_guard<std::mutex> lock(refereeMutex);
-    return this->refDataMsg;
+    auto msg = new proto::SSL_Referee();
+    msg->CopyFrom(this->refDataMsg);
+    return *msg;
 }
 
 void IOManager::publishRobotCommand(proto::RobotCommand cmd) {

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -1,10 +1,3 @@
-/*
- * Created by mrlukasbos on 19-9-18.
- *
- * This class gives handles for all ROS communication for roboteam_ai.
- * Using this class you don't have to think about callbacks or scoping, or weird ROS parameters.
- */
-
 #include <include/roboteam_ai/interface/api/Output.h>
 #include <utilities/IOManager.h>
 #include <utilities/Settings.h>
@@ -31,61 +24,43 @@ std::mutex IOManager::demoMutex;
 
 IOManager io;
 
-void IOManager::handleWorldState(proto::World &world) {
-    std::lock_guard<std::mutex> lock(worldStateMutex);
+void IOManager::init(int teamId) {
+    worldSubscriber = new proto::Subscriber<proto::World>(proto::WORLD_CHANNEL, &IOManager::handleWorldState, this);
+    geometrySubscriber = new proto::Subscriber<proto::SSL_GeometryData>(proto::GEOMETRY_CHANNEL, &IOManager::handleGeometry, this);
+    refSubscriber = new proto::Subscriber<proto::SSL_Referee>(proto::REFEREE_CHANNEL, &IOManager::handleReferee, this);
 
-    if (!SETTINGS.isLeft()) {
-        std::cout << "rotating message" << std::endl;
-        roboteam_utils::rotate(&world);
+    // set up advertisement to publish robotcommands and settings
+    if (teamId == 1) {
+        feedbackSubscriber = new proto::Subscriber<proto::RobotFeedback>(proto::FEEDBACK_SECONDARY_CHANNEL, &IOManager::handleFeedback, this);
+        robotCommandPublisher = new proto::Publisher<proto::RobotCommand>(proto::ROBOT_COMMANDS_SECONDARY_CHANNEL);
+        settingsPublisher = new proto::Publisher<proto::Setting>(proto::SETTINGS_SECONDARY_CHANNEL);
+    } else {
+        feedbackSubscriber = new proto::Subscriber<proto::RobotFeedback>(proto::FEEDBACK_PRIMARY_CHANNEL, &IOManager::handleFeedback, this);
+        robotCommandPublisher = new proto::Publisher<proto::RobotCommand>(proto::ROBOT_COMMANDS_PRIMARY_CHANNEL);
+        settingsPublisher = new proto::Publisher<proto::Setting>(proto::SETTINGS_PRIMARY_CHANNEL);
     }
-
-    this->worldMsg = world;
-    world::world->updateWorld(field, this->worldMsg);
-
-    world_new::World::instance()->updateWorld(world);
 }
 
-void IOManager::handleGeometry(proto::SSL_GeometryData &sslData) {
-    std::lock_guard<std::mutex> lock(geometryMutex);
+//////////////////////
+/// PROTO HANDLERS ///
+//////////////////////
+void IOManager::handleWorldState(proto::World &world) {
+    std::lock_guard<std::mutex> lock(worldStateMutex);
+    this->worldMsg = world;
+}
 
-    // protobuf objects are not very long-lasting so convert it into an object which we can store way longer in field
-    field = Field(sslData.field());
-    this->geometryMsg = sslData;
-    hasReceivedGeom = true;
+void IOManager::handleGeometry(proto::SSL_GeometryData &geometryData) {
+    std::lock_guard<std::mutex> lock(geometryMutex);
+    this->geometryMsg = geometryData;
 }
 
 void IOManager::handleReferee(proto::SSL_Referee &refData) {
     std::lock_guard<std::mutex> lock(refereeMutex);
-
-    if (interface::Output::usesRefereeCommands()) {
-        // Rotate the data from the referee (designated position, e.g. for ballplacement)
-        if (!SETTINGS.isLeft()) {
-            roboteam_utils::rotate(&refData);
-        }
-
-        this->refDataMsg = refData;
-
-        // Our name as specified by ssl-refbox : https://github.com/RoboCup-SSL/ssl-refbox/blob/master/referee.conf
-        std::string ROBOTEAM_TWENTE = "RoboTeam Twente";
-        if (refData.yellow().name() == ROBOTEAM_TWENTE) {
-            SETTINGS.setYellow(true);
-        } else if (refData.blue().name() == ROBOTEAM_TWENTE) {
-            SETTINGS.setYellow(false);
-        }
-
-        if (refData.blueteamonpositivehalf() ^ SETTINGS.isYellow()) {
-            SETTINGS.setLeft(false);
-        } else {
-            SETTINGS.setLeft(true);
-        }
-
-        GameStateManager::setRefereeData(refData);
-    }
+    this->refDataMsg = refData;
 }
 
-const Field &IOManager::getField() {
-    std::lock_guard<std::mutex> lock(geometryMutex);
-    return field;
+void IOManager::handleFeedback(proto::RobotFeedback &feedback) {
+    feedbackMap.insert({feedback.id(), feedback});
 }
 
 const proto::World &IOManager::getWorldState() {
@@ -164,45 +139,9 @@ const proto::DemoRobot &IOManager::getDemoInfo() {
     return this->demoInfoMsg;
 }
 
-void IOManager::init() {
-    worldSubscriber = new proto::Subscriber<proto::World>(proto::WORLD_CHANNEL, &IOManager::handleWorldState, this);
-    geometrySubscriber = new proto::Subscriber<proto::SSL_GeometryData>(proto::GEOMETRY_CHANNEL, &IOManager::handleGeometry, this);
-    refSubscriber = new proto::Subscriber<proto::SSL_Referee>(proto::REFEREE_CHANNEL, &IOManager::handleReferee, this);
-
-    // set up advertisement to publish robotcommands and settings
-    if (SETTINGS.getId() == 1) {
-        feedbackSubscriber = new proto::Subscriber<proto::RobotFeedback>(proto::FEEDBACK_SECONDARY_CHANNEL, &IOManager::handleFeedback, this);
-        robotCommandPublisher = new proto::Publisher<proto::RobotCommand>(proto::ROBOT_COMMANDS_SECONDARY_CHANNEL);
-        settingsPublisher = new proto::Publisher<proto::Setting>(proto::SETTINGS_SECONDARY_CHANNEL);
-    } else {
-        feedbackSubscriber = new proto::Subscriber<proto::RobotFeedback>(proto::FEEDBACK_PRIMARY_CHANNEL, &IOManager::handleFeedback, this);
-        robotCommandPublisher = new proto::Publisher<proto::RobotCommand>(proto::ROBOT_COMMANDS_PRIMARY_CHANNEL);
-        settingsPublisher = new proto::Publisher<proto::Setting>(proto::SETTINGS_PRIMARY_CHANNEL);
-    }
-}
 
 void IOManager::publishSettings(proto::Setting setting) { settingsPublisher->send(setting); }
 
-void IOManager::handleFeedback(proto::RobotFeedback &feedback) {
-    if (Constants::FEEDBACK_ENABLED()) {
-        std::lock_guard<std::mutex> lock(robotFeedbackMutex);
-        this->robotFeedbackMsg = feedback;
 
-        auto robot = world::world->getRobotForId(feedback.id());
-
-        if (robot) {
-            // indicate that now is last time the robot has received feedback
-            robot->UpdateFeedbackReceivedTime();
-
-            // override properties:
-            robot->setWorkingGeneva(feedback.genevaisworking());
-            robot->setHasWorkingBallSensor(feedback.ballsensorisworking());
-            robot->setBatteryLow(feedback.batterylow());
-            // robot->setGenevaStateFromFeedback(feedback.genevastate());
-        }
-
-        world_new::World::instance()->updateFeedback(feedback.id(), feedback);
-    }
-}
 
 }  // namespace rtt::ai::io

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -1,15 +1,11 @@
-#include <include/roboteam_ai/interface/api/Output.h>
 #include <utilities/IOManager.h>
 #include <utilities/Settings.h>
-#include "world_new/views/WorldDataView.hpp"
 #include "roboteam_proto/DemoRobot.pb.h"
 #include "roboteam_proto/RobotFeedback.pb.h"
 #include "roboteam_proto/messages_robocup_ssl_geometry.pb.h"
 
 #include "interface/api/Input.h"
-#include "utilities/GameStateManager.hpp"
 #include "utilities/Pause.h"
-#include "world/FieldComputations.h"
 #include "world/Robot.h"
 
 #include "roboteam_utils/normalize.h"

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -1,7 +1,7 @@
 #include <include/roboteam_ai/interface/api/Output.h>
 #include <utilities/IOManager.h>
 #include <utilities/Settings.h>
-#include <include/roboteam_ai/world_new/World.hpp>
+#include "world_new/views/WorldDataView.hpp"
 #include "roboteam_proto/DemoRobot.pb.h"
 #include "roboteam_proto/RobotFeedback.pb.h"
 #include "roboteam_proto/messages_robocup_ssl_geometry.pb.h"

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -72,7 +72,6 @@ void IOManager::handleReferee(proto::SSL_Referee &refData) {
         SETTINGS.setLeft(true);
     }
     ai::GameStateManager::setRefereeData(refData);
-
 }
 
 void IOManager::handleFeedback(proto::RobotFeedback &feedback) {

--- a/src/world/Field.cpp
+++ b/src/world/Field.cpp
@@ -65,13 +65,13 @@ void Field::initFieldVectors() {
     theirBottomGoalSide = theirGoalCenter.value() - goalWidthAdjust;
     theirTopGoalSide = theirGoalCenter.value() + goalWidthAdjust;
 
-    Vector2 lpl_begin = leftPenaltyLine.value().begin;
-    Vector2 lpl_end = leftPenaltyLine.value().end;
-    leftPenaltyPoint = lpl_begin + ((lpl_end - lpl_begin) * 0.5);
-
-    Vector2 rpl_begin = rightPenaltyLine.value().begin;
-    Vector2 rpl_end = rightPenaltyLine.value().end;
-    rightPenaltyPoint = rpl_begin + ((rpl_end - rpl_begin) * 0.5);
+//    Vector2 lpl_begin = leftPenaltyLine.value().begin;
+//    Vector2 lpl_end = leftPenaltyLine.value().end;
+//    leftPenaltyPoint = lpl_begin + ((lpl_end - lpl_begin) * 0.5);
+//
+//    Vector2 rpl_begin = rightPenaltyLine.value().begin;
+//    Vector2 rpl_end = rightPenaltyLine.value().end;
+//    rightPenaltyPoint = rpl_begin + ((rpl_end - rpl_begin) * 0.5);
 }
 
 float Field::mm_to_m(float scalar) { return scalar / 1000; }

--- a/src/world/Field.cpp
+++ b/src/world/Field.cpp
@@ -65,13 +65,13 @@ void Field::initFieldVectors() {
     theirBottomGoalSide = theirGoalCenter.value() - goalWidthAdjust;
     theirTopGoalSide = theirGoalCenter.value() + goalWidthAdjust;
 
-//    Vector2 lpl_begin = leftPenaltyLine.value().begin;
-//    Vector2 lpl_end = leftPenaltyLine.value().end;
-//    leftPenaltyPoint = lpl_begin + ((lpl_end - lpl_begin) * 0.5);
-//
-//    Vector2 rpl_begin = rightPenaltyLine.value().begin;
-//    Vector2 rpl_end = rightPenaltyLine.value().end;
-//    rightPenaltyPoint = rpl_begin + ((rpl_end - rpl_begin) * 0.5);
+    Vector2 lpl_begin = leftPenaltyLine.value().begin;
+    Vector2 lpl_end = leftPenaltyLine.value().end;
+    leftPenaltyPoint = lpl_begin + ((lpl_end - lpl_begin) * 0.5);
+
+    Vector2 rpl_begin = rightPenaltyLine.value().begin;
+    Vector2 rpl_end = rightPenaltyLine.value().end;
+    rightPenaltyPoint = rpl_begin + ((rpl_end - rpl_begin) * 0.5);
 }
 
 float Field::mm_to_m(float scalar) { return scalar / 1000; }

--- a/src/world/FieldComputations.cpp
+++ b/src/world/FieldComputations.cpp
@@ -8,6 +8,7 @@
 #include "world/World.h"
 #include "world/WorldData.h"
 #include "world_new/views/RobotView.hpp"
+#include "world_new/views/WorldDataView.hpp"
 
 namespace rtt {
 namespace ai {
@@ -37,7 +38,7 @@ double FieldComputations::getTotalGoalAngle(const Field &field, bool ourGoal, co
 double FieldComputations::getPercentageOfGoalVisibleFromPoint(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world, int id, bool ourTeam) {
     double goalWidth = field.getGoalWidth();
     double blockadeLength = 0;
-    for (auto const &blockade : getBlockadesMappedToGoal(field, ourGoal, point, world, id, ourTeam)) {
+    for (auto const &blockade : getBlockadesMappedToGoal(field, ourGoal, point, world.getRobotsNonOwning(), id, ourTeam)) {
         blockadeLength += blockade.start.dist(blockade.end);
     }
     return fmax(100 - blockadeLength / goalWidth * 100, 0.0);
@@ -56,7 +57,7 @@ std::vector<Line> FieldComputations::getBlockadesMappedToGoal(const Field &field
     // all the obstacles should be robots
     for (auto const &robot : robots) {
         if (robot->getId() == id && robot->getTeam() == (ourTeam ? world_new::Team::us : world_new::Team::them)) continue;
-        auto pos = robot.getPos();
+        auto pos = robot->getPos();
         double lenToBot = (point - pos).length();
         // discard already all robots that are not at all between the goal and point, or if a robot is standing on this point
         bool isRobotItself = lenToBot <= robotRadius;
@@ -306,7 +307,7 @@ std::vector<Line> FieldComputations::getVisiblePartsOfGoalByObstacles(const Fiel
  * This is the inverse of getting the blockades of a goal
  */
 std::vector<Line> FieldComputations::getVisiblePartsOfGoal(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world) {
-    return this->getVisiblePartsOfGoalByObstacles(field, ourGoal, point, world.getRobotsNonOwning());
+    return getVisiblePartsOfGoalByObstacles(field, ourGoal, point, world.getRobotsNonOwning());
 }
 
 

--- a/src/world/FieldComputations.cpp
+++ b/src/world/FieldComputations.cpp
@@ -1,12 +1,6 @@
-//
-// Created by mrlukasbos on 19-10-18.
-//
-
 #include "world/FieldComputations.h"
 #include <control/ControlUtils.h>
 #include <interface/api/Input.h>
-#include "world/World.h"
-#include "world/WorldData.h"
 #include "world_new/views/RobotView.hpp"
 #include "world_new/views/WorldDataView.hpp"
 
@@ -307,7 +301,7 @@ std::vector<Line> FieldComputations::getVisiblePartsOfGoalByObstacles(const Fiel
  * This is the inverse of getting the blockades of a goal
  */
 std::vector<Line> FieldComputations::getVisiblePartsOfGoal(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world) {
-    return getVisiblePartsOfGoalByObstacles(field, ourGoal, point, world.getRobotsNonOwning());
+    return getVisiblePartsOfGoalByObstacles(field, ourGoal, point, world.getUs());
 }
 
 

--- a/src/world/FieldComputations.cpp
+++ b/src/world/FieldComputations.cpp
@@ -33,16 +33,16 @@ double FieldComputations::getTotalGoalAngle(const Field &field, bool ourGoal, co
 }
 
 /// id and ourteam are for a robot not to be taken into account.
-double FieldComputations::getPercentageOfGoalVisibleFromPoint(const Field &field, bool ourGoal, const Vector2 &point, const world::WorldData &data, int id, bool ourTeam) {
+double FieldComputations::getPercentageOfGoalVisibleFromPoint(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world, int id, bool ourTeam) {
     double goalWidth = field.getGoalWidth();
     double blockadeLength = 0;
-    for (auto const &blockade : getBlockadesMappedToGoal(field, ourGoal, point, data, id, ourTeam)) {
+    for (auto const &blockade : getBlockadesMappedToGoal(field, ourGoal, point, world, id, ourTeam)) {
         blockadeLength += blockade.start.dist(blockade.end);
     }
     return fmax(100 - blockadeLength / goalWidth * 100, 0.0);
 }
 
-std::vector<Line> FieldComputations::getBlockadesMappedToGoal(const Field &field, bool ourGoal, const Vector2 &point, const world::WorldData &data, int id, bool ourTeam) {
+std::vector<Line> FieldComputations::getBlockadesMappedToGoal(const Field &field, bool ourGoal, const Vector2 &point, world_new::view::WorldDataView &world, int id, bool ourTeam) {
     const double robotRadius = Constants::ROBOT_RADIUS() + Constants::BALL_RADIUS();
 
     Vector2 lowerGoalSide, upperGoalSide;
@@ -53,21 +53,21 @@ std::vector<Line> FieldComputations::getBlockadesMappedToGoal(const Field &field
     std::vector<Line> blockades = {};
 
     // get all the robots
-    auto robots = data.us;
-    robots.insert(robots.begin(), data.them.begin(), data.them.end());
+    auto robots = world.getRobotsNonOwning();
     // all the obstacles should be robots
     for (auto const &robot : robots) {
-        if (robot->id == id && robot->team == (ourTeam ? Team::us : Team::them)) continue;
-        double lenToBot = (point - robot->pos).length();
+        if (robot->getId() == id && robot->getTeam() == (ourTeam ? world_new::Team::us : world_new::Team::them)) continue;
+        auto pos = robot.getPos();
+        double lenToBot = (point - pos).length();
         // discard already all robots that are not at all between the goal and point, or if a robot is standing on this point
         bool isRobotItself = lenToBot <= robotRadius;
-        bool isInPotentialBlockingZone = ourGoal ? robot->pos.x < point.x + robotRadius : robot->pos.x > point.x - robotRadius;
+        bool isInPotentialBlockingZone = ourGoal ? pos.x < point.x + robotRadius : pos.x > point.x - robotRadius;
         if (!isRobotItself && isInPotentialBlockingZone) {
             // get the left and right sides of the robot
             double theta = asin(robotRadius / lenToBot);
             double length = sqrt(lenToBot * lenToBot - robotRadius * robotRadius);
-            Vector2 lowerSideOfRobot = point + Vector2(length, 0).rotate((Vector2(robot->pos) - point).angle() - theta);
-            Vector2 upperSideOfRobot = point + Vector2(length, 0).rotate((Vector2(robot->pos) - point).angle() + theta);
+            Vector2 lowerSideOfRobot = point + Vector2(length, 0).rotate((Vector2(pos) - point).angle() - theta);
+            Vector2 upperSideOfRobot = point + Vector2(length, 0).rotate((Vector2(pos) - point).angle() + theta);
             // map points onto goal line
 
             // the forwardIntersection returns a double which is the scale of the vector projection

--- a/src/world/FieldComputations.cpp
+++ b/src/world/FieldComputations.cpp
@@ -7,6 +7,7 @@
 #include <interface/api/Input.h>
 #include "world/World.h"
 #include "world/WorldData.h"
+#include "world_new/views/RobotView.hpp"
 
 namespace rtt {
 namespace ai {
@@ -167,8 +168,8 @@ std::vector<Line> FieldComputations::mergeBlockades(std::vector<Line> blockades)
  * Get the visible parts of a goal
  * This is the inverse of getting the blockades of a goal
  */
-std::vector<Line> FieldComputations::getVisiblePartsOfGoal(const Field &field, bool ourGoal, const Vector2 &point, const world::WorldData &data) {
-    auto blockades = getBlockadesMappedToGoal(field, ourGoal, point, data);
+std::vector<Line> FieldComputations::getVisiblePartsOfGoal(const Field &field, bool ourGoal, const Vector2 &point,  world_new::view::WorldDataView &world) {
+    auto blockades = getBlockadesMappedToGoal(field, ourGoal, point, world);
 
     auto sides = getGoalSides(field, ourGoal);
     auto lower = sides.start;

--- a/src/world/World.cpp
+++ b/src/world/World.cpp
@@ -8,7 +8,10 @@ namespace rtt::ai::world {
 World worldObj;
 World *world = &worldObj;
 
-void World::updateWorld(const Field &field, const proto::World &message) {
+void World::updateWorld(const proto::SSL_GeometryFieldSize &fieldMessage, const proto::World &worldMessage) {
+    ai::Field field(fieldMessage);
+    this->field = field;
+
     worldNumber++;
 
     BallPtr oldBall = nullptr;
@@ -18,7 +21,7 @@ void World::updateWorld(const Field &field, const proto::World &message) {
         // create a worldData if there is none
         if (!worldDataPtr) {
             std::cout << "Creating first world" << std::endl;
-            auto worldData = WorldData(message);
+            auto worldData = WorldData(worldMessage);
             worldDataPtr = std::make_shared<WorldData>(worldData);
         }
 
@@ -29,7 +32,7 @@ void World::updateWorld(const Field &field, const proto::World &message) {
     }
 
     // update ballmodel, dribbling, position if not visible etc.
-    auto tempWorldData = WorldData(message);
+    auto tempWorldData = WorldData(worldMessage);
     if (oldBall) {
         tempWorldData.ball->updateBall(oldBall, tempWorldData);
     } else {
@@ -39,17 +42,17 @@ void World::updateWorld(const Field &field, const proto::World &message) {
     {
         std::lock_guard<std::mutex> lock(worldMutex);
         worldDataPtr->ball = tempWorldData.ball;
-        worldDataPtr->time = message.time();
+        worldDataPtr->time = worldMessage.time();
 
         std::vector<proto::WorldRobot> usMsg;
         std::vector<proto::WorldRobot> themMsg;
 
         if (SETTINGS.isYellow()) {
-            usMsg = std::vector<proto::WorldRobot>(message.yellow().begin(), message.yellow().end());
-            themMsg = std::vector<proto::WorldRobot>(message.blue().begin(), message.blue().end());
+            usMsg = std::vector<proto::WorldRobot>(worldMessage.yellow().begin(), worldMessage.yellow().end());
+            themMsg = std::vector<proto::WorldRobot>(worldMessage.blue().begin(), worldMessage.blue().end());
         } else {
-            usMsg = std::vector<proto::WorldRobot>(message.blue().begin(), message.blue().end());
-            themMsg = std::vector<proto::WorldRobot>(message.yellow().begin(), message.yellow().end());
+            usMsg = std::vector<proto::WorldRobot>(worldMessage.blue().begin(), worldMessage.blue().end());
+            themMsg = std::vector<proto::WorldRobot>(worldMessage.yellow().begin(), worldMessage.yellow().end());
         }
         updateRobotsFromData(us, usMsg, worldDataPtr->us, worldDataPtr->ball, worldNumber);
         updateRobotsFromData(them, themMsg, worldDataPtr->them, worldDataPtr->ball, worldNumber);

--- a/src/world_new/Ball.cpp
+++ b/src/world_new/Ball.cpp
@@ -113,6 +113,7 @@ void Ball::updateBallAtRobotPosition() noexcept {
     }
 
     auto world = World::instance()->getWorld();
+    if (!world.has_value()) return;
 
     auto robotWithBall = world->whichRobotHasBall();
     if (!robotWithBall) {

--- a/src/world_new/Robot.cpp
+++ b/src/world_new/Robot.cpp
@@ -24,9 +24,6 @@ Robot::Robot(std::unordered_map<uint8_t, proto::RobotFeedback> &feedback, const 
     if (id < 16) {
         workingDribbler = ai::Constants::ROBOT_HAS_WORKING_DRIBBLER(id);
         workingBallSensor = ai::Constants::ROBOT_HAS_WORKING_BALL_SENSOR(id);
-    } else {
-        std::cerr << "Warning: Creating robot with id = " << id << std::endl;
-       // assert(false);
     }
 
     if (feedback.find(id) != feedback.end()) {

--- a/src/world_new/Robot.cpp
+++ b/src/world_new/Robot.cpp
@@ -26,7 +26,7 @@ Robot::Robot(std::unordered_map<uint8_t, proto::RobotFeedback> &feedback, const 
         workingBallSensor = ai::Constants::ROBOT_HAS_WORKING_BALL_SENSOR(id);
     } else {
         std::cerr << "Warning: Creating robot with id = " << id << std::endl;
-        assert(false);
+       // assert(false);
     }
 
     if (feedback.find(id) != feedback.end()) {

--- a/src/world_new/World.cpp
+++ b/src/world_new/World.cpp
@@ -5,6 +5,7 @@
 #include "world_new/World.hpp"
 
 #include <utility>
+#include <include/roboteam_ai/world/Field.h>
 
 #include "include/roboteam_ai/utilities/Settings.h"
 #include "world_new/views/WorldDataView.hpp"
@@ -42,6 +43,14 @@ std::optional<view::WorldDataView> World::getWorld() const noexcept {
     }
 }
 
+std::optional<ai::world::Field> World::getField() const noexcept {
+    if (currentField) {
+        return currentField;
+    } else {
+        return std::nullopt;
+    }
+}
+
 view::WorldDataView World::getHistoryWorld(size_t ticksAgo) const noexcept {
     if (ticksAgo > history.size()) {
         return view::WorldDataView(nullptr);
@@ -53,6 +62,11 @@ view::WorldDataView World::getHistoryWorld(size_t ticksAgo) const noexcept {
 void World::updateWorld(proto::World &protoWorld) {
     WorldData data{protoWorld, *settings, updateMap};
     setWorld(data);
+}
+
+void World::updateField(proto::SSL_GeometryFieldSize &protoField) {
+    ai::world::Field field(protoField);
+    this->currentField = field;
 }
 
 World::World(Settings *settings) : settings{settings}, currentWorld{std::nullopt}, lastTick{0} { history.reserve(HISTORY_SIZE); }

--- a/src/world_new/WorldData.cpp
+++ b/src/world_new/WorldData.cpp
@@ -21,6 +21,7 @@ WorldData::WorldData(proto::World &protoMsg, rtt::Settings const &settings, std:
     robots.reserve(amountUs + amountThem);
     us.reserve(amountUs);
     them.reserve(amountThem);
+    robotsNonOwning.reserve(amountUs + amountThem);
 
     for (auto &each : ours) {
         auto _ptr = &robots.emplace_back(feedback, each, Team::us);

--- a/src/world_new/views/RobotView.cpp
+++ b/src/world_new/views/RobotView.cpp
@@ -7,6 +7,7 @@
 #include <include/roboteam_ai/utilities/Constants.h>
 
 #include <include/roboteam_ai/world_new/World.hpp>
+#include <include/roboteam_ai/world_new/Robot.hpp>
 
 namespace rtt::world_new::view {
 RobotView::RobotView(const rtt::world_new::robot::Robot *const _ptr) noexcept : robotPtr{_ptr} {}

--- a/src/world_new/views/WorldDataView.cpp
+++ b/src/world_new/views/WorldDataView.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "world_new/views/WorldDataView.hpp"
-
 #include "world_new/Ball.hpp"
 #include "world_new/WorldData.hpp"
 

--- a/src/world_new/views/WorldDataView.cpp
+++ b/src/world_new/views/WorldDataView.cpp
@@ -133,4 +133,5 @@ RobotView WorldDataView::getRobotClosestToPoint(const Vector2 &point, const std:
 const std::vector<RobotView> &WorldDataView::getRobotsNonOwning() const noexcept { return data->getRobotsNonOwning(); }
 
 WorldDataView::WorldDataView(WorldData const *_ptr) noexcept : data{_ptr} {}
+
 }  // namespace rtt::world_new::view


### PR DESCRIPTION
Quite a large refactor adopting the new world structure.

- [x] IOmanager is mostly single purpose again. it stores recent proto messages and application manager receives messages when needed. This should remove most race conditions in our system already. 
- [x] game analyzer is not a singleton anymore. I realized that generating a full 'analysis report' is often unnecessary to calculate and the performance hit is just too big. I converted it to static function definitions: just call one when you need it. This needs restructuring in a later PR. 
- [x] some necessary field refactors in some coaches, game analyzer, etc. 

fixes #695
