### PR TITLE
Fix/pass with chip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ set(NEW_TACTICS_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/new_tactics/BlockRobot.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/new_tactics/Receive.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/new_tactics/ChipAtPos.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/new_tactics/ShootAtPos.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/new_tactics/Intercept.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/new_tactics/Halt.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/new_constants/ControlConstants.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ set(NEW_SKILLS_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/new_skills/Chip.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/new_skills/Rotate.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/new_skills/GoToPos.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/new_skills/Shoot.cpp
         )
 
 set(NEW_TACTICS_SOURCES
@@ -134,7 +135,7 @@ set(NEW_PLAYS_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/new_plays/GetBallPossession.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/new_plays/FreeKickThem.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/new_plays/GetBallRisky.cpp
-         ${PROJECT_SOURCE_DIR}/src/stp/new_plays/ReflectKick.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/new_plays/ReflectKick.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/new_plays/GenericPass.cpp
         )
 

--- a/include/roboteam_ai/control/ControlUtils.h
+++ b/include/roboteam_ai/control/ControlUtils.h
@@ -5,10 +5,13 @@
 #ifndef ROBOTEAM_AI_CONTROLUTILS_H
 #define ROBOTEAM_AI_CONTROLUTILS_H
 
+#include <stp/StpInfo.h>
 #include <roboteam_utils/Arc.h>
 #include <roboteam_utils/Line.h>
+
 #include <cmath>
 #include <optional>
+
 #include "utilities/Constants.h"
 #include "world/Field.h"
 #include "world/FieldComputations.h"
@@ -49,6 +52,22 @@ namespace rtt::ai {
             static Vector2 projectPositionToWithinField(const world::Field &field, Vector2 position, double margin);
 
             static Vector2 projectPositionToOutsideDefenseArea(const world::Field &field, Vector2 position, double margin);
+
+            /**
+             * Determines the chip force based on the distance and the type of chip
+             * @param distance distance to the target
+             * @param desiredBallSpeedType type of the chip
+             * @return a chip speed between min and max chip speed
+             */
+            static double determineChipForce(const double distance, stp::KickChipType desiredBallSpeedType) noexcept;
+
+            /**
+             * Determines the kick force based on the distance and the type of kick
+             * @param distance distance to the target
+             * @param desiredBallSpeedType type of the kick
+             * @return a kick speed between min and max kick speed
+             */
+            static double determineKickForce(const double distance, stp::KickChipType desiredBallSpeedType) noexcept;
         };
 
     }  // namespace control

--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -121,6 +121,7 @@ struct StpInfo {
     const std::optional<KickChip> &getShootType() const { return shootType; }
 
     void setShootType(const std::optional<KickChip> &shootType) { StpInfo::shootType = shootType; }
+    
    private:
     /**
      * Robot this tactic applies to
@@ -192,7 +193,6 @@ struct StpInfo {
      * Set the shot to be a kick or chip
      */
     std::optional<KickChip> shootType;
-
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -75,6 +75,7 @@ struct Areas {
 const int blockLength = 3; // The number of elements in the blockdistance enum
 enum BlockDistance { CLOSE = 1, HALFWAY, FAR }; // If you change this be sure to change blocklength also
 enum KickChipType { PASS, TARGET, MAX };
+enum KickChip {KICK, CHIP};
 
 struct StpInfo {
    public:
@@ -117,7 +118,9 @@ struct StpInfo {
     const std::optional<double> &getAvoidBallDistance() const { return avoidBallDistance; }
     void setAvoidBallDistance(const std::optional<double> &avoidBallDistance) { this->avoidBallDistance = avoidBallDistance; }
 
+    const std::optional<KickChip> &getShootType() const { return shootType; }
 
+    void setShootType(const std::optional<KickChip> &shootType) { StpInfo::shootType = shootType; }
    private:
     /**
      * Robot this tactic applies to
@@ -184,6 +187,12 @@ struct StpInfo {
      * When avoiding the ball, the robot will try to keep this distance (in meters) between the ball and the robot)
      */
     std::optional<double> avoidBallDistance;
+
+    /**
+     * Set the shot to be a kick or chip
+     */
+    std::optional<KickChip> shootType;
+
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/new_plays/AttackingPass.h
+++ b/include/roboteam_ai/stp/new_plays/AttackingPass.h
@@ -51,12 +51,16 @@ class AttackingPass : public Play {
      */
     const char* getName() override;
 
-    [[nodiscard]] bool isValidPlayToKeep(world_new::World *world) noexcept override;
+    [[nodiscard]] bool isValidPlayToKeep(world_new::World* world) noexcept override;
 
    protected:
     bool shouldRoleSkipEndTactic() override;
 
-    Vector2 calculatePassLocation();
+    /**
+     * Calculates the pass location
+     * @return the pass location
+     */
+    const Vector2 calculatePassLocation() noexcept;
 
    private:
     [[nodiscard]] bool passFinished() noexcept;

--- a/include/roboteam_ai/stp/new_plays/GenericPass.h
+++ b/include/roboteam_ai/stp/new_plays/GenericPass.h
@@ -46,7 +46,7 @@ class GenericPass : public Play {
      * Calculates the pass location
      * @return the pass location
      */
-    const Vector2 calculatePassLocation() const noexcept;
+    const Vector2 calculatePassLocation() noexcept;
 
     [[nodiscard]] bool isValidPlayToKeep(world_new::World *world) noexcept override;
 

--- a/include/roboteam_ai/stp/new_skills/Shoot.h
+++ b/include/roboteam_ai/stp/new_skills/Shoot.h
@@ -1,0 +1,41 @@
+//
+// Created by rtt-vision on 23-06-20.
+//
+
+#ifndef RTT_SHOOT_H
+#define RTT_SHOOT_H
+
+
+#include "include/roboteam_ai/stp/Skill.h"
+
+namespace rtt::ai::stp::skill {
+
+    class Shoot : public Skill {
+        /**
+         * On initialize of this tactic
+         */
+        void onInitialize() noexcept override;
+
+        /**
+         * On update of this tactic
+         */
+        Status onUpdate(StpInfo const& info) noexcept override;
+
+        Status onUpdateChip(StpInfo const& info) noexcept;
+
+        Status onUpdateKick(StpInfo const& info) noexcept;
+
+        /**
+         * On terminate of this tactic
+         */
+        void onTerminate() noexcept override;
+
+        /**
+         * Gets the skill name
+         */
+        const char *getName() override;
+    };
+
+}  // namespace rtt::ai::stp::skill
+
+#endif //RTT_SHOOT_H

--- a/include/roboteam_ai/stp/new_skills/Shoot.h
+++ b/include/roboteam_ai/stp/new_skills/Shoot.h
@@ -1,12 +1,11 @@
 //
-// Created by rtt-vision on 23-06-20.
+// Created by Jesse on 23-06-20.
 //
 
 #ifndef RTT_SHOOT_H
 #define RTT_SHOOT_H
 
-
-#include "include/roboteam_ai/stp/Skill.h"
+#include "stp/Skill.h"
 
 namespace rtt::ai::stp::skill {
 

--- a/include/roboteam_ai/stp/new_skills/Shoot.h
+++ b/include/roboteam_ai/stp/new_skills/Shoot.h
@@ -21,6 +21,11 @@ namespace rtt::ai::stp::skill {
          */
         Status onUpdate(StpInfo const& info) noexcept override;
 
+        /**
+         * Calculate skillInfo based on whether the desired behaviour of the skill is a kick or a chip
+         * @param info
+         * @return
+         */
         Status onUpdateChip(StpInfo const& info) noexcept;
 
         Status onUpdateKick(StpInfo const& info) noexcept;

--- a/include/roboteam_ai/stp/new_tactics/ChipAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/ChipAtPos.h
@@ -36,14 +36,6 @@ class ChipAtPos : public Tactic {
      */
     std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * Calculate the chipforce for the skill
-     * @param distance distance to the target
-     * @param desiredBallSpeedType type of the chip
-     * @return the speed the chipper needs to chip at
-     */
-    double determineChipForce(double distance, KickChipType desiredBallSpeedType) noexcept;
-
     bool isEndTactic() noexcept override;
 
     bool isTacticFailing(const StpInfo &info) noexcept override;

--- a/include/roboteam_ai/stp/new_tactics/KickAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/KickAtPos.h
@@ -36,14 +36,6 @@ class KickAtPos : public Tactic {
      */
     std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * Calculate the kickforce for the skill
-     * @param distance distance to the target
-     * @param desiredBallSpeedType type of the kick
-     * @return the speed the kicker needs to kick at
-     */
-    double determineKickForce(double distance, KickChipType desiredBallSpeedType) noexcept;
-
     bool isEndTactic() noexcept override;
 
     bool isTacticFailing(const StpInfo &info) noexcept override;

--- a/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
@@ -1,0 +1,69 @@
+//
+// Created by rtt-vision on 23-06-20.
+//
+
+#ifndef RTT_SHOOTATPOS_H
+#define RTT_SHOOTATPOS_H
+
+
+
+#include "include/roboteam_ai/stp/Tactic.h"
+
+namespace rtt::ai::stp::tactic {
+
+    class ShootAtPos : public Tactic {
+    public:
+        ShootAtPos();
+
+    private:
+        /**
+         * On initialization of this tactic, initialize the state machine with skills
+         */
+        void onInitialize() noexcept override;
+
+        /**
+         * On update of this tactic
+         */
+        void onUpdate(Status const &status) noexcept override;
+
+        /**
+         * On terminate of this tactic, call terminate on all underlying skills
+         */
+        void onTerminate() noexcept override;
+
+        /**
+         * Calculate the SkillInfo from the TacticInfo
+         * @param info info is the TacticInfo passed by the role
+         * @return std::optional<SkillInfo> based on the TacticInfo
+         */
+        std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+
+        /**
+         * Calculate the kickforce for the skill
+         * @param distance distance to the target
+         * @param desiredBallSpeedType type of the kick
+         * @return the speed the kicker needs to kick at
+         */
+        double determineKickForce(double distance, KickChipType desiredBallSpeedType) noexcept;
+
+        bool isEndTactic() noexcept override;
+
+        bool isTacticFailing(const StpInfo &info) noexcept override;
+
+        bool shouldTacticReset(const StpInfo &info) noexcept override;
+
+        /**
+         * Gets the tactic name
+         */
+        const char *getName() override;
+
+        std::optional<StpInfo> calculateInfoForKick(const StpInfo &info) noexcept;
+
+        std::optional<StpInfo> calculateInfoForChip(const StpInfo &info) noexcept;
+
+        double determineChipForce(double distance, KickChipType desiredBallSpeedType) noexcept;
+    };
+}  // namespace rtt::ai::stp::tactic
+
+
+#endif //RTT_SHOOTATPOS_H

--- a/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
@@ -46,22 +46,6 @@ namespace rtt::ai::stp::tactic {
          */
         std::optional<StpInfo> calculateInfoForChip(const StpInfo &info) noexcept;
 
-        /**
-         * Calculate the kickforce for the skill
-         * @param distance distance to the target
-         * @param desiredBallSpeedType type of the kick
-         * @return the speed the kicker needs to kick at
-         */
-        double determineKickForce(double distance, KickChipType desiredBallSpeedType) noexcept;
-
-        /**
-         * Calculate the chip force for the skill
-         * @param distance distance to the target
-         * @param desiredBallSpeedType type of the chip
-         * @return the speed the chipper needs to chip at
-         */
-        double determineChipForce(double distance, KickChipType desiredBallSpeedType) noexcept;
-
         bool isEndTactic() noexcept override;
 
         bool isTacticFailing(const StpInfo &info) noexcept override;

--- a/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
@@ -1,13 +1,11 @@
 //
-// Created by rtt-vision on 23-06-20.
+// Created by Jesse on 23-06-20.
 //
 
 #ifndef RTT_SHOOTATPOS_H
 #define RTT_SHOOTATPOS_H
 
-
-
-#include "include/roboteam_ai/stp/Tactic.h"
+#include "stp/Tactic.h"
 
 namespace rtt::ai::stp::tactic {
 

--- a/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
@@ -39,12 +39,30 @@ namespace rtt::ai::stp::tactic {
         std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
         /**
+         * Calculate the info if the role/play wants to execute a kick
+         */
+        std::optional<StpInfo> calculateInfoForKick(const StpInfo &info) noexcept;
+
+        /**
+         * Calculate the info if the role/play wants to execute a chip
+         */
+        std::optional<StpInfo> calculateInfoForChip(const StpInfo &info) noexcept;
+
+        /**
          * Calculate the kickforce for the skill
          * @param distance distance to the target
          * @param desiredBallSpeedType type of the kick
          * @return the speed the kicker needs to kick at
          */
         double determineKickForce(double distance, KickChipType desiredBallSpeedType) noexcept;
+
+        /**
+         * Calculate the chip force for the skill
+         * @param distance distance to the target
+         * @param desiredBallSpeedType type of the chip
+         * @return the speed the chipper needs to chip at
+         */
+        double determineChipForce(double distance, KickChipType desiredBallSpeedType) noexcept;
 
         bool isEndTactic() noexcept override;
 
@@ -57,11 +75,8 @@ namespace rtt::ai::stp::tactic {
          */
         const char *getName() override;
 
-        std::optional<StpInfo> calculateInfoForKick(const StpInfo &info) noexcept;
 
-        std::optional<StpInfo> calculateInfoForChip(const StpInfo &info) noexcept;
 
-        double determineChipForce(double distance, KickChipType desiredBallSpeedType) noexcept;
     };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
@@ -74,9 +74,6 @@ namespace rtt::ai::stp::tactic {
          * Gets the tactic name
          */
         const char *getName() override;
-
-
-
     };
 }  // namespace rtt::ai::stp::tactic
 

--- a/src/stp/new_plays/AttackingPass.cpp
+++ b/src/stp/new_plays/AttackingPass.cpp
@@ -121,10 +121,7 @@ bool AttackingPass::shouldRoleSkipEndTactic() { return false; }
 
 const char* AttackingPass::getName() { return "AttackingPass"; }
 
-Vector2 AttackingPass::calculatePassLocation() {
-    auto ourBots = world->getWorld()->getUs();
-    auto theirBots = world->getWorld()->getThem();
-
+const Vector2 AttackingPass::calculatePassLocation() noexcept{
     auto fieldWidth = field.getFieldWidth();
     auto fieldLength = field.getFieldLength();
 
@@ -158,12 +155,13 @@ Vector2 AttackingPass::calculatePassLocation() {
                 // Make sure the angle to shoot at the goal with is okay
                 auto trialToGoalAngle = 1 - fabs((field.getTheirGoalCenter() - trial).angle()) / M_PI_2;
 
-                // Make sure the ball can reach the target
-                auto canReachTarget{1.0};
+                /// If we can't reach target using kick, use chip
                 auto passLine = Tube(w->getBall()->get()->getPos(), trial, control_constants::ROBOT_CLOSE_TO_POINT);
                 auto enemyBots = w.getThem();
                 if (std::any_of(enemyBots.begin(), enemyBots.end(), [&](const auto& bot) { return passLine.contains(bot->getPos()); })) {
-                    canReachTarget = 0.0;
+                    stpInfos["passer"].setShootType(CHIP);
+                } else {
+                    stpInfos["passer"].setShootType(KICK);
                 }
 
                 // Search closest bot to this point and get that distance
@@ -174,7 +172,7 @@ Vector2 AttackingPass::calculatePassLocation() {
                 }
 
                 // Calculate total score for this point
-                auto pointScore = (goalDistance + visibility + trialToGoalAngle) * (0.5 * theirClosestBotDistance * canReachTarget);
+                auto pointScore = (goalDistance + visibility + trialToGoalAngle) * (0.5 * theirClosestBotDistance);
 
                 // Check for best score
                 if (pointScore > bestScore) {

--- a/src/stp/new_plays/GenericPass.cpp
+++ b/src/stp/new_plays/GenericPass.cpp
@@ -54,7 +54,7 @@ void GenericPass::calculateInfoForRoles() noexcept {
 
     auto receivePosition = passingPosition;
     if ((ball->getPos() - passingPosition).length() <= 2.0 && ball->getVelocity().length() > 0.1) {
-       receivePosition = ball->getPos();
+        receivePosition = ball->getPos();
     }
 
     // Receiver
@@ -90,7 +90,7 @@ Dealer::FlagMap GenericPass::decideRoleFlags() const noexcept {
 
 const char* GenericPass::getName() { return "Generic Pass"; }
 
-const Vector2 GenericPass::calculatePassLocation() const noexcept {
+const Vector2 GenericPass::calculatePassLocation() noexcept {
     double offSetX = 0;  // start looking for suitable positions to move to at 30% of the field width
     double offSetY = -3;
     double regionWidth = 3;
@@ -113,23 +113,24 @@ const Vector2 GenericPass::calculatePassLocation() const noexcept {
                 auto fieldLength = field.getFieldLength();
                 auto fieldDiagonalLength = sqrt(fieldWidth * fieldWidth + fieldLength * fieldLength);
 
-                // Make sure the ball can reach the target
-                auto canReachTarget{1.0};
+                /// If we can't reach target using kick, use chip
                 auto passLine = Tube(w->getBall()->get()->getPos(), trial, control_constants::ROBOT_CLOSE_TO_POINT);
                 auto enemyBots = w.getThem();
                 if (std::any_of(enemyBots.begin(), enemyBots.end(), [&](const auto& bot) { return passLine.contains(bot->getPos()); })) {
-                    canReachTarget = 0.0;
+                    stpInfos["passer"].setShootType(CHIP);
+                } else {
+                    stpInfos["passer"].setShootType(KICK);
                 }
 
                 // Search closest bot to this point and get that distance
                 auto theirClosestBot = w.getRobotClosestToPoint(trial, world_new::Team::them);
                 auto theirClosestBotDistance{1.0};
-                if(theirClosestBot) {
+                if (theirClosestBot) {
                     theirClosestBotDistance = theirClosestBot.value()->getPos().dist(trial) / fieldDiagonalLength;
                 }
 
                 // Calculate total score for this point
-                auto pointScore = 0.5 * theirClosestBotDistance * canReachTarget;
+                auto pointScore = 0.5 * theirClosestBotDistance;
 
                 // Check for best score
                 if (pointScore > bestScore) {
@@ -142,22 +143,23 @@ const Vector2 GenericPass::calculatePassLocation() const noexcept {
     return bestPosition;
 }
 
-bool GenericPass::isValidPlayToKeep(world_new::World *world) noexcept {
+bool GenericPass::isValidPlayToKeep(world_new::World* world) noexcept {
     world::Field field = world->getField().value();
-    return std::all_of(keepPlayInvariants.begin(), keepPlayInvariants.end(), [world, field](auto &x){return x->checkInvariant(world->getWorld().value(), &field);}) && !passFinished() && !passFailed();
+    return std::all_of(keepPlayInvariants.begin(), keepPlayInvariants.end(), [world, field](auto& x) { return x->checkInvariant(world->getWorld().value(), &field); }) &&
+           !passFinished() && !passFailed();
 }
 
 bool GenericPass::passFinished() noexcept {
-    //TODO: fix this condition
-    if(stpInfos["receiver"].getRobot() && stpInfos["receiver"].getRobot()->get()->getDistanceToBall() < 0.5) {
+    // TODO: fix this condition
+    if (stpInfos["receiver"].getRobot() && stpInfos["receiver"].getRobot()->get()->getDistanceToBall() < 0.5) {
         return true;
     }
     return false;
 }
 
 bool GenericPass::passFailed() noexcept {
-    //TODO: fix this condition
-    if(stpInfos["receiver"].getRobot() && stpInfos["receiver"].getRobot()->get()->getAngleDiffToBall() > M_PI_4) {
+    // TODO: fix this condition
+    if (stpInfos["receiver"].getRobot() && stpInfos["receiver"].getRobot()->get()->getAngleDiffToBall() > M_PI_4) {
         return true;
     }
     return false;

--- a/src/stp/new_plays/ReflectKick.cpp
+++ b/src/stp/new_plays/ReflectKick.cpp
@@ -98,6 +98,7 @@ void ReflectKick::calculateInfoForRoles() noexcept {
     // Passer
     stpInfos["passer"].setPositionToShootAt(passPosition);
     stpInfos["passer"].setKickChipType(TARGET);
+    stpInfos["passer"].setShootType(KICK);
 
     // Offenders
     stpInfos["offender_1"].setPositionToMoveTo(Vector2(field.getFieldLength() / 4, field.getFieldWidth() / 4));

--- a/src/stp/new_roles/Passer.cpp
+++ b/src/stp/new_roles/Passer.cpp
@@ -5,12 +5,12 @@
 #include "stp/new_roles/Passer.h"
 
 #include "stp/new_tactics/GetBallInDirection.h"
-#include "stp/new_tactics/KickAtPos.h"
+#include "stp/new_tactics/ShootAtPos.h"
 
 namespace rtt::ai::stp::role {
 
 Passer::Passer(std::string name) : Role(std::move(name)) {
     // create state machine and initializes the first state
-    robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::GetBallInDirection(), tactic::KickAtPos()};
+    robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::GetBallInDirection(), tactic::ShootAtPos()};
 }
 }  // namespace rtt::ai::stp::role

--- a/src/stp/new_skills/Shoot.cpp
+++ b/src/stp/new_skills/Shoot.cpp
@@ -1,8 +1,8 @@
 //
-// Created by rtt-vision on 23-06-20.
+// Created by Jesse on 23-06-20.
 //
 
-#include "include/roboteam_ai/stp/new_skills/Shoot.h"
+#include "stp/new_skills/Shoot.h"
 
 namespace rtt::ai::stp::skill {
 

--- a/src/stp/new_skills/Shoot.cpp
+++ b/src/stp/new_skills/Shoot.cpp
@@ -1,0 +1,65 @@
+//
+// Created by rtt-vision on 23-06-20.
+//
+
+#include "include/roboteam_ai/stp/new_skills/Shoot.h"
+
+namespace rtt::ai::stp::skill {
+
+    void Shoot::onInitialize() noexcept {}
+
+    Status Shoot::onUpdate(const StpInfo &info) noexcept {
+        if (info.getShootType() == rtt::ai::stp::KickChip::CHIP) {
+            return onUpdateChip(info);
+        }
+        if (info.getShootType() == rtt::ai::stp::KickChip::KICK) {
+            return onUpdateKick(info);
+        }
+    }
+
+    Status Shoot::onUpdateKick(const StpInfo &info) noexcept {
+
+        // Clamp and set kick velocity
+        double kickVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
+
+        // Set kick command
+        command.set_kicker(true);
+
+        command.set_chip_kick_vel(kickVelocity);
+
+        command.set_dribbler(info.getDribblerSpeed() / 100 * 32);
+
+        // Set angle command
+        command.set_w(info.getRobot().value()->getAngle());
+
+        publishRobotCommand();
+
+        if (info.getBall()->get()->getVelocity().length() > stp::control_constants::HAS_KICKED_ERROR_MARGIN &&
+            info.getRobot().value()->getAngleDiffToBall() <= control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI) {
+            return Status::Success;
+        }
+        return Status::Running;
+    }
+    Status Shoot::onUpdateChip(const StpInfo &info) noexcept {
+        // Clamp and set chip velocity
+        double chipVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
+
+        // Set chip command
+        command.set_chipper(true);
+        command.set_chip_kick_vel(chipVelocity);
+
+        // Set angle command
+        command.set_w(info.getRobot().value()->getAngle());
+
+        publishRobotCommand();
+
+        if (info.getBall()->get()->getVelocity().length() > stp::control_constants::HAS_CHIPPED_ERROR_MARGIN) {
+            return Status::Success;
+        }
+        return Status::Running;
+    }
+    void Shoot::onTerminate() noexcept {}
+
+    const char *Shoot::getName() { return "Shoot"; }
+
+}  // namespace rtt::ai::stp::skill

--- a/src/stp/new_skills/Shoot.cpp
+++ b/src/stp/new_skills/Shoot.cpp
@@ -4,61 +4,65 @@
 
 #include "stp/new_skills/Shoot.h"
 
+#include "roboteam_utils/Print.h"
+
 namespace rtt::ai::stp::skill {
 
-    void Shoot::onInitialize() noexcept {}
+void Shoot::onInitialize() noexcept {}
 
-    Status Shoot::onUpdate(const StpInfo &info) noexcept {
-        if (info.getShootType() == rtt::ai::stp::KickChip::CHIP) {
-            return onUpdateChip(info);
-        }
-        if (info.getShootType() == rtt::ai::stp::KickChip::KICK) {
-            return onUpdateKick(info);
-        }
+Status Shoot::onUpdate(const StpInfo &info) noexcept {
+    if (info.getShootType() == rtt::ai::stp::KickChip::CHIP) {
+        return onUpdateChip(info);
+    } else if (info.getShootType() == rtt::ai::stp::KickChip::KICK) {
+        return onUpdateKick(info);
+    } else {
+        RTT_ERROR("No ShootType set!")
+        return Status::Failure;
     }
+}
 
-    Status Shoot::onUpdateKick(const StpInfo &info) noexcept {
-        // Clamp and set kick velocity
-        double kickVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
+Status Shoot::onUpdateKick(const StpInfo &info) noexcept {
+    // Clamp and set kick velocity
+    double kickVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
 
-        // Set kick command
-        command.set_kicker(true);
+    // Set kick command
+    command.set_kicker(true);
 
-        command.set_chip_kick_vel(kickVelocity);
+    command.set_chip_kick_vel(kickVelocity);
 
-        command.set_dribbler(info.getDribblerSpeed() / 100 * 32);
+    command.set_dribbler(info.getDribblerSpeed() / 100 * 32);
 
-        // Set angle command
-        command.set_w(info.getRobot().value()->getAngle());
+    // Set angle command
+    command.set_w(info.getRobot().value()->getAngle());
 
-        publishRobotCommand();
+    publishRobotCommand(info.getCurrentWorld());
 
-        if (info.getBall()->get()->getVelocity().length() > stp::control_constants::HAS_KICKED_ERROR_MARGIN &&
-            info.getRobot().value()->getAngleDiffToBall() <= control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI) {
-            return Status::Success;
-        }
-        return Status::Running;
+    if (info.getBall()->get()->getVelocity().length() > stp::control_constants::HAS_KICKED_ERROR_MARGIN &&
+        info.getRobot().value()->getAngleDiffToBall() <= control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI) {
+        return Status::Success;
     }
-    Status Shoot::onUpdateChip(const StpInfo &info) noexcept {
-        // Clamp and set chip velocity
-        double chipVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
+    return Status::Running;
+}
+Status Shoot::onUpdateChip(const StpInfo &info) noexcept {
+    // Clamp and set chip velocity
+    double chipVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
 
-        // Set chip command
-        command.set_chipper(true);
-        command.set_chip_kick_vel(chipVelocity);
+    // Set chip command
+    command.set_chipper(true);
+    command.set_chip_kick_vel(chipVelocity);
 
-        // Set angle command
-        command.set_w(info.getRobot().value()->getAngle());
+    // Set angle command
+    command.set_w(info.getRobot().value()->getAngle());
 
-        publishRobotCommand();
+    publishRobotCommand(info.getCurrentWorld());
 
-        if (info.getBall()->get()->getVelocity().length() > stp::control_constants::HAS_CHIPPED_ERROR_MARGIN) {
-            return Status::Success;
-        }
-        return Status::Running;
+    if (info.getBall()->get()->getVelocity().length() > stp::control_constants::HAS_CHIPPED_ERROR_MARGIN) {
+        return Status::Success;
     }
-    void Shoot::onTerminate() noexcept {}
+    return Status::Running;
+}
+void Shoot::onTerminate() noexcept {}
 
-    const char *Shoot::getName() { return "Shoot"; }
+const char *Shoot::getName() { return "Shoot"; }
 
 }  // namespace rtt::ai::stp::skill

--- a/src/stp/new_skills/Shoot.cpp
+++ b/src/stp/new_skills/Shoot.cpp
@@ -16,8 +16,8 @@ Status Shoot::onUpdate(const StpInfo &info) noexcept {
     } else if (info.getShootType() == rtt::ai::stp::KickChip::KICK) {
         return onUpdateKick(info);
     } else {
-        RTT_ERROR("No ShootType set!")
-        return Status::Failure;
+        RTT_ERROR("No ShootType set, kicking by default!")
+        return onUpdateKick(info);
     }
 }
 

--- a/src/stp/new_skills/Shoot.cpp
+++ b/src/stp/new_skills/Shoot.cpp
@@ -18,7 +18,6 @@ namespace rtt::ai::stp::skill {
     }
 
     Status Shoot::onUpdateKick(const StpInfo &info) noexcept {
-
         // Clamp and set kick velocity
         double kickVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
 

--- a/src/stp/new_tactics/ChipAtPos.cpp
+++ b/src/stp/new_tactics/ChipAtPos.cpp
@@ -4,9 +4,9 @@
 
 #include "stp/new_tactics/ChipAtPos.h"
 
+#include <control/ControlUtils.h>
 #include <stp/new_skills/Chip.h>
 #include <stp/new_skills/Rotate.h>
-#include <include/roboteam_ai/utilities/Constants.h>
 
 namespace rtt::ai::stp::tactic {
 
@@ -29,7 +29,7 @@ void ChipAtPos::onTerminate() noexcept {
 std::optional<StpInfo> ChipAtPos::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 
-    if(!skillStpInfo.getPositionToShootAt() || !skillStpInfo.getRobot() || !skillStpInfo.getBall()) return std::nullopt;
+    if (!skillStpInfo.getPositionToShootAt() || !skillStpInfo.getRobot() || !skillStpInfo.getBall()) return std::nullopt;
 
     // Calculate the angle the robot needs to aim
     double angleToTarget = (info.getPositionToShootAt().value() - info.getRobot().value()->getPos()).angle();
@@ -37,7 +37,7 @@ std::optional<StpInfo> ChipAtPos::calculateInfoForSkill(StpInfo const &info) noe
 
     // Calculate the distance and the chip force
     double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
-    skillStpInfo.setKickChipVelocity(determineChipForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineChipForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
 
     // When rotating, we need to dribble to keep the ball, but when chipping we don't
     if (skills.current_num() == 0) {
@@ -45,37 +45,6 @@ std::optional<StpInfo> ChipAtPos::calculateInfoForSkill(StpInfo const &info) noe
     }
 
     return skillStpInfo;
-}
-
-double ChipAtPos::determineChipForce(double distance, KickChipType desiredBallSpeedType) noexcept {
-    // TODO: TUNE these factors need tuning
-    // Increase these factors to decrease chip velocity
-    // Decrease these factors to increase chip velocity
-    constexpr double TARGET_FACTOR{1.0};
-    constexpr double GRSIM_TARGET_FACTOR{1.3};
-    constexpr double PASS_FACTOR{0.8};
-    constexpr double GRSIM_PASS_FACTOR{1.1};
-
-    if (desiredBallSpeedType == MAX) return stp::control_constants::MAX_CHIP_POWER;
-
-    double limitingFactor{};
-    // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
-    if (desiredBallSpeedType == PASS) {
-        Constants::GRSIM() ? limitingFactor = GRSIM_PASS_FACTOR : limitingFactor = PASS_FACTOR;
-    } else if (desiredBallSpeedType == TARGET) {
-        Constants::GRSIM() ? limitingFactor = GRSIM_TARGET_FACTOR : limitingFactor = TARGET_FACTOR;
-    } else {
-        RTT_ERROR("No valid ballSpeedType, chip velocity set to 0")
-        return 0;
-    }
-
-    // TODO: TUNE this function might need to change
-    // TODO: TUNE chip related constants might need tuning
-    // Calculate the velocity based on this function with the previously set limitingFactor
-    auto velocity = sqrt(distance) * stp::control_constants::MAX_CHIP_POWER / (sqrt(stp::control_constants::MAX_POWER_CHIP_DISTANCE) * limitingFactor);
-
-    // Make sure velocity is always between MIN_CHIP_POWER and MAX_CHIP_POWER
-    return std::clamp(velocity, stp::control_constants::MIN_CHIP_POWER, stp::control_constants::MAX_CHIP_POWER);
 }
 
 bool ChipAtPos::isEndTactic() noexcept {
@@ -87,7 +56,7 @@ bool ChipAtPos::isTacticFailing(const StpInfo &info) noexcept {
     // Fail tactic if:
     // robot doesn't have the ball or if there is no shootTarget
     // But only check when we are not chipping
-    if(skills.current_num() != 1) {
+    if (skills.current_num() != 1) {
         return !info.getRobot()->hasBall() || !info.getPositionToShootAt();
     }
     return false;
@@ -102,8 +71,6 @@ bool ChipAtPos::shouldTacticReset(const StpInfo &info) noexcept {
     return false;
 }
 
-const char *ChipAtPos::getName() {
-    return "Chip At Pos";
-}
+const char *ChipAtPos::getName() { return "Chip At Pos"; }
 
 }  // namespace rtt::ai::stp::tactic

--- a/src/stp/new_tactics/KickAtPos.cpp
+++ b/src/stp/new_tactics/KickAtPos.cpp
@@ -4,7 +4,7 @@
 
 #include "stp/new_tactics/KickAtPos.h"
 
-#include <utilities/Constants.h>
+#include <control/ControlUtils.h>
 #include <stp/new_skills/Kick.h>
 #include <stp/new_skills/Rotate.h>
 
@@ -37,44 +37,13 @@ std::optional<StpInfo> KickAtPos::calculateInfoForSkill(StpInfo const &info) noe
 
     // Calculate the distance and the kick force
     double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
-    skillStpInfo.setKickChipVelocity(determineKickForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineKickForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
 
     // When the angle is not within the margin, dribble so we don't lose the ball while rotating
     double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
     skillStpInfo.setDribblerSpeed(50);
 
     return skillStpInfo;
-}
-
-double KickAtPos::determineKickForce(double distance, KickChipType desiredBallSpeedType) noexcept {
-    // TODO: TUNE these factors need tuning
-    // Increase these factors to decrease kick velocity
-    // Decrease these factors to increase kick velocity
-    constexpr double TARGET_FACTOR{2.65};
-    constexpr double GRSIM_TARGET_FACTOR{1.65};
-    constexpr double PASS_FACTOR{1.45};
-    constexpr double GRSIM_PASS_FACTOR{1.45};
-
-    if (desiredBallSpeedType == MAX) return stp::control_constants::MAX_KICK_POWER;
-
-    double limitingFactor{};
-    // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
-    if (desiredBallSpeedType == PASS) {
-        Constants::GRSIM() ? limitingFactor = GRSIM_PASS_FACTOR : limitingFactor = PASS_FACTOR;
-    } else if (desiredBallSpeedType == TARGET) {
-        Constants::GRSIM() ? limitingFactor = GRSIM_TARGET_FACTOR : limitingFactor = TARGET_FACTOR;
-    } else {
-        RTT_ERROR("No valid ballSpeedType, kick velocity set to 0")
-        return 0;
-    }
-
-    // TODO: TUNE this function might need to change
-    // TODO: TUNE kick related constants (in Constants.h) might need tuning
-    // Calculate the velocity based on this function with the previously set limitingFactor
-    auto velocity = sqrt(distance) * stp::control_constants::MAX_KICK_POWER / (sqrt(stp::control_constants::MAX_POWER_KICK_DISTANCE) * limitingFactor);
-
-    // Make sure velocity is always between MIN_KICK_POWER and MAX_KICK_POWER
-    return std::clamp(velocity, stp::control_constants::MIN_KICK_POWER, stp::control_constants::MAX_KICK_POWER);
 }
 
 bool KickAtPos::isEndTactic() noexcept {

--- a/src/stp/new_tactics/ShootAtPos.cpp
+++ b/src/stp/new_tactics/ShootAtPos.cpp
@@ -3,162 +3,162 @@
 //
 
 #include "stp/new_tactics/ShootAtPos.h"
-#include "stp/new_tactics/KickAtPos.h"
 
-#include <utilities/Constants.h>
-#include <stp/new_skills/Shoot.h>
 #include <stp/new_skills/Rotate.h>
+#include <stp/new_skills/Shoot.h>
+#include <utilities/Constants.h>
+
+#include "stp/new_tactics/KickAtPos.h"
 
 namespace rtt::ai::stp::tactic {
 
-    ShootAtPos::ShootAtPos() {
-        // Create state machine of skills and initialize first skill
-        skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::Shoot()};
+ShootAtPos::ShootAtPos() {
+    // Create state machine of skills and initialize first skill
+    skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::Shoot()};
+}
+
+void ShootAtPos::onInitialize() noexcept {}
+
+void ShootAtPos::onUpdate(Status const &status) noexcept {}
+
+void ShootAtPos::onTerminate() noexcept {
+    // Call terminate on all skills
+    for (auto &x : skills) {
+        x->terminate();
+    }
+}
+std::optional<StpInfo> ShootAtPos::calculateInfoForSkill(StpInfo const &info) noexcept {
+    if (info.getShootType() == stp::KickChip::KICK) {
+        return calculateInfoForKick(info);
+    }
+    if (info.getShootType() == stp::KickChip::CHIP) {
+        return calculateInfoForChip(info);
+    }
+}
+
+std::optional<StpInfo> ShootAtPos::calculateInfoForKick(StpInfo const &info) noexcept {
+    StpInfo skillStpInfo = info;
+
+    if (!skillStpInfo.getPositionToShootAt() || !skillStpInfo.getRobot() || !skillStpInfo.getBall()) return std::nullopt;
+
+    // Calculate the angle the robot needs to aim
+    double angleToTarget = (info.getPositionToShootAt().value() - info.getRobot().value()->getPos()).angle();
+    skillStpInfo.setAngle(angleToTarget);
+
+    // Calculate the distance and the kick force
+    double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
+    skillStpInfo.setKickChipVelocity(determineKickForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+
+    // When the angle is not within the margin, dribble so we don't lose the ball while rotating
+    double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
+    skillStpInfo.setDribblerSpeed(50);
+
+    return skillStpInfo;
+}
+
+double ShootAtPos::determineKickForce(double distance, KickChipType desiredBallSpeedType) noexcept {
+    // TODO: TUNE these factors need tuning
+    // Increase these factors to decrease kick velocity
+    // Decrease these factors to increase kick velocity
+    constexpr double TARGET_FACTOR{2.65};
+    constexpr double GRSIM_TARGET_FACTOR{1.65};
+    constexpr double PASS_FACTOR{1.45};
+    constexpr double GRSIM_PASS_FACTOR{1.45};
+
+    if (desiredBallSpeedType == MAX) return stp::control_constants::MAX_KICK_POWER;
+
+    double limitingFactor{};
+    // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
+    if (desiredBallSpeedType == PASS) {
+        Constants::GRSIM() ? limitingFactor = GRSIM_PASS_FACTOR : limitingFactor = PASS_FACTOR;
+    } else if (desiredBallSpeedType == TARGET) {
+        Constants::GRSIM() ? limitingFactor = GRSIM_TARGET_FACTOR : limitingFactor = TARGET_FACTOR;
+    } else {
+        RTT_ERROR("No valid ballSpeedType, kick velocity set to 0")
+        return 0;
     }
 
-    void ShootAtPos::onInitialize() noexcept {}
+    // TODO: TUNE this function might need to change
+    // TODO: TUNE kick related constants (in Constants.h) might need tuning
+    // Calculate the velocity based on this function with the previously set limitingFactor
+    auto velocity = sqrt(distance) * stp::control_constants::MAX_KICK_POWER / (sqrt(stp::control_constants::MAX_POWER_KICK_DISTANCE) * limitingFactor);
 
-    void ShootAtPos::onUpdate(Status const &status) noexcept {}
+    // Make sure velocity is always between MIN_KICK_POWER and MAX_KICK_POWER
+    return std::clamp(velocity, stp::control_constants::MIN_KICK_POWER, stp::control_constants::MAX_KICK_POWER);
+}
 
-    void ShootAtPos::onTerminate() noexcept {
-        // Call terminate on all skills
-        for (auto &x : skills) {
-            x->terminate();
-        }
+std::optional<StpInfo> ShootAtPos::calculateInfoForChip(StpInfo const &info) noexcept {
+    StpInfo skillStpInfo = info;
+
+    if (!skillStpInfo.getPositionToShootAt() || !skillStpInfo.getRobot() || !skillStpInfo.getBall()) return std::nullopt;
+
+    // Calculate the angle the robot needs to aim
+    double angleToTarget = (info.getPositionToShootAt().value() - info.getRobot().value()->getPos()).angle();
+    skillStpInfo.setAngle(angleToTarget);
+
+    // Calculate the distance and the chip force
+    double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
+    skillStpInfo.setKickChipVelocity(determineChipForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+
+    // When rotating, we need to dribble to keep the ball, but when chipping we don't
+    if (skills.current_num() == 0) {
+        skillStpInfo.setDribblerSpeed(30);
     }
-    std::optional<StpInfo> ShootAtPos::calculateInfoForSkill(StpInfo const &info) noexcept {
-        if (info.getShootType() == stp::KickChip::KICK) {
-            return calculateInfoForKick(info);
-        }
-        if (info.getShootType() == stp::KickChip::CHIP) {
-            return calculateInfoForChip(info);
-        }
+
+    return skillStpInfo;
+}
+
+double ShootAtPos::determineChipForce(double distance, KickChipType desiredBallSpeedType) noexcept {
+    // TODO: TUNE these factors need tuning
+    // Increase these factors to decrease chip velocity
+    // Decrease these factors to increase chip velocity
+    constexpr double TARGET_FACTOR{1.0};
+    constexpr double GRSIM_TARGET_FACTOR{1.3};
+    constexpr double PASS_FACTOR{0.8};
+    constexpr double GRSIM_PASS_FACTOR{1.1};
+
+    if (desiredBallSpeedType == MAX) return stp::control_constants::MAX_CHIP_POWER;
+
+    double limitingFactor{};
+    // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
+    if (desiredBallSpeedType == PASS) {
+        Constants::GRSIM() ? limitingFactor = GRSIM_PASS_FACTOR : limitingFactor = PASS_FACTOR;
+    } else if (desiredBallSpeedType == TARGET) {
+        Constants::GRSIM() ? limitingFactor = GRSIM_TARGET_FACTOR : limitingFactor = TARGET_FACTOR;
+    } else {
+        RTT_ERROR("No valid ballSpeedType, chip velocity set to 0")
+        return 0;
     }
 
-    std::optional<StpInfo> ShootAtPos::calculateInfoForKick(StpInfo const &info) noexcept {
-        StpInfo skillStpInfo = info;
+    // TODO: TUNE this function might need to change
+    // TODO: TUNE chip related constants might need tuning
+    // Calculate the velocity based on this function with the previously set limitingFactor
+    auto velocity = sqrt(distance) * stp::control_constants::MAX_CHIP_POWER / (sqrt(stp::control_constants::MAX_POWER_CHIP_DISTANCE) * limitingFactor);
 
-        if (!skillStpInfo.getPositionToShootAt() || !skillStpInfo.getRobot() || !skillStpInfo.getBall()) return std::nullopt;
+    // Make sure velocity is always between MIN_CHIP_POWER and MAX_CHIP_POWER
+    return std::clamp(velocity, stp::control_constants::MIN_CHIP_POWER, stp::control_constants::MAX_CHIP_POWER);
+}
 
-        // Calculate the angle the robot needs to aim
-        double angleToTarget = (info.getPositionToShootAt().value() - info.getRobot().value()->getPos()).angle();
-        skillStpInfo.setAngle(angleToTarget);
+bool ShootAtPos::isEndTactic() noexcept {
+    // This is not an end tactic
+    return false;
+}
 
-        // Calculate the distance and the kick force
-        double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
-        skillStpInfo.setKickChipVelocity(determineKickForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+bool ShootAtPos::isTacticFailing(const StpInfo &info) noexcept {
+    // Fail tactic if:
+    // robot doesn't have the ball or if there is no shootTarget
+    return !info.getRobot()->hasBall() || !info.getPositionToShootAt();
+}
 
-        // When the angle is not within the margin, dribble so we don't lose the ball while rotating
+bool ShootAtPos::shouldTacticReset(const StpInfo &info) noexcept {
+    // Reset when angle is wrong outside of the rotate skill, reset to rotate again
+    if (skills.current_num() != 0) {
         double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
-        skillStpInfo.setDribblerSpeed(50);
-
-        return skillStpInfo;
+        return info.getRobot().value()->getAngle().shortestAngleDiff(info.getAngle()) > errorMargin;
     }
+    return false;
+}
 
-    double ShootAtPos::determineKickForce(double distance, KickChipType desiredBallSpeedType) noexcept {
-        // TODO: TUNE these factors need tuning
-        // Increase these factors to decrease kick velocity
-        // Decrease these factors to increase kick velocity
-        constexpr double TARGET_FACTOR{2.65};
-        constexpr double GRSIM_TARGET_FACTOR{1.65};
-        constexpr double PASS_FACTOR{1.45};
-        constexpr double GRSIM_PASS_FACTOR{1.45};
-
-        if (desiredBallSpeedType == MAX) return stp::control_constants::MAX_KICK_POWER;
-
-        double limitingFactor{};
-        // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
-        if (desiredBallSpeedType == PASS) {
-            Constants::GRSIM() ? limitingFactor = GRSIM_PASS_FACTOR : limitingFactor = PASS_FACTOR;
-        } else if (desiredBallSpeedType == TARGET) {
-            Constants::GRSIM() ? limitingFactor = GRSIM_TARGET_FACTOR : limitingFactor = TARGET_FACTOR;
-        } else {
-            RTT_ERROR("No valid ballSpeedType, kick velocity set to 0")
-            return 0;
-        }
-
-        // TODO: TUNE this function might need to change
-        // TODO: TUNE kick related constants (in Constants.h) might need tuning
-        // Calculate the velocity based on this function with the previously set limitingFactor
-        auto velocity = sqrt(distance) * stp::control_constants::MAX_KICK_POWER / (sqrt(stp::control_constants::MAX_POWER_KICK_DISTANCE) * limitingFactor);
-
-        // Make sure velocity is always between MIN_KICK_POWER and MAX_KICK_POWER
-        return std::clamp(velocity, stp::control_constants::MIN_KICK_POWER, stp::control_constants::MAX_KICK_POWER);
-    }
-
-
-    std::optional<StpInfo> ShootAtPos::calculateInfoForChip(StpInfo const &info) noexcept {
-        StpInfo skillStpInfo = info;
-
-        if(!skillStpInfo.getPositionToShootAt() || !skillStpInfo.getRobot() || !skillStpInfo.getBall()) return std::nullopt;
-
-        // Calculate the angle the robot needs to aim
-        double angleToTarget = (info.getPositionToShootAt().value() - info.getRobot().value()->getPos()).angle();
-        skillStpInfo.setAngle(angleToTarget);
-
-        // Calculate the distance and the chip force
-        double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
-        skillStpInfo.setKickChipVelocity(determineChipForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
-
-        // When rotating, we need to dribble to keep the ball, but when chipping we don't
-        if (skills.current_num() == 0) {
-            skillStpInfo.setDribblerSpeed(30);
-        }
-
-        return skillStpInfo;
-    }
-
-    double ShootAtPos::determineChipForce(double distance, KickChipType desiredBallSpeedType) noexcept {
-        // TODO: TUNE these factors need tuning
-        // Increase these factors to decrease chip velocity
-        // Decrease these factors to increase chip velocity
-        constexpr double TARGET_FACTOR{1.0};
-        constexpr double GRSIM_TARGET_FACTOR{1.3};
-        constexpr double PASS_FACTOR{0.8};
-        constexpr double GRSIM_PASS_FACTOR{1.1};
-
-        if (desiredBallSpeedType == MAX) return stp::control_constants::MAX_CHIP_POWER;
-
-        double limitingFactor{};
-        // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
-        if (desiredBallSpeedType == PASS) {
-            Constants::GRSIM() ? limitingFactor = GRSIM_PASS_FACTOR : limitingFactor = PASS_FACTOR;
-        } else if (desiredBallSpeedType == TARGET) {
-            Constants::GRSIM() ? limitingFactor = GRSIM_TARGET_FACTOR : limitingFactor = TARGET_FACTOR;
-        } else {
-            RTT_ERROR("No valid ballSpeedType, chip velocity set to 0")
-            return 0;
-        }
-
-        // TODO: TUNE this function might need to change
-        // TODO: TUNE chip related constants might need tuning
-        // Calculate the velocity based on this function with the previously set limitingFactor
-        auto velocity = sqrt(distance) * stp::control_constants::MAX_CHIP_POWER / (sqrt(stp::control_constants::MAX_POWER_CHIP_DISTANCE) * limitingFactor);
-
-        // Make sure velocity is always between MIN_CHIP_POWER and MAX_CHIP_POWER
-        return std::clamp(velocity, stp::control_constants::MIN_CHIP_POWER, stp::control_constants::MAX_CHIP_POWER);
-    }
-
-    bool ShootAtPos::isEndTactic() noexcept {
-        // This is not an end tactic
-        return false;
-    }
-
-    bool ShootAtPos::isTacticFailing(const StpInfo &info) noexcept {
-        // Fail tactic if:
-        // robot doesn't have the ball or if there is no shootTarget
-        return !info.getRobot()->hasBall() || !info.getPositionToShootAt();
-    }
-
-    bool ShootAtPos::shouldTacticReset(const StpInfo &info) noexcept {
-        // Reset when angle is wrong outside of the rotate skill, reset to rotate again
-        if (skills.current_num() != 0) {
-            double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
-            return info.getRobot().value()->getAngle().shortestAngleDiff(info.getAngle()) > errorMargin;
-        }
-        return false;
-    }
-
-    const char *ShootAtPos::getName() { return "Kick At Pos"; }
+const char *ShootAtPos::getName() { return "Kick At Pos"; }
 
 }  // namespace rtt::ai::stp::tactic

--- a/src/stp/new_tactics/ShootAtPos.cpp
+++ b/src/stp/new_tactics/ShootAtPos.cpp
@@ -4,9 +4,9 @@
 
 #include "stp/new_tactics/ShootAtPos.h"
 
+#include <control/ControlUtils.h>
 #include <stp/new_skills/Rotate.h>
 #include <stp/new_skills/Shoot.h>
-#include <utilities/Constants.h>
 
 #include "stp/new_tactics/KickAtPos.h"
 
@@ -31,8 +31,12 @@ std::optional<StpInfo> ShootAtPos::calculateInfoForSkill(StpInfo const &info) no
     if (info.getShootType() == stp::KickChip::KICK) {
         return calculateInfoForKick(info);
     }
-    if (info.getShootType() == stp::KickChip::CHIP) {
+    else if (info.getShootType() == stp::KickChip::CHIP) {
         return calculateInfoForChip(info);
+    }
+    else {
+        RTT_ERROR("No ShootType is set, kicking by default")
+        return calculateInfoForKick(info);
     }
 }
 
@@ -47,44 +51,13 @@ std::optional<StpInfo> ShootAtPos::calculateInfoForKick(StpInfo const &info) noe
 
     // Calculate the distance and the kick force
     double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
-    skillStpInfo.setKickChipVelocity(determineKickForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineKickForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
 
     // When the angle is not within the margin, dribble so we don't lose the ball while rotating
     double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
     skillStpInfo.setDribblerSpeed(50);
 
     return skillStpInfo;
-}
-
-double ShootAtPos::determineKickForce(double distance, KickChipType desiredBallSpeedType) noexcept {
-    // TODO: TUNE these factors need tuning
-    // Increase these factors to decrease kick velocity
-    // Decrease these factors to increase kick velocity
-    constexpr double TARGET_FACTOR{2.65};
-    constexpr double GRSIM_TARGET_FACTOR{1.65};
-    constexpr double PASS_FACTOR{1.45};
-    constexpr double GRSIM_PASS_FACTOR{1.45};
-
-    if (desiredBallSpeedType == MAX) return stp::control_constants::MAX_KICK_POWER;
-
-    double limitingFactor{};
-    // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
-    if (desiredBallSpeedType == PASS) {
-        Constants::GRSIM() ? limitingFactor = GRSIM_PASS_FACTOR : limitingFactor = PASS_FACTOR;
-    } else if (desiredBallSpeedType == TARGET) {
-        Constants::GRSIM() ? limitingFactor = GRSIM_TARGET_FACTOR : limitingFactor = TARGET_FACTOR;
-    } else {
-        RTT_ERROR("No valid ballSpeedType, kick velocity set to 0")
-        return 0;
-    }
-
-    // TODO: TUNE this function might need to change
-    // TODO: TUNE kick related constants (in Constants.h) might need tuning
-    // Calculate the velocity based on this function with the previously set limitingFactor
-    auto velocity = sqrt(distance) * stp::control_constants::MAX_KICK_POWER / (sqrt(stp::control_constants::MAX_POWER_KICK_DISTANCE) * limitingFactor);
-
-    // Make sure velocity is always between MIN_KICK_POWER and MAX_KICK_POWER
-    return std::clamp(velocity, stp::control_constants::MIN_KICK_POWER, stp::control_constants::MAX_KICK_POWER);
 }
 
 std::optional<StpInfo> ShootAtPos::calculateInfoForChip(StpInfo const &info) noexcept {
@@ -98,7 +71,7 @@ std::optional<StpInfo> ShootAtPos::calculateInfoForChip(StpInfo const &info) noe
 
     // Calculate the distance and the chip force
     double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
-    skillStpInfo.setKickChipVelocity(determineChipForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineChipForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
 
     // When rotating, we need to dribble to keep the ball, but when chipping we don't
     if (skills.current_num() == 0) {
@@ -106,37 +79,6 @@ std::optional<StpInfo> ShootAtPos::calculateInfoForChip(StpInfo const &info) noe
     }
 
     return skillStpInfo;
-}
-
-double ShootAtPos::determineChipForce(double distance, KickChipType desiredBallSpeedType) noexcept {
-    // TODO: TUNE these factors need tuning
-    // Increase these factors to decrease chip velocity
-    // Decrease these factors to increase chip velocity
-    constexpr double TARGET_FACTOR{1.0};
-    constexpr double GRSIM_TARGET_FACTOR{1.3};
-    constexpr double PASS_FACTOR{0.8};
-    constexpr double GRSIM_PASS_FACTOR{1.1};
-
-    if (desiredBallSpeedType == MAX) return stp::control_constants::MAX_CHIP_POWER;
-
-    double limitingFactor{};
-    // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
-    if (desiredBallSpeedType == PASS) {
-        Constants::GRSIM() ? limitingFactor = GRSIM_PASS_FACTOR : limitingFactor = PASS_FACTOR;
-    } else if (desiredBallSpeedType == TARGET) {
-        Constants::GRSIM() ? limitingFactor = GRSIM_TARGET_FACTOR : limitingFactor = TARGET_FACTOR;
-    } else {
-        RTT_ERROR("No valid ballSpeedType, chip velocity set to 0")
-        return 0;
-    }
-
-    // TODO: TUNE this function might need to change
-    // TODO: TUNE chip related constants might need tuning
-    // Calculate the velocity based on this function with the previously set limitingFactor
-    auto velocity = sqrt(distance) * stp::control_constants::MAX_CHIP_POWER / (sqrt(stp::control_constants::MAX_POWER_CHIP_DISTANCE) * limitingFactor);
-
-    // Make sure velocity is always between MIN_CHIP_POWER and MAX_CHIP_POWER
-    return std::clamp(velocity, stp::control_constants::MIN_CHIP_POWER, stp::control_constants::MAX_CHIP_POWER);
 }
 
 bool ShootAtPos::isEndTactic() noexcept {

--- a/src/stp/new_tactics/ShootAtPos.cpp
+++ b/src/stp/new_tactics/ShootAtPos.cpp
@@ -1,0 +1,160 @@
+#include "include/roboteam_ai/stp/new_tactics/ShootAtPos.h"
+#include "stp/new_tactics/KickAtPos.h"
+
+#include <utilities/Constants.h>
+#include <stp/new_skills/Shoot.h>
+#include <stp/new_skills/Rotate.h>
+
+namespace rtt::ai::stp::tactic {
+
+    ShootAtPos::ShootAtPos() {
+        // Create state machine of skills and initialize first skill
+        skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::Shoot()};
+    }
+
+    void ShootAtPos::onInitialize() noexcept {}
+
+    void ShootAtPos::onUpdate(Status const &status) noexcept {}
+
+    void ShootAtPos::onTerminate() noexcept {
+        // Call terminate on all skills
+        for (auto &x : skills) {
+            x->terminate();
+        }
+    }
+    std::optional<StpInfo> ShootAtPos::calculateInfoForSkill(StpInfo const &info) noexcept {
+        if (info.getShootType() == stp::KickChip::KICK) {
+            return calculateInfoForKick(info);
+        }
+        if (info.getShootType() == stp::KickChip::CHIP) {
+            return calculateInfoForChip(info);
+        }
+    }
+
+    std::optional<StpInfo> ShootAtPos::calculateInfoForKick(StpInfo const &info) noexcept {
+        StpInfo skillStpInfo = info;
+
+        if (!skillStpInfo.getPositionToShootAt() || !skillStpInfo.getRobot() || !skillStpInfo.getBall()) return std::nullopt;
+
+        // Calculate the angle the robot needs to aim
+        double angleToTarget = (info.getPositionToShootAt().value() - info.getRobot().value()->getPos()).angle();
+        skillStpInfo.setAngle(angleToTarget);
+
+        // Calculate the distance and the kick force
+        double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
+        skillStpInfo.setKickChipVelocity(determineKickForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+
+        // When the angle is not within the margin, dribble so we don't lose the ball while rotating
+        double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
+        skillStpInfo.setDribblerSpeed(50);
+
+        return skillStpInfo;
+    }
+
+    double ShootAtPos::determineKickForce(double distance, KickChipType desiredBallSpeedType) noexcept {
+        // TODO: TUNE these factors need tuning
+        // Increase these factors to decrease kick velocity
+        // Decrease these factors to increase kick velocity
+        constexpr double TARGET_FACTOR{2.65};
+        constexpr double GRSIM_TARGET_FACTOR{1.65};
+        constexpr double PASS_FACTOR{1.45};
+        constexpr double GRSIM_PASS_FACTOR{1.45};
+
+        if (desiredBallSpeedType == MAX) return stp::control_constants::MAX_KICK_POWER;
+
+        double limitingFactor{};
+        // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
+        if (desiredBallSpeedType == PASS) {
+            Constants::GRSIM() ? limitingFactor = GRSIM_PASS_FACTOR : limitingFactor = PASS_FACTOR;
+        } else if (desiredBallSpeedType == TARGET) {
+            Constants::GRSIM() ? limitingFactor = GRSIM_TARGET_FACTOR : limitingFactor = TARGET_FACTOR;
+        } else {
+            RTT_ERROR("No valid ballSpeedType, kick velocity set to 0")
+            return 0;
+        }
+
+        // TODO: TUNE this function might need to change
+        // TODO: TUNE kick related constants (in Constants.h) might need tuning
+        // Calculate the velocity based on this function with the previously set limitingFactor
+        auto velocity = sqrt(distance) * stp::control_constants::MAX_KICK_POWER / (sqrt(stp::control_constants::MAX_POWER_KICK_DISTANCE) * limitingFactor);
+
+        // Make sure velocity is always between MIN_KICK_POWER and MAX_KICK_POWER
+        return std::clamp(velocity, stp::control_constants::MIN_KICK_POWER, stp::control_constants::MAX_KICK_POWER);
+    }
+
+
+    std::optional<StpInfo> ShootAtPos::calculateInfoForChip(StpInfo const &info) noexcept {
+        StpInfo skillStpInfo = info;
+
+        if(!skillStpInfo.getPositionToShootAt() || !skillStpInfo.getRobot() || !skillStpInfo.getBall()) return std::nullopt;
+
+        // Calculate the angle the robot needs to aim
+        double angleToTarget = (info.getPositionToShootAt().value() - info.getRobot().value()->getPos()).angle();
+        skillStpInfo.setAngle(angleToTarget);
+
+        // Calculate the distance and the chip force
+        double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
+        skillStpInfo.setKickChipVelocity(determineChipForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+
+        // When rotating, we need to dribble to keep the ball, but when chipping we don't
+        if (skills.current_num() == 0) {
+            skillStpInfo.setDribblerSpeed(30);
+        }
+
+        return skillStpInfo;
+    }
+
+    double ShootAtPos::determineChipForce(double distance, KickChipType desiredBallSpeedType) noexcept {
+        // TODO: TUNE these factors need tuning
+        // Increase these factors to decrease chip velocity
+        // Decrease these factors to increase chip velocity
+        constexpr double TARGET_FACTOR{1.0};
+        constexpr double GRSIM_TARGET_FACTOR{1.3};
+        constexpr double PASS_FACTOR{0.8};
+        constexpr double GRSIM_PASS_FACTOR{1.1};
+
+        if (desiredBallSpeedType == MAX) return stp::control_constants::MAX_CHIP_POWER;
+
+        double limitingFactor{};
+        // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
+        if (desiredBallSpeedType == PASS) {
+            Constants::GRSIM() ? limitingFactor = GRSIM_PASS_FACTOR : limitingFactor = PASS_FACTOR;
+        } else if (desiredBallSpeedType == TARGET) {
+            Constants::GRSIM() ? limitingFactor = GRSIM_TARGET_FACTOR : limitingFactor = TARGET_FACTOR;
+        } else {
+            RTT_ERROR("No valid ballSpeedType, chip velocity set to 0")
+            return 0;
+        }
+
+        // TODO: TUNE this function might need to change
+        // TODO: TUNE chip related constants might need tuning
+        // Calculate the velocity based on this function with the previously set limitingFactor
+        auto velocity = sqrt(distance) * stp::control_constants::MAX_CHIP_POWER / (sqrt(stp::control_constants::MAX_POWER_CHIP_DISTANCE) * limitingFactor);
+
+        // Make sure velocity is always between MIN_CHIP_POWER and MAX_CHIP_POWER
+        return std::clamp(velocity, stp::control_constants::MIN_CHIP_POWER, stp::control_constants::MAX_CHIP_POWER);
+    }
+
+    bool ShootAtPos::isEndTactic() noexcept {
+        // This is not an end tactic
+        return false;
+    }
+
+    bool ShootAtPos::isTacticFailing(const StpInfo &info) noexcept {
+        // Fail tactic if:
+        // robot doesn't have the ball or if there is no shootTarget
+        return !info.getRobot()->hasBall() || !info.getPositionToShootAt();
+    }
+
+    bool ShootAtPos::shouldTacticReset(const StpInfo &info) noexcept {
+        // Reset when angle is wrong outside of the rotate skill, reset to rotate again
+        if (skills.current_num() != 0) {
+            double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
+            return info.getRobot().value()->getAngle().shortestAngleDiff(info.getAngle()) > errorMargin;
+        }
+        return false;
+    }
+
+    const char *ShootAtPos::getName() { return "Kick At Pos"; }
+
+}  // namespace rtt::ai::stp::tactic

--- a/src/stp/new_tactics/ShootAtPos.cpp
+++ b/src/stp/new_tactics/ShootAtPos.cpp
@@ -1,4 +1,8 @@
-#include "include/roboteam_ai/stp/new_tactics/ShootAtPos.h"
+//
+// Created by Jesse on 23-06-20.
+//
+
+#include "stp/new_tactics/ShootAtPos.h"
 #include "stp/new_tactics/KickAtPos.h"
 
 #include <utilities/Constants.h>


### PR DESCRIPTION
Create Shoot skill and shootatpos tactic that can use both chip and shoot. Changed passer role's kickatpos to a shootatpos to allow it to also use chipping