### PR TITLE
Fixed a bug that caused some tests to randomly fail

### DIFF
--- a/test/UtilTests/DealerTest.cpp
+++ b/test/UtilTests/DealerTest.cpp
@@ -25,7 +25,7 @@ class DealerTest : public ::testing::Test {
           amountYellow = 3;
           amountBlue = 1;
       }
-      auto protoWorld = testhelpers::WorldHelper::getWorldMsg(amountYellow, amountBlue, false, testhelpers::FieldHelper::generateField());
+      auto protoWorld = testhelpers::WorldHelper::getWorldMsg(amountYellow, amountBlue, true, testhelpers::FieldHelper::generateField());
       world_new::World::instance()->updateWorld(protoWorld);
   }
 };

--- a/test/UtilTests/RefereeTest.cpp
+++ b/test/UtilTests/RefereeTest.cpp
@@ -12,7 +12,7 @@
 #include "utilities/GameStateManager.hpp"
 
 TEST(RefereeTest, it_gets_and_sets_the_ref) {
-    auto world = testhelpers::WorldHelper::getWorldMsg(11, 11, false, testhelpers::FieldHelper::generateField());
+    auto world = testhelpers::WorldHelper::getWorldMsg(11, 11, true, testhelpers::FieldHelper::generateField());
     rtt::world_new::World::instance()->updateWorld(world);
     proto::SSL_Referee refereeData;
     refereeData.set_command(proto::SSL_Referee_Command_PREPARE_KICKOFF_BLUE);

--- a/test/World_newTests/WorldResetTests.cpp
+++ b/test/World_newTests/WorldResetTests.cpp
@@ -11,7 +11,7 @@ TEST(World_newTest, GenericWorldRemoval) {
     namespace w_n = rtt::world_new;
     proto::GeometryFieldSize size {};
     size.set_field_length(250);
-    auto msg = testhelpers::WorldHelper::getWorldMsg(5, 7, false, size);
+    auto msg = testhelpers::WorldHelper::getWorldMsg(5, 7, true, size);
     auto second = msg;
     w_n::World::instance()->reset();
     w_n::World::instance()->updateWorld(msg);
@@ -27,7 +27,7 @@ TEST(World_newTest, HistorySizeTest) {
     namespace w_n = rtt::world_new;
     proto::GeometryFieldSize size {};
     size.set_field_length(250);
-    auto msg = testhelpers::WorldHelper::getWorldMsg(5, 7, false, size);
+    auto msg = testhelpers::WorldHelper::getWorldMsg(5, 7, true, size);
     auto second = msg;
     w_n::World::instance()->reset();
     w_n::World::instance()->updateWorld(msg);
@@ -43,7 +43,7 @@ TEST(World_newTest, ResetWorldTest) {
     namespace w_n = rtt::world_new;
     proto::GeometryFieldSize size {};
     size.set_field_length(250);
-    auto msg = testhelpers::WorldHelper::getWorldMsg(5, 7, false, size);
+    auto msg = testhelpers::WorldHelper::getWorldMsg(5, 7, true, size);
     auto second = msg;
     w_n::World::instance()->reset();
     w_n::World::instance()->updateWorld(msg);

--- a/test/helpers/WorldHelper.cpp
+++ b/test/helpers/WorldHelper.cpp
@@ -157,19 +157,16 @@ google::protobuf::RepeatedPtrField<proto::WorldRobot> WorldHelper::generateRando
 proto::World WorldHelper::getWorldMsg(int amountYellow, int amountBlue, bool withBall, const proto::GeometryFieldSize &field) {
     proto::World msg;
 
-
-    auto randomBall = generateRandomBall(field);
-    auto randomYellow = generateRandomRobots(amountYellow, field);
-    auto randomBlue = generateRandomRobots(amountBlue, field);
-
+    // Generate random robots and a ball and check if none are colliding
+    // If there is a collision, generate new random robots
     do {
+        auto randomBall = generateRandomBall(field);
+        auto randomYellow = generateRandomRobots(amountYellow, field);
+        auto randomBlue = generateRandomRobots(amountBlue, field);
+
         msg.mutable_yellow()->CopyFrom(randomYellow);
         msg.mutable_blue()->CopyFrom(randomBlue);
-
-        if (withBall) {
-            std::cerr << "[WorldHelper] Caution: generating a world with a ball is not stable!" << std::endl;
-            msg.set_allocated_ball(randomBall);
-        }
+        msg.set_allocated_ball(randomBall);
     } while (!allPositionsAreValid(msg, withBall));
 
     return msg;

--- a/test/helpers/WorldHelper.cpp
+++ b/test/helpers/WorldHelper.cpp
@@ -1,11 +1,11 @@
-#include <random>
+#include "WorldHelper.h"
+
+#include <include/roboteam_ai/utilities/Constants.h>
 #include <roboteam_proto/World.pb.h>
 #include <roboteam_proto/WorldRobot.pb.h>
 #include <roboteam_utils/Vector2.h>
-#include <include/roboteam_ai/utilities/Constants.h>
-#include "WorldHelper.h"
 
-
+#include <random>
 
 namespace testhelpers {
 
@@ -79,7 +79,7 @@ bool WorldHelper::allPositionsAreValid(const proto::World &worldMsg, bool withBa
 /*
  * Generate a robot on a random position
  */
-proto::WorldRobot * WorldHelper::generateRandomRobot(int id, proto::GeometryFieldSize field) {
+proto::WorldRobot *WorldHelper::generateRandomRobot(int id, proto::GeometryFieldSize field) {
     auto randomFieldPos = getRandomFieldPosition(std::move(field));
     auto randomVel = getRandomVelocity();
 
@@ -97,7 +97,7 @@ proto::WorldRobot * WorldHelper::generateRandomRobot(int id, proto::GeometryFiel
 /*
  * Generate a ball at a random position
  */
-proto::WorldBall * WorldHelper::generateRandomBall(proto::GeometryFieldSize field) {
+proto::WorldBall *WorldHelper::generateRandomBall(proto::GeometryFieldSize field) {
     auto randomFieldPos = getRandomFieldPosition(std::move(field));
     auto randomVel = getRandomVelocity();
 

--- a/test/helpers/WorldHelper.cpp
+++ b/test/helpers/WorldHelper.cpp
@@ -166,7 +166,8 @@ proto::World WorldHelper::getWorldMsg(int amountYellow, int amountBlue, bool wit
 
         msg.mutable_yellow()->CopyFrom(randomYellow);
         msg.mutable_blue()->CopyFrom(randomBlue);
-        msg.set_allocated_ball(randomBall);
+
+        if (withBall) msg.set_allocated_ball(randomBall);
     } while (!allPositionsAreValid(msg, withBall));
 
     return msg;


### PR DESCRIPTION
Fixes a really annoying problem with tests randomly failing. The randomly generated robots are checked for colliding positions, but when there was a collision, the robots were never re-generated which means they will always have colliding positions because the positions stayed the same.

I also re-enabled the ball-flags in the tests that used those, since the ball was never the problem.

Closes #909 