### PR TITLE
Implemented distance from ball invariant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ set(INVARIANTS_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/invariants/BallGotShotInvariant.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/invariants/BallMovesSlowInvariant.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/invariants/BallOnOurSideInvariant.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/invariants/DistanceFromBallInvariant.cpp
         )
 
 set(CONTROL_SOURCES

--- a/include/roboteam_ai/stp/invariants/DistanceFromBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/DistanceFromBallInvariant.h
@@ -1,0 +1,34 @@
+//
+// Created by timovdk on 4/21/20.
+//
+
+#ifndef RTT_DISTANCEFROMBALLINVARIANT_H
+#define RTT_DISTANCEFROMBALLINVARIANT_H
+
+#include <NFParam/Param.h>
+
+#include "BaseInvariant.h"
+
+namespace rtt::ai::stp::invariant {
+class DistanceFromBallInvariant : public BaseInvariant {
+   public:
+    DistanceFromBallInvariant() noexcept;
+
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+
+   private:
+    /**
+     * Calculates the actual metric value using the piecewise linear function member
+     * @param x the x of the function
+     * @return metric value between 0-255
+     */
+    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+
+    /**
+     * Unique pointer to the piecewise linear function that calculates the fuzzy value
+     */
+    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+};
+}  // namespace rtt::ai::stp::invariant
+
+#endif  // RTT_DISTANCEFROMBALLINVARIANT_H

--- a/include/roboteam_ai/stp/new_constants/ControlConstants.h
+++ b/include/roboteam_ai/stp/new_constants/ControlConstants.h
@@ -27,6 +27,7 @@ extern const double BALL_STILL_VEL;
 extern const double BALL_IS_MOVING_VEL;
 extern const double BALL_GOT_SHOT_LIMIT;
 extern const double BALL_IS_MOVING_SLOW_LIMIT;
+extern const double BALL_IS_CLOSE;
 extern const double BALL_RADIUS;
 extern const double HAS_KICKED_ERROR_MARGIN;
 extern const double HAS_CHIPPED_ERROR_MARGIN;

--- a/src/stp/invariants/DistanceFromBallInvariant.cpp
+++ b/src/stp/invariants/DistanceFromBallInvariant.cpp
@@ -26,7 +26,7 @@ uint8_t DistanceFromBallInvariant::metricCheck(world_new::view::WorldDataView wo
     auto& us = world.getUs();
     auto ballPos = world.getBall()->get()->getPos();
     std::vector<double> distanceMetrics{};
-    distanceMetrics.reserve(control_constants::MAX_ROBOT_COUNT);
+    distances.reserve(control_constants::MAX_ROBOT_COUNT);
 
     std::transform(us.begin(), us.end(), std::back_inserter(distanceMetrics), [&](auto& robot) { return robot.get()->getPos().dist(ballPos); });
 

--- a/src/stp/invariants/DistanceFromBallInvariant.cpp
+++ b/src/stp/invariants/DistanceFromBallInvariant.cpp
@@ -16,10 +16,10 @@ DistanceFromBallInvariant::DistanceFromBallInvariant() noexcept {
      *   (0,0)  |----------------XXXXXXX
      *              (Distance to Ball)
      */
-    piecewiseLinearFunction = nativeformat::param::createParam(0, 255, 0, "testParam");
-    piecewiseLinearFunction->setYAtX(255, 0.0);
-    piecewiseLinearFunction->linearRampToYAtX(0, stp::control_constants::BALL_IS_CLOSE * 4 + stp::control_constants::FUZZY_MARGIN);
-    piecewiseLinearFunction->setYAtX(0, stp::control_constants::BALL_IS_CLOSE * 4 + stp::control_constants::FUZZY_MARGIN);
+    piecewiseLinearFunction = nativeformat::param::createParam(control_constants::FUZZY_FALSE, control_constants::FUZZY_TRUE, control_constants::FUZZY_FALSE, "distanceFromBall");
+    piecewiseLinearFunction->setYAtX(control_constants::FUZZY_TRUE, 0.0);
+    piecewiseLinearFunction->linearRampToYAtX(control_constants::FUZZY_FALSE, stp::control_constants::BALL_IS_CLOSE * 4 + stp::control_constants::FUZZY_MARGIN);
+    piecewiseLinearFunction->setYAtX(control_constants::FUZZY_FALSE, stp::control_constants::BALL_IS_CLOSE * 4 + stp::control_constants::FUZZY_MARGIN);
 }
 
 uint8_t DistanceFromBallInvariant::metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept {

--- a/src/stp/invariants/DistanceFromBallInvariant.cpp
+++ b/src/stp/invariants/DistanceFromBallInvariant.cpp
@@ -25,12 +25,12 @@ DistanceFromBallInvariant::DistanceFromBallInvariant() noexcept {
 uint8_t DistanceFromBallInvariant::metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept {
     auto& us = world.getUs();
     auto ballPos = world.getBall()->get()->getPos();
-    std::vector<double> distanceMetrics{};
+    std::vector<double> distances{};
     distances.reserve(control_constants::MAX_ROBOT_COUNT);
 
-    std::transform(us.begin(), us.end(), std::back_inserter(distanceMetrics), [&](auto& robot) { return robot.get()->getPos().dist(ballPos); });
+    std::transform(us.begin(), us.end(), std::back_inserter(distances), [&](auto& robot) { return robot.get()->getPos().dist(ballPos); });
 
-    return calculateMetric(*std::min_element(distanceMetrics.begin(), distanceMetrics.end()));
+    return calculateMetric(*std::min_element(distances.begin(), distances.end()));
 }
 
 uint8_t DistanceFromBallInvariant::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }

--- a/src/stp/invariants/DistanceFromBallInvariant.cpp
+++ b/src/stp/invariants/DistanceFromBallInvariant.cpp
@@ -26,6 +26,7 @@ uint8_t DistanceFromBallInvariant::metricCheck(world_new::view::WorldDataView wo
     auto& us = world.getUs();
     auto ballPos = world.getBall()->get()->getPos();
     std::vector<double> distanceMetrics{};
+    distanceMetrics.reserve(control_constants::MAX_ROBOT_COUNT);
 
     std::transform(us.begin(), us.end(), std::back_inserter(distanceMetrics), [&](auto& robot) { return robot.get()->getPos().dist(ballPos); });
 

--- a/src/stp/invariants/DistanceFromBallInvariant.cpp
+++ b/src/stp/invariants/DistanceFromBallInvariant.cpp
@@ -1,0 +1,36 @@
+//
+// Created by timovdk on 4/21/20.
+//
+
+#include "stp/invariants/DistanceFromBallInvariant.h"
+
+namespace rtt::ai::stp::invariant {
+DistanceFromBallInvariant::DistanceFromBallInvariant() noexcept {
+    /**
+     * Creates a piecewise linear function that looks as follows:
+     *
+     * (0,255)  |XX
+     *          | XXXXXX
+     *          |      XXXXXX
+     *          |           XXXXXX
+     *   (0,0)  |----------------XXXXXXX
+     *              (Distance to Ball)
+     */
+    piecewiseLinearFunction = nativeformat::param::createParam(0, 255, 0, "testParam");
+    piecewiseLinearFunction->setYAtX(255, 0.0);
+    piecewiseLinearFunction->linearRampToYAtX(0, stp::control_constants::BALL_IS_CLOSE * 4 + stp::control_constants::FUZZY_MARGIN);
+    piecewiseLinearFunction->setYAtX(0, stp::control_constants::BALL_IS_CLOSE * 4 + stp::control_constants::FUZZY_MARGIN);
+}
+
+uint8_t DistanceFromBallInvariant::metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept {
+    auto& us = world.getUs();
+    auto ballPos = world.getBall()->get()->getPos();
+    std::vector<double> distanceMetrics{};
+
+    std::transform(us.begin(), us.end(), std::back_inserter(distanceMetrics), [&](auto& robot) { return robot.get()->getPos().dist(ballPos); });
+
+    return calculateMetric(*std::min_element(distanceMetrics.begin(), distanceMetrics.end()));
+}
+
+uint8_t DistanceFromBallInvariant::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }
+}  // namespace rtt::ai::stp::invariant

--- a/src/stp/new_constants/ControlConstants.cpp
+++ b/src/stp/new_constants/ControlConstants.cpp
@@ -24,6 +24,7 @@ constexpr double BALL_STILL_VEL = 0.1;
 constexpr double BALL_IS_MOVING_VEL = 0.5;
 constexpr double BALL_GOT_SHOT_LIMIT = 1.5;
 constexpr double BALL_IS_MOVING_SLOW_LIMIT = 0.5;
+constexpr double BALL_IS_CLOSE = 0.5;
 constexpr double BALL_RADIUS = 0.0215;
 constexpr double HAS_KICKED_ERROR_MARGIN = 0.4;
 constexpr double HAS_CHIPPED_ERROR_MARGIN = 0.4;


### PR DESCRIPTION
Returns 0-255 for the closest robot to a ball. The values 0-255 relate to a difference in distance of 0-2 meters (so fuzzy value 127 is 1 meter distance from the ball). This relation between fuzzy value and distance still needs to be tweaked.
closes #1020 