### PR TITLE
Fixed publish robot command issue, first limit, then rotate.

### DIFF
--- a/src/stp/Skill.cpp
+++ b/src/stp/Skill.cpp
@@ -21,11 +21,11 @@ void Skill::rotateRobotCommand() noexcept {
 }
 
 void Skill::publishRobotCommand() noexcept {
+    limitRobotCommand();
+
     if (!SETTINGS.isLeft()) {
         rotateRobotCommand();
     }
-
-    limitRobotCommand();
 
     if (std::isnan(command.vel().x()) || std::isnan(command.vel().y())) {
         RTT_ERROR("x or y vel in command is NaN in skill" + std::string{getName()} + "!\nRobot: " + std::to_string(robot.value()->getId()));


### PR DESCRIPTION
The robot command previously was rotated first, and then limited. This way, the limiting happens in the wrong direction which changes the behaviour. Now, first the command is limited and then rotated.
Closes #993 