### PR TITLE
Added failing conditions for tactics

### DIFF
--- a/include/roboteam_ai/stp/Tactic.h
+++ b/include/roboteam_ai/stp/Tactic.h
@@ -42,6 +42,18 @@ class Tactic {
     virtual void onTerminate() noexcept = 0;
 
     /**
+     * The condition when the current tactic fails
+     * @return true if the tactic's prerequisites are no longer met (e.g. losing the ball)
+     */
+    virtual bool isTacticFailing() noexcept = 0;
+
+    /**
+     * When the state should reset
+     * @return true if the active skill cannot execute (it's prerequisites are no longer met)
+     */
+    virtual bool shouldTacticReset() noexcept = 0;
+
+    /**
      * The state machine of skills
      */
     rtt::collections::state_machine<Skill, Status, StpInfo> skills;
@@ -63,6 +75,12 @@ class Tactic {
      * Calls onTerminate
      */
     virtual void terminate() noexcept;
+
+    /**
+     * Check if the current tactic is an end tactic - only Running or Failure status
+     * @return true if the current tactic cannot succeed (i.e. is an end tactic); default false
+     */
+    virtual bool isEndTactic() noexcept;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/Tactic.h
+++ b/include/roboteam_ai/stp/Tactic.h
@@ -43,15 +43,17 @@ class Tactic {
 
     /**
      * The condition when the current tactic fails
+     * @param info the tactic info passed down from the play
      * @return true if the tactic's prerequisites are no longer met (e.g. losing the ball)
      */
-    virtual bool isTacticFailing() noexcept = 0;
+    virtual bool isTacticFailing(const StpInfo &info) noexcept = 0;
 
     /**
      * When the state should reset
+     * @param info the tactic info passed down from the play
      * @return true if the active skill cannot execute (it's prerequisites are no longer met)
      */
-    virtual bool shouldTacticReset() noexcept = 0;
+    virtual bool shouldTacticReset(const StpInfo &info) noexcept = 0;
 
     /**
      * The state machine of skills

--- a/include/roboteam_ai/stp/new_tactics/TestTactic.h
+++ b/include/roboteam_ai/stp/new_tactics/TestTactic.h
@@ -36,9 +36,9 @@ class TestTactic : public Tactic {
      */
     StpInfo calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    bool isTacticFailing() noexcept override;
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    bool shouldTacticReset() noexcept override;
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 };
 
 }  // namespace rtt::ai::stp

--- a/include/roboteam_ai/stp/new_tactics/TestTactic.h
+++ b/include/roboteam_ai/stp/new_tactics/TestTactic.h
@@ -35,6 +35,10 @@ class TestTactic : public Tactic {
      * @return SkillInfo based on the TacticInfo
      */
     StpInfo calculateInfoForSkill(StpInfo const &info) noexcept override;
+
+    bool isTacticFailing() noexcept override;
+
+    bool shouldTacticReset() noexcept override;
 };
 
 }  // namespace rtt::ai::stp

--- a/src/stp/Tactic.cpp
+++ b/src/stp/Tactic.cpp
@@ -14,9 +14,23 @@ void Tactic::initialize() noexcept { onInitialize(); }
 
 Status Tactic::update(StpInfo const &info) noexcept {
     // Check if the skills are all finished
-    if (skills.finished()) {
+    if (skills.finished() && !isEndTactic()) {
         RTT_INFO("TACTIC SUCCESSFUL!!!!!!!!!!!!!!!!!!!!!!!!:)")
         return Status::Success;
+    }
+
+    // if the failing condition is true, the current tactic will fail
+    if(isTacticFailing()){
+        RTT_INFO("Current Tactic Failed for ID = ", info.getRobot()->get()->getId())
+        return Status::Failure;
+    }
+
+    // the tactic will not be reset if it's the first skill; it will be reset as well if the
+    // state machine is finished
+    if(skills.finished() || (skills.current_num() != 0 && shouldTacticReset())){
+        RTT_INFO("State Machine reset for current tactic for ID = ", info.getRobot()->get()->getId())
+        // TODO: messy reset, do it in the state machine
+        skills.skip_n(- skills.current_num());
     }
 
     // Update skill info
@@ -33,4 +47,8 @@ Status Tactic::update(StpInfo const &info) noexcept {
 }
 
 void Tactic::terminate() noexcept { onTerminate(); }
+
+bool Tactic::isEndTactic() noexcept {
+    return false;
+}
 }  // namespace rtt::ai::stp

--- a/src/stp/Tactic.cpp
+++ b/src/stp/Tactic.cpp
@@ -20,14 +20,14 @@ Status Tactic::update(StpInfo const &info) noexcept {
     }
 
     // if the failing condition is true, the current tactic will fail
-    if(isTacticFailing()){
+    if(isTacticFailing(info)){
         RTT_INFO("Current Tactic Failed for ID = ", info.getRobot()->get()->getId())
         return Status::Failure;
     }
 
     // the tactic will not be reset if it's the first skill; it will be reset as well if the
     // state machine is finished
-    if(skills.finished() || (skills.current_num() != 0 && shouldTacticReset())){
+    if(skills.finished() || (skills.current_num() != 0 && shouldTacticReset(info))){
         RTT_INFO("State Machine reset for current tactic for ID = ", info.getRobot()->get()->getId())
         // TODO: messy reset, do it in the state machine
         skills.skip_n(- skills.current_num());

--- a/src/stp/new_tactics/TestTactic.cpp
+++ b/src/stp/new_tactics/TestTactic.cpp
@@ -37,4 +37,12 @@ StpInfo TestTactic::calculateInfoForSkill(StpInfo const& info) noexcept {
     return skillStpInfo;
 }
 
+bool TestTactic::isTacticFailing() noexcept {
+    return false;
+}
+
+bool TestTactic::shouldTacticReset() noexcept {
+    return false;
+}
+
 }  // namespace rtt::ai::stp

--- a/src/stp/new_tactics/TestTactic.cpp
+++ b/src/stp/new_tactics/TestTactic.cpp
@@ -37,11 +37,11 @@ StpInfo TestTactic::calculateInfoForSkill(StpInfo const& info) noexcept {
     return skillStpInfo;
 }
 
-bool TestTactic::isTacticFailing() noexcept {
+bool TestTactic::isTacticFailing(const StpInfo &info) noexcept {
     return false;
 }
 
-bool TestTactic::shouldTacticReset() noexcept {
+bool TestTactic::shouldTacticReset(const StpInfo &info) noexcept {
     return false;
 }
 


### PR DESCRIPTION
Failing conditions include:
- when does a tactic fail?
- when does a tactic reset?
- is the tactic an end tactic (can it succeed in the first place)?

Added checks in the update function for these situations