### PR TITLE
Resetting all roles when re-dealing roles

### DIFF
--- a/include/roboteam_ai/stp/Role.hpp
+++ b/include/roboteam_ai/stp/Role.hpp
@@ -55,6 +55,11 @@ public:
     */
     void forceNextTactic() noexcept;
 
+    /**
+     * Resets the tactics, skills and robot of this role so re-dealing of robots works as expected
+     */
+    void reset() noexcept;
+
 protected:
     /**
      * Robot to which this role is currently assigned

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -96,6 +96,7 @@ void Play::distributeRoles() noexcept {
 
     stpInfos = std::unordered_map<std::string, StpInfo>{};
     for (auto& role : roles) {
+        role->reset();
         auto roleName{role->getName()};
         if (distribution.find(roleName) != distribution.end()) {
             auto robot = distribution.find(role->getName())->second;

--- a/src/stp/Role.cpp
+++ b/src/stp/Role.cpp
@@ -63,7 +63,7 @@ Tactic * Role::getCurrentTactic() {
 void Role::reset() noexcept {
     currentRobot.reset();
 
-    // Reset all skills
+    // Reset all tactics
     for (auto& tactic : robotTactics) {
         tactic->reset();
     }

--- a/src/stp/Role.cpp
+++ b/src/stp/Role.cpp
@@ -60,4 +60,15 @@ Tactic * Role::getCurrentTactic() {
     return robotTactics.get_current();
 }
 
+void Role::reset() noexcept {
+    currentRobot.reset();
+
+    // Reset all skills
+    for (auto& tactic : robotTactics) {
+        tactic->reset();
+    }
+    // Reset Tactics state machine
+    robotTactics.reset();
+}
+
 }  // namespace rtt::ai::stp


### PR DESCRIPTION
Roles now reset the currentRobot (for interface), tactics and the skills.
closes #1084 