### PR TITLE
Sensible GUI framerates

### DIFF
--- a/include/roboteam_ai/interface/api/Input.h
+++ b/include/roboteam_ai/interface/api/Input.h
@@ -40,7 +40,7 @@ struct Drawing {
 
 class Input {
    public:
-    explicit Input() = default;
+    explicit Input();
     virtual ~Input();
 
     static void clearDrawings();
@@ -56,7 +56,6 @@ class Input {
     static std::vector<Drawing> drawings;
     static std::mutex drawingMutex;
     static std::mutex fpsMutex;
-    static void makeDrawing(Drawing const &drawing);
     static int FPS;
 };
 

--- a/include/roboteam_ai/interface/widgets/TreeVisualizerWidget.h
+++ b/include/roboteam_ai/interface/widgets/TreeVisualizerWidget.h
@@ -19,9 +19,9 @@ class TreeVisualizerWidget : public QTreeWidget {
     FRIEND_TEST(TreeVisualizerTest, it_sets_proper_color_for_status);
 
    private:
-    QColor getColorForStatus(bt::Node::Status status);
+    static QColor getColorForStatus(bt::Node::Status status);
     void addRootItem(bt::Node::Ptr parent, QTreeWidgetItem *QParent);
-    std::map<QTreeWidgetItem *, bt::Node::Ptr> treeItemMapping;
+    std::unordered_map<QTreeWidgetItem *, bt::Node::Ptr> treeItemMapping;
     bool hasCorrectTree = false;
     MainWindow *parent = nullptr;
     unsigned long long mostTicks = 0;

--- a/src/interface/widgets/TreeVisualizerWidget.cpp
+++ b/src/interface/widgets/TreeVisualizerWidget.cpp
@@ -8,13 +8,9 @@
  */
 
 #include "interface/widgets/TreeVisualizerWidget.h"
-
 #include <treeinterp/BTFactory.h>
-
 #include <QtWidgets/QLayoutItem>
 #include <utilities/GameStateManager.hpp>
-
-#include "QLayout"
 #include "interface/widgets/mainWindow.h"
 
 namespace rtt::ai::interface {
@@ -81,13 +77,10 @@ void TreeVisualizerWidget::addRootItem(bt::Node::Ptr parent, QTreeWidgetItem *QP
 
 // update the contents in a row of the treewidget
 void TreeVisualizerWidget::populateRow(bt::Node::Ptr node, QTreeWidgetItem *row, bool isUpdate) {
-    //    ros::Time currentTime = ros::Time::now();
-
     // if the row is updated we don't need to change node names
     // also insert the pair into treeItemMapping
     if (!isUpdate) {
         row->setText(0, QString::fromStdString(node->node_name()));
-
         std::pair<QTreeWidgetItem *, bt::Node::Ptr> pair{row, node};
         treeItemMapping.insert(pair);
     }
@@ -99,38 +92,6 @@ void TreeVisualizerWidget::populateRow(bt::Node::Ptr node, QTreeWidgetItem *row,
         row->setForeground(1, getColorForStatus(node->getStatus()));
     }
 
-    // Update the elapsed time (if ticked)
-    //    ros::Duration duration = currentTime - node->getLastTickTime();
-
-    if (node->getAmountOfTicks() > 0) {
-        //        if (duration.toSec() < 1) {
-        //            row->setForeground(2, Qt::white);
-        //            row->setText(2, "Just now");
-        //        } else if (duration.toSec() < 60){
-        //            row->setForeground(2, Qt::gray);
-        //            row->setText(2, QString::number(duration.toSec(), 'f', 1)+"s ago");
-        //        } else {
-        //            row->setForeground(2, Qt::darkGray);
-        //            row->setText(2, "> 1m ago");
-        //        }
-    } else {
-        row->setForeground(2, Qt::darkGray);
-        row->setText(2, "N/A");
-    }
-
-    // update the total amount of ticks
-    row->setForeground(3, Qt::darkGray);
-
-    // go from yellow to red
-    // yellow = red + green
-    // so we just need to decrease green.
-    mostTicks = std::max(node->getAmountOfTicks(), mostTicks);
-    if (mostTicks != 0) {
-        double div = (node->getAmountOfTicks() * 1.0) / (mostTicks * 1.0);
-        div = log((127) * div + 1) / log(128);
-        auto factor = static_cast<int>(255 * div);
-        row->setForeground(3, QColor{255, 255 - factor, factor});
-    }
     row->setText(3, QString::number(node->getAmountOfTicks(), 'f', 0));
 }
 

--- a/src/interface/widgets/mainWindow.cpp
+++ b/src/interface/widgets/mainWindow.cpp
@@ -133,8 +133,6 @@ MainWindow::MainWindow(const rtt::world_new::World &worldManager, QWidget *paren
     auto *graphTimer = new QTimer(this);
     connect(graphTimer, SIGNAL(timeout()), graphWidget, SLOT(updateContents()));
     graphTimer->start(500);  // 2fps
-
-    connect(robotsTimer, SIGNAL(timeout()), this, SLOT(updateRobotsWidget()));  // we need to pass the visualizer so thats why a seperate function is used
 }
 
 /// Set up a checkbox and add it to the layout

--- a/src/interface/widgets/mainWindow.cpp
+++ b/src/interface/widgets/mainWindow.cpp
@@ -114,7 +114,7 @@ MainWindow::MainWindow(const rtt::world_new::World &worldManager, QWidget *paren
     // update mainwindow and field visualization
     auto *timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(update()));
-    timer->start(50);  // 20fps
+    timer->start(100);  // 10fps
 
     connect(mainControlsWidget, SIGNAL(treeHasChanged()), treeWidget, SLOT(invalidateTree()));
     connect(mainControlsWidget, SIGNAL(treeHasChanged()), keeperTreeWidget, SLOT(invalidateTree()));
@@ -128,7 +128,7 @@ MainWindow::MainWindow(const rtt::world_new::World &worldManager, QWidget *paren
     connect(robotsTimer, SIGNAL(timeout()), this, SLOT(updateRobotsWidget()));  // we need to pass the visualizer so thats why a seperate function is used
     connect(robotsTimer, SIGNAL(timeout()), mainControlsWidget, SLOT(updatePause()));
     connect(robotsTimer, SIGNAL(timeout()), mainControlsWidget, SLOT(updateContents()));
-    robotsTimer->start(200);  // 5fps
+    robotsTimer->start(500);  // 2fps
 
     auto *graphTimer = new QTimer(this);
     connect(graphTimer, SIGNAL(timeout()), graphWidget, SLOT(updateContents()));

--- a/src/interface/widgets/mainWindow.cpp
+++ b/src/interface/widgets/mainWindow.cpp
@@ -114,7 +114,7 @@ MainWindow::MainWindow(const rtt::world_new::World &worldManager, QWidget *paren
     // update mainwindow and field visualization
     auto *timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(update()));
-    timer->start(200);  // 5fps
+    timer->start(50);  // 20fps
 
     connect(mainControlsWidget, SIGNAL(treeHasChanged()), treeWidget, SLOT(invalidateTree()));
     connect(mainControlsWidget, SIGNAL(treeHasChanged()), keeperTreeWidget, SLOT(invalidateTree()));
@@ -128,11 +128,11 @@ MainWindow::MainWindow(const rtt::world_new::World &worldManager, QWidget *paren
     connect(robotsTimer, SIGNAL(timeout()), this, SLOT(updateRobotsWidget()));  // we need to pass the visualizer so thats why a seperate function is used
     connect(robotsTimer, SIGNAL(timeout()), mainControlsWidget, SLOT(updatePause()));
     connect(robotsTimer, SIGNAL(timeout()), mainControlsWidget, SLOT(updateContents()));
-    robotsTimer->start(40);  // 25fps
+    robotsTimer->start(200);  // 5fps
 
     auto *graphTimer = new QTimer(this);
     connect(graphTimer, SIGNAL(timeout()), graphWidget, SLOT(updateContents()));
-    graphTimer->start(200);  // 5fps
+    graphTimer->start(500);  // 2fps
 
     connect(robotsTimer, SIGNAL(timeout()), this, SLOT(updateRobotsWidget()));  // we need to pass the visualizer so thats why a seperate function is used
 }


### PR DESCRIPTION
During profiling I noticed that the visualizer was not that heavy. In fact, the treewidget updates were. I saw that all ui widgets where updated at 25hz. That is actually really a lot for something that is not that important.  I turned it down to 5hz. The visualization of the robots updated at 5hz, I turned that up to 20. 

Another thing I noticed is that the Treewidget was still using a lot of CPU. Apparantly changing text color is heavy, and for some things we changed the color every tick. I have removed that feature entirely. 

After this PR the CPU load went down drastically for me: (From 90% to 70% during halt strategy and from 160% to 130% during normal play). 