### PR TITLE
Reset state machines of role and tactics

### DIFF
--- a/include/roboteam_ai/stp/Tactic.h
+++ b/include/roboteam_ai/stp/Tactic.h
@@ -100,10 +100,9 @@ class Tactic {
     Tactic(Tactic &&other) = default;
 
     /**
-     * Returns the skills state machine
-     * @return Skills state machine
+     * Reset the state machine
      */
-    rtt::collections::state_machine<Skill, Status, StpInfo> & getSkills() { return skills; };
+    void reset() noexcept;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/Tactic.h
+++ b/include/roboteam_ai/stp/Tactic.h
@@ -98,6 +98,12 @@ class Tactic {
      * Default move-ctor, ensures proper move-construction of Tactic
      */
     Tactic(Tactic &&other) = default;
+
+    /**
+     * Returns the skills state machine
+     * @return Skills state machine
+     */
+    rtt::collections::state_machine<Skill, Status, StpInfo> & getSkills() { return skills; };
 };
 }  // namespace rtt::ai::stp
 

--- a/src/stp/Role.cpp
+++ b/src/stp/Role.cpp
@@ -23,8 +23,8 @@ Status Role::update(StpInfo const& info) noexcept {
     if (robotTactics.current_num() != 0 && shouldRoleReset(tacticInfo)) {
         RTT_INFO("State Machine reset for current role for ID = ", tacticInfo.getRobot()->get()->getId())
         // Reset all the Tactics state machines
-        for (auto tactics = robotTactics.begin(); tactics < robotTactics.end(); tactics++) {
-            tactics->get()->getSkills().reset();
+        for (auto& tactic : robotTactics) {
+            tactic->getSkills().reset();
         }
         // Reset Role state machine
         robotTactics.reset();

--- a/src/stp/Role.cpp
+++ b/src/stp/Role.cpp
@@ -16,15 +16,21 @@ Status Role::update(StpInfo const& info) noexcept {
         return Status::Success;
     }
 
-    // Reset the role
-    if (robotTactics.current_num() != 0 && shouldRoleReset(info)) {
-        RTT_INFO("State Machine reset for current role for ID = ", info.getRobot()->get()->getId())
-        // TODO: messy reset, do it in the state machine
-        robotTactics.skip_n(-robotTactics.current_num());
-    }
-
     // Update tactic info
     auto tacticInfo = calculateInfoForTactic(info);
+
+    // Reset the role
+    if (robotTactics.current_num() != 0 && shouldRoleReset(tacticInfo)) {
+        RTT_INFO("State Machine reset for current role for ID = ", tacticInfo.getRobot()->get()->getId())
+        // Reset all the Tactics state machines
+        robotTactics.reset();
+        while (robotTactics.current_num() != robotTactics.total_count()) {
+            robotTactics.get_current()->getSkills().reset();
+            robotTactics.skip_n(1);
+        }
+        // Reset Role state machine
+        robotTactics.reset();
+    }
 
     // Update the state machine of tactics with the TacticInfo from Play
     return robotTactics.update(tacticInfo);

--- a/src/stp/Role.cpp
+++ b/src/stp/Role.cpp
@@ -24,7 +24,7 @@ Status Role::update(StpInfo const& info) noexcept {
         RTT_INFO("State Machine reset for current role for ID = ", tacticInfo.getRobot()->get()->getId())
         // Reset all the Tactics state machines
         for (auto& tactic : robotTactics) {
-            tactic->getSkills().reset();
+            tactic->reset();
         }
         // Reset Role state machine
         robotTactics.reset();

--- a/src/stp/Role.cpp
+++ b/src/stp/Role.cpp
@@ -23,10 +23,8 @@ Status Role::update(StpInfo const& info) noexcept {
     if (robotTactics.current_num() != 0 && shouldRoleReset(tacticInfo)) {
         RTT_INFO("State Machine reset for current role for ID = ", tacticInfo.getRobot()->get()->getId())
         // Reset all the Tactics state machines
-        robotTactics.reset();
-        while (robotTactics.current_num() != robotTactics.total_count()) {
-            robotTactics.get_current()->getSkills().reset();
-            robotTactics.skip_n(1);
+        for (auto tactics = robotTactics.begin(); tactics < robotTactics.end(); tactics++) {
+            tactics->get()->getSkills().reset();
         }
         // Reset Role state machine
         robotTactics.reset();

--- a/src/stp/Tactic.cpp
+++ b/src/stp/Tactic.cpp
@@ -30,16 +30,15 @@ Status Tactic::update(StpInfo const &info) noexcept {
         return Status::Failure;
     }
 
-    // the tactic will not be reset if it's the first skill; it will be reset as well if the
-    // state machine is finished
-    if(skills.finished() || (skills.current_num() != 0 && shouldTacticReset(info))){
-        RTT_INFO("State Machine reset for current tactic for ID = ", info.getRobot()->get()->getId())
-        // TODO: messy reset, do it in the state machine
-        skills.skip_n(- skills.current_num());
-    }
-
     // Update skill info
     auto skill_info = calculateInfoForSkill(info);
+
+    // the tactic will not be reset if it's the first skill; it will be reset as well if the
+    // state machine is finished
+    if(skills.finished() || (skills.current_num() != 0 && shouldTacticReset(skill_info))){
+        RTT_INFO("State Machine reset for current tactic for ID = ", skill_info.getRobot()->get()->getId())
+        skills.reset();
+    }
 
     // Update the current skill with the new SkillInfo
     auto status = skills.update(skill_info);

--- a/src/stp/Tactic.cpp
+++ b/src/stp/Tactic.cpp
@@ -37,7 +37,7 @@ Status Tactic::update(StpInfo const &info) noexcept {
     // state machine is finished
     if(skills.finished() || (skills.current_num() != 0 && shouldTacticReset(skill_info))){
         RTT_INFO("State Machine reset for current tactic for ID = ", skill_info.getRobot()->get()->getId())
-        skills.reset();
+        reset();
     }
 
     // Update the current skill with the new SkillInfo
@@ -51,5 +51,9 @@ Status Tactic::update(StpInfo const &info) noexcept {
 }
 
 void Tactic::terminate() noexcept { onTerminate(); }
+
+void Tactic::reset() noexcept {
+    skills.reset();
+}
 
 }  // namespace rtt::ai::stp


### PR DESCRIPTION
Reset all tactics state machines when resetting role. This fixes the problem of tactics being successful immediately after the first time.