### PR TITLE
Fixed bug std::out_of_range when a controller disconnects

### DIFF
--- a/src/manual/JoystickManager.cpp
+++ b/src/manual/JoystickManager.cpp
@@ -105,7 +105,10 @@ void JoystickManager::loop() {
             iEvents++;
 
             /* PANIC BUTTON! STOP EVERYTHING! */
-            if (joystickHandlers.at(event.jdevice.which)->getJoystickState().XBOX) std::terminate();
+            // Prevent std::out_of_range in joystickHandlers when handler was removed in handleEvent()
+            if(joystickHandlers.count(event.jdevice.which) == 1)
+                if (joystickHandlers.at(event.jdevice.which)->getJoystickState().XBOX)
+                    std::terminate();
 
             /* Check if there is time for another event, of if it is time for the next tick */
             msToNextTick = (int)duration_cast<milliseconds>(tTickNext - steady_clock::now()).count();


### PR DESCRIPTION
line 104 : `handleEvent(event);` <- removes joystickHandler from map
line 110 : `joystickHandlers.at(event.jdevice.which)` <- tries to get from the map the joystickHandler that was just removed <- segfault

fix:
line 109 `if(joystickHandlers.count(event.jdevice.which) == 1)` <- check if joystickHandler is in map

Fix might be slightly inefficient, but lookup time of count() is O(N) and N is never larger than 4, so...