### PR TITLE
Basic tactic failing condition tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ set(TEST_SOURCES
         ${PROJECT_SOURCE_DIR}/test/World_newTests/WorldResetTests.cpp
         ${PROJECT_SOURCE_DIR}/test/StpTests/PlayCheckerTests.cpp
         ${PROJECT_SOURCE_DIR}/test/StpTests/PlayDeciderTests.cpp
+        ${PROJECT_SOURCE_DIR}/test/StpTests/TacticTests.cpp
         )
 
 

--- a/test/StpTests/TacticTests.cpp
+++ b/test/StpTests/TacticTests.cpp
@@ -40,6 +40,10 @@ public:
 };
 
 //TODO: nice to have, but too much for this: a before for each test case; see junit for details
+/** A non-end tactic will succeed when the state machine is finished.
+ * As the state machine is empty, this only implies that the tactic is not an end tactic.
+ */
+
 TEST(TacticTests, nonEndTacticFinishedSuccessful){
     MockTactic tactic;
     StpInfo info;
@@ -52,6 +56,10 @@ TEST(TacticTests, nonEndTacticFinishedSuccessful){
     ASSERT_EQ(rtt::ai::stp::Status::Success, result);
 }
 
+/** The tactic returns Failure if it didn't reach the end, and the failing condition is
+ * true. As the state machine is empty, this implies that this should be an end tactic
+ * (as it cannot succeed)
+ */
 TEST(TacticTests, endTacticFailingCondition){
     MockTactic tactic;
     StpInfo info;
@@ -71,6 +79,7 @@ TEST(TacticTests, endTacticFailingCondition){
     ASSERT_EQ(rtt::ai::stp::Status::Failure, result);
 }
 
+/// The tactic returns running if it's not an end tactic, and it didn't fail
 TEST(TacticTests, isTacticRunningSuccessful){
     MockTactic tactic;
     StpInfo info;

--- a/test/StpTests/TacticTests.cpp
+++ b/test/StpTests/TacticTests.cpp
@@ -1,0 +1,91 @@
+//
+// Created by ratoone on 12-03-20.
+//
+
+#include <stp/Tactic.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace rtt::ai::stp;
+
+class MockTactic : public Tactic{
+public:
+    StpInfo calculateInfoForSkill(const StpInfo &info) noexcept override {
+        return StpInfo();
+    }
+
+    void onInitialize() noexcept override {}
+
+    void onUpdate(const Status &status) noexcept override {}
+
+    void onTerminate() noexcept override {}
+
+    MOCK_METHOD1(isTacticFailingMock, bool(const StpInfo&));
+
+    bool isTacticFailing(const StpInfo &info) noexcept override {
+        return isTacticFailingMock(info);
+    }
+
+    MOCK_METHOD1(shouldTacticResetMock, bool(const StpInfo&));
+
+    bool shouldTacticReset(const StpInfo &info) noexcept override {
+        return shouldTacticResetMock(info);
+    }
+
+    MOCK_METHOD0(isEndTacticMock, bool());
+
+    bool isEndTactic() noexcept override {
+        return isEndTacticMock();
+    }
+};
+
+//TODO: nice to have, but too much for this: a before for each test case; see junit for details
+TEST(TacticTests, nonEndTacticFinishedSuccessful){
+    MockTactic tactic;
+    StpInfo info;
+    info.setBall(rtt::world_new::view::BallView(nullptr));
+    info.setField(rtt::ai::world::Field());
+    info.setRobot(rtt::world_new::view::RobotView(nullptr));
+
+    EXPECT_CALL(tactic, isEndTacticMock()).WillOnce(testing::Return(false));
+    auto result = tactic.update(info);
+    ASSERT_EQ(rtt::ai::stp::Status::Success, result);
+}
+
+TEST(TacticTests, endTacticFailingCondition){
+    MockTactic tactic;
+    StpInfo info;
+    info.setBall(rtt::world_new::view::BallView(nullptr));
+    info.setField(rtt::ai::world::Field());
+
+    proto::WorldRobot robot_proto;
+    robot_proto.set_id(1);
+    robot_proto.mutable_pos()->set_x(0.1);
+    std::unordered_map<uint8_t, proto::RobotFeedback> updateMap;
+    auto robot = rtt::world_new::robot::Robot(updateMap, robot_proto);
+    info.setRobot(rtt::world_new::view::RobotView(&robot));
+
+    EXPECT_CALL(tactic, isEndTacticMock()).WillOnce(testing::Return(true));
+    EXPECT_CALL(tactic, isTacticFailingMock(testing::_)).WillOnce(testing::Return(true));
+    auto result = tactic.update(info);
+    ASSERT_EQ(rtt::ai::stp::Status::Failure, result);
+}
+
+TEST(TacticTests, isTacticRunningSuccessful){
+    MockTactic tactic;
+    StpInfo info;
+    info.setBall(rtt::world_new::view::BallView(nullptr));
+    info.setField(rtt::ai::world::Field());
+
+    proto::WorldRobot robot_proto;
+    robot_proto.set_id(1);
+    robot_proto.mutable_pos()->set_x(0.1);
+    std::unordered_map<uint8_t, proto::RobotFeedback> updateMap;
+    auto robot = rtt::world_new::robot::Robot(updateMap, robot_proto);
+    info.setRobot(rtt::world_new::view::RobotView(&robot));
+
+    EXPECT_CALL(tactic, isEndTacticMock()).WillOnce(testing::Return(true));
+    EXPECT_CALL(tactic, isTacticFailingMock(testing::_)).WillOnce(testing::Return(false));
+    auto result = tactic.update(info);
+    ASSERT_EQ(rtt::ai::stp::Status::Running, result);
+}

--- a/test/UtilTests/RefereeTest.cpp
+++ b/test/UtilTests/RefereeTest.cpp
@@ -1,44 +1,44 @@
-////
-//// Created by mrlukasbos on 14-11-18.
-////
 //
-//#include <interface/api/Output.h>
-//#include <roboteam_proto/messages_robocup_ssl_referee.pb.h>
-//#include <include/roboteam_ai/world_new/World.hpp>
-//#include <test/helpers/WorldHelper.h>
-//#include <test/helpers/FieldHelper.h>
+// Created by mrlukasbos on 14-11-18.
 //
-//#include "gtest/gtest.h"
-//#include "utilities/GameStateManager.hpp"
-//
-//TEST(RefereeTest, it_gets_and_sets_the_ref) {
-//    auto world = testhelpers::WorldHelper::getWorldMsg(11, 11, false, testhelpers::FieldHelper::generateField());
-//    rtt::world_new::World::instance()->updateWorld(world);
-//    proto::SSL_Referee refereeData;
-//    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_KICKOFF_BLUE);
-//    rtt::ai::GameStateManager::setRefereeData(refereeData);
-//
-//    EXPECT_EQ(rtt::ai::GameStateManager::getRefereeData().command(), proto::SSL_Referee_Command_PREPARE_KICKOFF_BLUE);
-//
-//    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_KICKOFF_YELLOW);
-//    rtt::ai::GameStateManager::setRefereeData(refereeData);
-//
-//    EXPECT_EQ(rtt::ai::GameStateManager::getRefereeData().command(), proto::SSL_Referee_Command_PREPARE_KICKOFF_YELLOW);
-//
-//    // this is necessary for this following test to work properly since it listens to the interface
-//    rtt::ai::interface::Output::setUseRefereeCommands(true);
-//
-//    refereeData.set_stage(proto::SSL_Referee_Stage_PENALTY_SHOOTOUT);
-//    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_PENALTY_YELLOW);
-//    rtt::ai::GameStateManager::setRefereeData(refereeData);
-//
-//    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().strategyName, "time_out_strategy");
-//    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().keeperStrategyName, "keeper_penalty_prepare_tactic");
-//
-//    refereeData.set_stage(proto::SSL_Referee_Stage_PENALTY_SHOOTOUT);
-//    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_PENALTY_BLUE);
-//    rtt::ai::GameStateManager::setRefereeData(refereeData);
-//
-//    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().strategyName, "time_out_strategy");
-//    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().keeperStrategyName, "shootout_prepare_tactic");
-//}
+
+#include <interface/api/Output.h>
+#include <roboteam_proto/messages_robocup_ssl_referee.pb.h>
+#include <include/roboteam_ai/world_new/World.hpp>
+#include <test/helpers/WorldHelper.h>
+#include <test/helpers/FieldHelper.h>
+
+#include "gtest/gtest.h"
+#include "utilities/GameStateManager.hpp"
+
+TEST(RefereeTest, it_gets_and_sets_the_ref) {
+    auto world = testhelpers::WorldHelper::getWorldMsg(11, 11, false, testhelpers::FieldHelper::generateField());
+    rtt::world_new::World::instance()->updateWorld(world);
+    proto::SSL_Referee refereeData;
+    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_KICKOFF_BLUE);
+    rtt::ai::GameStateManager::setRefereeData(refereeData);
+
+    EXPECT_EQ(rtt::ai::GameStateManager::getRefereeData().command(), proto::SSL_Referee_Command_PREPARE_KICKOFF_BLUE);
+
+    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_KICKOFF_YELLOW);
+    rtt::ai::GameStateManager::setRefereeData(refereeData);
+
+    EXPECT_EQ(rtt::ai::GameStateManager::getRefereeData().command(), proto::SSL_Referee_Command_PREPARE_KICKOFF_YELLOW);
+
+    // this is necessary for this following test to work properly since it listens to the interface
+    rtt::ai::interface::Output::setUseRefereeCommands(true);
+
+    refereeData.set_stage(proto::SSL_Referee_Stage_PENALTY_SHOOTOUT);
+    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_PENALTY_YELLOW);
+    rtt::ai::GameStateManager::setRefereeData(refereeData);
+
+    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().strategyName, "time_out_strategy");
+    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().keeperStrategyName, "keeper_penalty_prepare_tactic");
+
+    refereeData.set_stage(proto::SSL_Referee_Stage_PENALTY_SHOOTOUT);
+    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_PENALTY_BLUE);
+    rtt::ai::GameStateManager::setRefereeData(refereeData);
+
+    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().strategyName, "time_out_strategy");
+    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().keeperStrategyName, "shootout_prepare_tactic");
+}

--- a/test/UtilTests/RefereeTest.cpp
+++ b/test/UtilTests/RefereeTest.cpp
@@ -1,44 +1,44 @@
+////
+//// Created by mrlukasbos on 14-11-18.
+////
 //
-// Created by mrlukasbos on 14-11-18.
+//#include <interface/api/Output.h>
+//#include <roboteam_proto/messages_robocup_ssl_referee.pb.h>
+//#include <include/roboteam_ai/world_new/World.hpp>
+//#include <test/helpers/WorldHelper.h>
+//#include <test/helpers/FieldHelper.h>
 //
-
-#include <interface/api/Output.h>
-#include <roboteam_proto/messages_robocup_ssl_referee.pb.h>
-#include <include/roboteam_ai/world_new/World.hpp>
-#include <test/helpers/WorldHelper.h>
-#include <test/helpers/FieldHelper.h>
-
-#include "gtest/gtest.h"
-#include "utilities/GameStateManager.hpp"
-
-TEST(RefereeTest, it_gets_and_sets_the_ref) {
-    auto world = testhelpers::WorldHelper::getWorldMsg(11, 11, false, testhelpers::FieldHelper::generateField());
-    rtt::world_new::World::instance()->updateWorld(world);
-    proto::SSL_Referee refereeData;
-    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_KICKOFF_BLUE);
-    rtt::ai::GameStateManager::setRefereeData(refereeData);
-
-    EXPECT_EQ(rtt::ai::GameStateManager::getRefereeData().command(), proto::SSL_Referee_Command_PREPARE_KICKOFF_BLUE);
-
-    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_KICKOFF_YELLOW);
-    rtt::ai::GameStateManager::setRefereeData(refereeData);
-
-    EXPECT_EQ(rtt::ai::GameStateManager::getRefereeData().command(), proto::SSL_Referee_Command_PREPARE_KICKOFF_YELLOW);
-
-    // this is necessary for this following test to work properly since it listens to the interface
-    rtt::ai::interface::Output::setUseRefereeCommands(true);
-
-    refereeData.set_stage(proto::SSL_Referee_Stage_PENALTY_SHOOTOUT);
-    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_PENALTY_YELLOW);
-    rtt::ai::GameStateManager::setRefereeData(refereeData);
-
-    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().strategyName, "time_out_strategy");
-    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().keeperStrategyName, "keeper_penalty_prepare_tactic");
-
-    refereeData.set_stage(proto::SSL_Referee_Stage_PENALTY_SHOOTOUT);
-    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_PENALTY_BLUE);
-    rtt::ai::GameStateManager::setRefereeData(refereeData);
-
-    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().strategyName, "time_out_strategy");
-    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().keeperStrategyName, "shootout_prepare_tactic");
-}
+//#include "gtest/gtest.h"
+//#include "utilities/GameStateManager.hpp"
+//
+//TEST(RefereeTest, it_gets_and_sets_the_ref) {
+//    auto world = testhelpers::WorldHelper::getWorldMsg(11, 11, false, testhelpers::FieldHelper::generateField());
+//    rtt::world_new::World::instance()->updateWorld(world);
+//    proto::SSL_Referee refereeData;
+//    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_KICKOFF_BLUE);
+//    rtt::ai::GameStateManager::setRefereeData(refereeData);
+//
+//    EXPECT_EQ(rtt::ai::GameStateManager::getRefereeData().command(), proto::SSL_Referee_Command_PREPARE_KICKOFF_BLUE);
+//
+//    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_KICKOFF_YELLOW);
+//    rtt::ai::GameStateManager::setRefereeData(refereeData);
+//
+//    EXPECT_EQ(rtt::ai::GameStateManager::getRefereeData().command(), proto::SSL_Referee_Command_PREPARE_KICKOFF_YELLOW);
+//
+//    // this is necessary for this following test to work properly since it listens to the interface
+//    rtt::ai::interface::Output::setUseRefereeCommands(true);
+//
+//    refereeData.set_stage(proto::SSL_Referee_Stage_PENALTY_SHOOTOUT);
+//    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_PENALTY_YELLOW);
+//    rtt::ai::GameStateManager::setRefereeData(refereeData);
+//
+//    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().strategyName, "time_out_strategy");
+//    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().keeperStrategyName, "keeper_penalty_prepare_tactic");
+//
+//    refereeData.set_stage(proto::SSL_Referee_Stage_PENALTY_SHOOTOUT);
+//    refereeData.set_command(proto::SSL_Referee_Command_PREPARE_PENALTY_BLUE);
+//    rtt::ai::GameStateManager::setRefereeData(refereeData);
+//
+//    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().strategyName, "time_out_strategy");
+//    EXPECT_EQ(rtt::ai::GameStateManager::getCurrentGameState().keeperStrategyName, "shootout_prepare_tactic");
+//}


### PR DESCRIPTION
As the tactic says. The state machine reset tests are not implemented though, as they should be performed directly on the state machine