### PR TITLE
STP Documentation and Cleanup - Headers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -85,7 +85,7 @@ IncludeIsMainSourceRegex: ''
 IndentCaseLabels: true
 IndentGotoLabels: true
 IndentPPDirectives: None
-IndentWidth:     2
+IndentWidth:     4
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,168 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     180
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/include/roboteam_ai/control/ControlUtils.h
+++ b/include/roboteam_ai/control/ControlUtils.h
@@ -57,18 +57,18 @@ namespace rtt::ai {
             /**
              * Determines the chip force based on the distance and the type of chip
              * @param distance distance to the target
-             * @param desiredBallSpeedType type of the chip
+             * @param shotType type of the chip
              * @return a chip speed between min and max chip speed
              */
-            static double determineChipForce(const double distance, stp::KickChipType desiredBallSpeedType) noexcept;
+            static double determineChipForce(const double distance, stp::ShotType shotType) noexcept;
 
             /**
              * Determines the kick force based on the distance and the type of kick
              * @param distance distance to the target
-             * @param desiredBallSpeedType type of the kick
+             * @param shotType type of the kick
              * @return a kick speed between min and max kick speed
              */
-            static double determineKickForce(const double distance, stp::KickChipType desiredBallSpeedType) noexcept;
+            static double determineKickForce(const double distance, stp::ShotType shotType) noexcept;
 
             /**
              * Determine the best position for a midfielder

--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -19,147 +19,147 @@ namespace rtt::ai::stp {
  * on update traverses every Role, and updates it.
  */
 class Play {
- public:
-  /**
-   * Invariant vector that contains invariants that need to be true to continue execution of this play
-   */
-  std::vector<std::unique_ptr<invariant::BaseInvariant>> keepPlayInvariants;
+   public:
+    /**
+     * Invariant vector that contains invariants that need to be true to continue execution of this play
+     */
+    std::vector<std::unique_ptr<invariant::BaseInvariant>> keepPlayInvariants;
 
-  /**
-   * Invariant vector that contains invariants that need to be true to start this play
-   */
-  std::vector<std::unique_ptr<invariant::BaseInvariant>> startPlayInvariants;
+    /**
+     * Invariant vector that contains invariants that need to be true to start this play
+     */
+    std::vector<std::unique_ptr<invariant::BaseInvariant>> startPlayInvariants;
 
-  /**
-   * Initializes stpInfos struct, distributes roles, sets the previousRobotNum variable and calls onInitialize()
-   */
-  void initialize() noexcept;
+    /**
+     * Initializes stpInfos struct, distributes roles, sets the previousRobotNum variable and calls onInitialize()
+     */
+    void initialize() noexcept;
 
-  /**
-   * Virtual function that is called in initialize().
-   * This function should contain all play-specific init code
-   */
-  virtual void onInitialize() noexcept {};
+    /**
+     * Virtual function that is called in initialize().
+     * This function should contain all play-specific init code
+     */
+    virtual void onInitialize() noexcept {};
 
-  /**
-   * Updates the stored world pointer and field using this world pointer
-   * @param pointer to World
-   */
-  void updateWorld(world_new::World* world) noexcept;
+    /**
+     * Updates the stored world pointer and field using this world pointer
+     * @param pointer to World
+     */
+    void updateWorld(world_new::World* world) noexcept;
 
-  /**
-   * Updates all the roles that have robots assigned to them
-   */
-  virtual void update() noexcept;
+    /**
+     * Updates all the roles that have robots assigned to them
+     */
+    virtual void update() noexcept;
 
-  /**
-   * Calculates all the info the roles need in order to execute correctly
-   */
-  virtual void calculateInfoForRoles() noexcept = 0;
+    /**
+     * Calculates all the info the roles need in order to execute correctly
+     */
+    virtual void calculateInfoForRoles() noexcept = 0;
 
-  /**
-   * Gets the score for the current play that is in the range of 0 - 255
-   * @param world World to get the score for
-   * @return The score, 0 - 255
-   */
-  [[nodiscard]] virtual uint8_t score(world_new::World* world) noexcept = 0;
+    /**
+     * Gets the score for the current play that is in the range of 0 - 255
+     * @param world World to get the score for
+     * @return The score, 0 - 255
+     */
+    [[nodiscard]] virtual uint8_t score(world_new::World* world) noexcept = 0;
 
-  /**
-   * Virtual default dtor, ensures proper destruction of derived plays
-   */
-  virtual ~Play() = default;
+    /**
+     * Virtual default dtor, ensures proper destruction of derived plays
+     */
+    virtual ~Play() = default;
 
-  /**
-   * Default ctor, proper construction
-   */
-  Play() = default;
+    /**
+     * Default ctor, proper construction
+     */
+    Play() = default;
 
-  /**
-   * Default move-ctor, ensures proper move-construction of Play
-   */
-  Play(Play&& other) = default;
+    /**
+     * Default move-ctor, ensures proper move-construction of Play
+     */
+    Play(Play&& other) = default;
 
-  /**
-   * Check if the preconditions of this play are true
-   * @return true if the play is allowed to be started, else false
-   */
-  [[nodiscard]] bool isValidPlayToStart(world_new::World* world) const noexcept;
+    /**
+     * Check if the preconditions of this play are true
+     * @return true if the play is allowed to be started, else false
+     */
+    [[nodiscard]] bool isValidPlayToStart(world_new::World* world) const noexcept;
 
-  /**
-   * Check if the invariants necessary to keep this play are true
-   * @return true if the play is valid to keep, else false
-   */
-  [[nodiscard]] virtual bool isValidPlayToKeep(world_new::World* world) noexcept;
+    /**
+     * Check if the invariants necessary to keep this play are true
+     * @return true if the play is valid to keep, else false
+     */
+    [[nodiscard]] virtual bool isValidPlayToKeep(world_new::World* world) noexcept;
 
-  /**
-   * Getter for the role -> status mapping
-   * @return The internal role -> status mapping, roleStatuses
-   */
-  [[nodiscard]] std::unordered_map<Role*, Status> const& getRoleStatuses() const;
+    /**
+     * Getter for the role -> status mapping
+     * @return The internal role -> status mapping, roleStatuses
+     */
+    [[nodiscard]] std::unordered_map<Role*, Status> const& getRoleStatuses() const;
 
-  /**
-   * Gets the current play name
-   */
-  virtual const char* getName() = 0;
+    /**
+     * Gets the current play name
+     */
+    virtual const char* getName() = 0;
 
- protected:
-  /**
-   * The roles, constructed in ctor of a play
-   */
-  std::array<std::unique_ptr<Role>, rtt::ai::Constants::ROBOT_COUNT()> roles;
+   protected:
+    /**
+     * The roles, constructed in ctor of a play
+     */
+    std::array<std::unique_ptr<Role>, rtt::ai::Constants::ROBOT_COUNT()> roles;
 
-  /**
-   * Map that keeps track of the status of each role.
-   * It's a Role*, because that's hashable and a unique identifier
-   */
-  std::unordered_map<Role*, Status> roleStatuses;
+    /**
+     * Map that keeps track of the status of each role.
+     * It's a Role*, because that's hashable and a unique identifier
+     */
+    std::unordered_map<Role*, Status> roleStatuses;
 
-  /**
-   * The stpInfos, constructed in distributeRoles
-   * The string is the role_name to be able to update the info in the right role
-   */
-  std::unordered_map<std::string, StpInfo> stpInfos;
+    /**
+     * The stpInfos, constructed in distributeRoles
+     * The string is the role_name to be able to update the info in the right role
+     */
+    std::unordered_map<std::string, StpInfo> stpInfos;
 
-  /**
-   * The world pointer
-   */
-  rtt::world_new::World* world{};
+    /**
+     * The world pointer
+     */
+    rtt::world_new::World* world{};
 
-  /**
-   * The Field
-   */
-  rtt::ai::world::Field field;
+    /**
+     * The Field
+     */
+    rtt::ai::world::Field field;
 
-  /**
-   * Decides the input for the robot dealer. The result will be used to distribute the roles
-   * @return a mapping between roles and robot flags, used by the robot dealer to assign roles
-   */
-  virtual Dealer::FlagMap decideRoleFlags() const noexcept = 0;
+    /**
+     * Decides the input for the robot dealer. The result will be used to distribute the roles
+     * @return a mapping between roles and robot flags, used by the robot dealer to assign roles
+     */
+    virtual Dealer::FlagMap decideRoleFlags() const noexcept = 0;
 
-  /**
-   * This function is used to determine if -- when a role is in an endTactic -- the endTactic should be skipped.
-   * An example could be BlockRobot and Intercept. You block a robot (endTactic) until a ball is shot and then the robot
-   * closest to the ball should try to intercept (skip the BlockRobot tactic to execute Intercept)
-   */
-  virtual bool shouldRoleSkipEndTactic() = 0;
+    /**
+     * This function is used to determine if -- when a role is in an endTactic -- the endTactic should be skipped.
+     * An example could be BlockRobot and Intercept. You block a robot (endTactic) until a ball is shot and then the robot
+     * closest to the ball should try to intercept (skip the BlockRobot tactic to execute Intercept)
+     */
+    virtual bool shouldRoleSkipEndTactic() = 0;
 
- private:
-  /**
-   * This function refreshes the RobotViews, the BallViews and the Fields for all stpInfos.
-   * This is necessary because the views are stored for a limited time; not refreshing will lead to UB
-   */
-  void refreshData() noexcept;
+   private:
+    /**
+     * This function refreshes the RobotViews, the BallViews and the Fields for all stpInfos.
+     * This is necessary because the views are stored for a limited time; not refreshing will lead to UB
+     */
+    void refreshData() noexcept;
 
-  /**
-   * Assigns robots to roles
-   */
-  void distributeRoles() noexcept;
+    /**
+     * Assigns robots to roles
+     */
+    void distributeRoles() noexcept;
 
-  /**
-   * The previous amount of robots
-   * This is used to check if we need to redeal (if a robot disappears for example)
-   */
-  int previousRobotNum{};
+    /**
+     * The previous amount of robots
+     * This is used to check if we need to redeal (if a robot disappears for example)
+     */
+    int previousRobotNum{};
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -42,18 +42,19 @@ class Play {
     virtual void onInitialize() noexcept {};
 
     /**
-     * Updates the stored world pointer and field using this world pointer
+     * Updates the stored world pointer and after that, updates the field instance using the updated world pointer
      * @param pointer to World
      */
     void updateWorld(world_new::World* world) noexcept;
 
     /**
-     * Updates all the roles that have robots assigned to them
+     * Updates (or ticks) all the roles that have robots assigned to them
      */
     virtual void update() noexcept;
 
     /**
-     * Calculates all the info the roles need in order to execute correctly
+     * Calculates all the info the roles need in order to execute correctly.
+     * This is a purely virtual function, so it is implemented in every play.
      */
     virtual void calculateInfoForRoles() noexcept = 0;
 

--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -5,13 +5,11 @@
 #ifndef RTT_PLAY_HPP
 #define RTT_PLAY_HPP
 
-#include <utilities/Constants.h>
-#include <utilities/Dealer.h>
-
 #include <array>
-#include <stp/invariants/BaseInvariant.h>
 
 #include "Role.hpp"
+#include "stp/invariants/BaseInvariant.h"
+#include "utilities/Dealer.h"
 #include "world_new/World.hpp"
 
 namespace rtt::ai::stp {
@@ -21,148 +19,147 @@ namespace rtt::ai::stp {
  * on update traverses every Role, and updates it.
  */
 class Play {
-   public:
-    /**
-    * Invariant vector that contains invariants that need to be true to continue execution of this play
-    */
-    std::vector<std::unique_ptr<invariant::BaseInvariant>> keepPlayInvariants;
+ public:
+  /**
+   * Invariant vector that contains invariants that need to be true to continue execution of this play
+   */
+  std::vector<std::unique_ptr<invariant::BaseInvariant>> keepPlayInvariants;
 
-    /**
-    * Invariant vector that contains invariants that need to be true to start this play
-    */
-    std::vector<std::unique_ptr<invariant::BaseInvariant>> startPlayInvariants;
-	
-    /**
-     * Initializes tacticInfos vector and calls distributeRoles
-     */
-    void initialize() noexcept;
+  /**
+   * Invariant vector that contains invariants that need to be true to start this play
+   */
+  std::vector<std::unique_ptr<invariant::BaseInvariant>> startPlayInvariants;
 
-    virtual void onInitialize() noexcept {};
+  /**
+   * Initializes stpInfos struct, distributes roles, sets the previousRobotNum variable and calls onInitialize()
+   */
+  void initialize() noexcept;
 
-    /**
-     * Updated the stored world
-     * @param world
-     */
-    void updateWorld(world_new::World* world) noexcept;
+  /**
+   * Virtual function that is called in initialize().
+   * This function should contain all play-specific init code
+   */
+  virtual void onInitialize() noexcept {};
 
-    /**
-     * Updates all the roles
-     */
-    virtual void update() noexcept;
+  /**
+   * Updates the stored world pointer and field using this world pointer
+   * @param pointer to World
+   */
+  void updateWorld(world_new::World* world) noexcept;
 
-    /**
-     * Calculates all the info (mostly positions) the roles in this play need to execute
-     */
-    virtual void calculateInfoForRoles() noexcept = 0;
+  /**
+   * Updates all the roles that have robots assigned to them
+   */
+  virtual void update() noexcept;
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlayToStart() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    [[nodiscard]] virtual uint8_t score(world_new::World* world) noexcept = 0;
+  /**
+   * Calculates all the info the roles need in order to execute correctly
+   */
+  virtual void calculateInfoForRoles() noexcept = 0;
 
-    /**
-     * Virtual default dtor, ensures proper destruction of Play
-     */
-    virtual ~Play() = default;
+  /**
+   * Gets the score for the current play that is in the range of 0 - 255
+   * @param world World to get the score for
+   * @return The score, 0 - 255
+   */
+  [[nodiscard]] virtual uint8_t score(world_new::World* world) noexcept = 0;
 
-    /**
-     * Ctor that constructs a play and assigns its name
-     */
-    Play() = default;
+  /**
+   * Virtual default dtor, ensures proper destruction of derived plays
+   */
+  virtual ~Play() = default;
 
-    /**
-     * Default move-ctor, ensures proper move-construction of Play
-     */
-    Play(Play&& other) = default;
+  /**
+   * Default ctor, proper construction
+   */
+  Play() = default;
 
-    /**
-     * Check if the preconditions of this play are true
-     * @return true if the play is allowed to be started, else false
-     */
-    [[nodiscard]] bool isValidPlayToStart(world_new::World* world) const noexcept;
+  /**
+   * Default move-ctor, ensures proper move-construction of Play
+   */
+  Play(Play&& other) = default;
 
-    /**
-     * Check if the invariants for the play to keep running are true
-     * @return
-     */
-    [[nodiscard]] virtual bool isValidPlayToKeep(world_new::World* world) noexcept;
+  /**
+   * Check if the preconditions of this play are true
+   * @return true if the play is allowed to be started, else false
+   */
+  [[nodiscard]] bool isValidPlayToStart(world_new::World* world) const noexcept;
 
-    /**
-     * @return true if all roles are finished
-     */
-    [[nodiscard]] bool arePlayRolesFinished();
+  /**
+   * Check if the invariants necessary to keep this play are true
+   * @return true if the play is valid to keep, else false
+   */
+  [[nodiscard]] virtual bool isValidPlayToKeep(world_new::World* world) noexcept;
 
-    /**
-     * @return The internal role -> status mapping
-     */
-    [[nodiscard]] std::unordered_map<Role*, Status> const& getRoleStatuses() const;
+  /**
+   * Getter for the role -> status mapping
+   * @return The internal role -> status mapping, roleStatuses
+   */
+  [[nodiscard]] std::unordered_map<Role*, Status> const& getRoleStatuses() const;
 
-    /**
-     * Gets the current play name
-     */
-    virtual const char* getName() = 0;
+  /**
+   * Gets the current play name
+   */
+  virtual const char* getName() = 0;
 
-protected:
-    /**
-     * The roles, constructed in ctor of a play
-     */
-    std::array<std::unique_ptr<Role>, rtt::ai::Constants::ROBOT_COUNT()> roles;
+ protected:
+  /**
+   * The roles, constructed in ctor of a play
+   */
+  std::array<std::unique_ptr<Role>, rtt::ai::Constants::ROBOT_COUNT()> roles;
 
-    /**
-     * Map that keeps track of the status of each role.
-     * It's a Role*, because that's hashable and only 1
-     * instance exists of each role
-     */
-    std::unordered_map<Role*, Status> roleStatuses;
+  /**
+   * Map that keeps track of the status of each role.
+   * It's a Role*, because that's hashable and a unique identifier
+   */
+  std::unordered_map<Role*, Status> roleStatuses;
 
-    /**
-     * The stpInfos, constructed in distributeRoles
-     * The string is the role_name to be able to update the info in the right role
-     */
-    std::unordered_map<std::string, StpInfo> stpInfos;
+  /**
+   * The stpInfos, constructed in distributeRoles
+   * The string is the role_name to be able to update the info in the right role
+   */
+  std::unordered_map<std::string, StpInfo> stpInfos;
 
-    /**
-     * The world
-     */
-    rtt::world_new::World* world;
+  /**
+   * The world pointer
+   */
+  rtt::world_new::World* world{};
 
-    /**
-     * The Field
-     */
-    rtt::ai::world::Field field;
+  /**
+   * The Field
+   */
+  rtt::ai::world::Field field;
 
-    /**
-     * Decides the input to the robot dealer. The result will be used to distribute the roles
-     * @return a mapping between roles and robot flags, used by the robot dealer to assign roles
-     */
-    virtual Dealer::FlagMap decideRoleFlags() const noexcept = 0;
+  /**
+   * Decides the input for the robot dealer. The result will be used to distribute the roles
+   * @return a mapping between roles and robot flags, used by the robot dealer to assign roles
+   */
+  virtual Dealer::FlagMap decideRoleFlags() const noexcept = 0;
 
-    /**
-     * This function is used to determine if, when a role is in an endtactic, that endtactic should be skipped.
-     * An example could be BlockRobot and Intercept. You block a robot until a ball is shot and then the robot
-     * closest to the ball should try to intercept
-     */
-    virtual bool shouldRoleSkipEndTactic() = 0;
+  /**
+   * This function is used to determine if -- when a role is in an endTactic -- the endTactic should be skipped.
+   * An example could be BlockRobot and Intercept. You block a robot (endTactic) until a ball is shot and then the robot
+   * closest to the ball should try to intercept (skip the BlockRobot tactic to execute Intercept)
+   */
+  virtual bool shouldRoleSkipEndTactic() = 0;
 
-   private:
-    /**
-     * This function refreshes the RobotViews, the BallViews and the Fields for all stpInfos.
-     * This is necessary because the views are stored for a limited time; not refreshing will lead to UB
-     */
-    void refreshData() noexcept;
+ private:
+  /**
+   * This function refreshes the RobotViews, the BallViews and the Fields for all stpInfos.
+   * This is necessary because the views are stored for a limited time; not refreshing will lead to UB
+   */
+  void refreshData() noexcept;
 
-    /**
-     * Assigns robots to roles
-     */
-    void distributeRoles() noexcept;
+  /**
+   * Assigns robots to roles
+   */
+  void distributeRoles() noexcept;
 
-    int previousRobotNum{};
+  /**
+   * The previous amount of robots
+   * This is used to check if we need to redeal (if a robot disappears for example)
+   */
+  int previousRobotNum{};
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/PlayChecker.hpp
+++ b/include/roboteam_ai/stp/PlayChecker.hpp
@@ -15,42 +15,42 @@ namespace rtt::ai::stp {
  * Class that gets all the viable plays for a tick
  */
 class PlayChecker {
- public:
-  /**
-   * Sets all the plays in the PlayChecker, takes ownership of plays
-   * @param plays Moved vector of unique plays
-   */
-  void setPlays(std::vector<std::unique_ptr<Play>>& plays) noexcept;
+   public:
+    /**
+     * Sets all the plays in the PlayChecker, takes ownership of plays
+     * @param plays Moved vector of unique plays
+     */
+    void setPlays(std::vector<std::unique_ptr<Play>>& plays) noexcept;
 
-  /**
-   * Gets a vector of currently valid plays
-   * @return map(plays, isValid)
-   */
-  [[nodiscard]] std::vector<Play*> getValidPlays() noexcept;
+    /**
+     * Gets a vector of currently valid plays
+     * @return map(plays, isValid)
+     */
+    [[nodiscard]] std::vector<Play*> getValidPlays() noexcept;
 
-  /**
-   * Sets this->world
-   * @param world World to update against
-   */
-  void update(world_new::World* world) noexcept;
+    /**
+     * Sets this->world
+     * @param world World to update against
+     */
+    void update(world_new::World* world) noexcept;
 
-  /**
-   * Returns the default play
-   * @param playName The name of the play we want to return
-   * @return The play with the name of the argument
-   */
-  [[nodiscard]] Play* getPlayForName(const std::string& playName) const noexcept;
+    /**
+     * Returns the default play
+     * @param playName The name of the play we want to return
+     * @return The play with the name of the argument
+     */
+    [[nodiscard]] Play* getPlayForName(const std::string& playName) const noexcept;
 
- private:
-  /**
-   * A vector of all the plays
-   */
-  std::vector<std::unique_ptr<Play>>* allPlays{};
+   private:
+    /**
+     * A vector of all the plays
+     */
+    std::vector<std::unique_ptr<Play>>* allPlays{};
 
-  /**
-   * Current world, do not use before update()
-   */
-  world_new::World* world{};
+    /**
+     * Current world, do not use before update()
+     */
+    world_new::World* world{};
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/PlayChecker.hpp
+++ b/include/roboteam_ai/stp/PlayChecker.hpp
@@ -10,48 +10,48 @@
 #include "Play.hpp"
 
 namespace rtt::ai::stp {
+
 /**
- * Class that gets all the viable plays
+ * Class that gets all the viable plays for a tick
  */
 class PlayChecker {
-   public:
-    /**
-     * Sets all the plays in the PlayChecker, takes ownership of plays
-     * @param plays Moved vector of unique plays
-     */
-    void setPlays(std::vector<std::unique_ptr<Play>>& plays) noexcept;
+ public:
+  /**
+   * Sets all the plays in the PlayChecker, takes ownership of plays
+   * @param plays Moved vector of unique plays
+   */
+  void setPlays(std::vector<std::unique_ptr<Play>>& plays) noexcept;
 
-    /**
-     * Gets a vector of currently valid plays
-     * @return map(plays, isValid)
-     */
-    [[nodiscard]] std::vector<Play*> getValidPlays() noexcept;
+  /**
+   * Gets a vector of currently valid plays
+   * @return map(plays, isValid)
+   */
+  [[nodiscard]] std::vector<Play*> getValidPlays() noexcept;
 
-    /**
-     * Sets this->world
-     * @param world World to update against
-     */
-    void update(world_new::World* world) noexcept;
+  /**
+   * Sets this->world
+   * @param world World to update against
+   */
+  void update(world_new::World* world) noexcept;
 
-    /**
-     * Returns the default play
-     * @param playName The name of the play we want to return
-     * @return The play with the name of the argument
-     */
-    Play* getPlayForName(const std::string& playName) const noexcept;
+  /**
+   * Returns the default play
+   * @param playName The name of the play we want to return
+   * @return The play with the name of the argument
+   */
+  [[nodiscard]] Play* getPlayForName(const std::string& playName) const noexcept;
 
-   private:
-    /**
-     * An array of all the plays
-     */
-    std::vector<std::unique_ptr<Play>>* allPlays{};
+ private:
+  /**
+   * A vector of all the plays
+   */
+  std::vector<std::unique_ptr<Play>>* allPlays{};
 
-    /**
-     * Current world, do not use before update()
-     */
-    world_new::World* world{};
+  /**
+   * Current world, do not use before update()
+   */
+  world_new::World* world{};
 };
-
 }  // namespace rtt::ai::stp
 
 #endif  // RTT_PLAYCHECKER_HPP

--- a/include/roboteam_ai/stp/PlayDecider.hpp
+++ b/include/roboteam_ai/stp/PlayDecider.hpp
@@ -14,27 +14,27 @@ namespace rtt::ai::stp {
  * If there is a play set in the interface, this play will be picked.
  */
 class PlayDecider {
-  /**
-   * play that's set from the interface in case it's overridden
-   */
-  static inline Play *lockedPlay;
+    /**
+     * play that's set from the interface in case it's overridden
+     */
+    static inline Play *lockedPlay;
 
- public:
-  /**
-   * Sets the locked play, read variable above
-   * @param play Play to lock to
-   */
-  static void lockPlay(Play *play);
+   public:
+    /**
+     * Sets the locked play, read variable above
+     * @param play Play to lock to
+     */
+    static void lockPlay(Play *play);
 
-  /**
-   * This function checks if there is a locked play. If there is, pick that play.
-   * If there isn't, pick the play with the highest score
-   * @param pWorld The world pointer
-   * @param plays the vector of plays
-   * @return The best play for the current tick
-   * (either a locked play through the interface or just the highest scored play)
-   */
-  Play *decideBestPlay(world_new::World *pWorld, std::vector<Play *> plays) noexcept;
+    /**
+     * This function checks if there is a locked play. If there is, pick that play.
+     * If there isn't, pick the play with the highest score
+     * @param pWorld The world pointer
+     * @param plays the vector of plays
+     * @return The best play for the current tick
+     * (either a locked play through the interface or just the highest scored play)
+     */
+    Play *decideBestPlay(world_new::World *pWorld, std::vector<Play *> plays) noexcept;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/PlayDecider.hpp
+++ b/include/roboteam_ai/stp/PlayDecider.hpp
@@ -9,20 +9,33 @@
 
 namespace rtt::ai::stp {
 
-    class PlayDecider {
-        // play that's set from the interface in case it's overridden
-        static inline Play *lockedPlay;
+/**
+ * Decides the best play from a vector of plays.
+ * If there is a play set in the interface, this play will be picked.
+ */
+class PlayDecider {
+  /**
+   * play that's set from the interface in case it's overridden
+   */
+  static inline Play *lockedPlay;
 
-    public:
-        /**
-         * Sets the locked play, read variable above
-         * @param play Play to lock to
-         */
-        static void lockPlay(Play *play);
+ public:
+  /**
+   * Sets the locked play, read variable above
+   * @param play Play to lock to
+   */
+  static void lockPlay(Play *play);
 
-        Play *decideBestPlay(world_new::World *pWorld, std::vector<Play *> plays) noexcept;
-    };
-
+  /**
+   * This function checks if there is a locked play. If there is, pick that play.
+   * If there isn't, pick the play with the highest score
+   * @param pWorld The world pointer
+   * @param plays the vector of plays
+   * @return The best play for the current tick
+   * (either a locked play through the interface or just the highest scored play)
+   */
+  Play *decideBestPlay(world_new::World *pWorld, std::vector<Play *> plays) noexcept;
+};
 }  // namespace rtt::ai::stp
 
 #endif  // RTT_PLAYDECIDER_HPP

--- a/include/roboteam_ai/stp/Role.hpp
+++ b/include/roboteam_ai/stp/Role.hpp
@@ -16,83 +16,83 @@ namespace rtt::ai::stp {
  * A role is essentially a state machine of Tactics
  */
 class Role {
- public:
-  /**
-   * Constructor that has a name as its parameter
-   * @param name the name of the role
-   */
-  explicit Role(std::string name) : roleName{std::move(name)} {}
+   public:
+    /**
+     * Constructor that has a name as its parameter
+     * @param name the name of the role
+     */
+    explicit Role(std::string name) : roleName{std::move(name)} {}
 
-  /**
-   * Function that's called every tick, default implementation is robotTactics.update();
-   * @param info TacticInfo to be passed to update()
-   * @return The status that the current tactic returns
-   */
-  [[nodiscard]] virtual Status update(StpInfo const& info) noexcept;
+    /**
+     * Function that's called every tick, default implementation is robotTactics.update();
+     * @param info TacticInfo to be passed to update()
+     * @return The status that the current tactic returns
+     */
+    [[nodiscard]] virtual Status update(StpInfo const& info) noexcept;
 
-  /**
-   * @return True if all tactics returned Status::finish
-   */
-  [[nodiscard]] bool finished() const noexcept;
+    /**
+     * @return True if all tactics returned Status::finish
+     */
+    [[nodiscard]] bool finished() const noexcept;
 
-  /**
-   * Gets the name
-   * @return name of the role
-   */
-  std::string getName() { return roleName; }
+    /**
+     * Gets the name
+     * @return name of the role
+     */
+    std::string getName() { return roleName; }
 
-  /**
-   * Gets the current robot
-   * @return view to the robot this role belongs to, optional.
-   */
-  [[nodiscard]] std::optional<world_new::view::RobotView> const& getCurrentRobot() const;
+    /**
+     * Gets the current robot
+     * @return view to the robot this role belongs to, optional.
+     */
+    [[nodiscard]] std::optional<world_new::view::RobotView> const& getCurrentRobot() const;
 
-  /**
-   * Gets the tactic whose turn it is
-   * @return Tactic*
-   */
-  [[nodiscard]] Tactic* getCurrentTactic();
+    /**
+     * Gets the tactic whose turn it is
+     * @return Tactic*
+     */
+    [[nodiscard]] Tactic* getCurrentTactic();
 
-  /**
-   * Forces the Role to skip to the next tactic in the state machine
-   */
-  void forceNextTactic() noexcept;
+    /**
+     * Forces the Role to skip to the next tactic in the state machine
+     */
+    void forceNextTactic() noexcept;
 
-  /**
-   * Resets the tactics, skills and robot of this role so re-dealing of robots works as expected
-   */
-  void reset() noexcept;
+    /**
+     * Resets the tactics, skills and robot of this role so re-dealing of robots works as expected
+     */
+    void reset() noexcept;
 
-  /**
-   * Virtual default dtor, ensures proper destruction of Role
-   */
-  virtual ~Role() = default;
+    /**
+     * Virtual default dtor, ensures proper destruction of Role
+     */
+    virtual ~Role() = default;
 
-  /**
-   * Default cpy ctor, ensures proper copy construction of Role
-   */
-  Role(Role& other) = default;
+    /**
+     * Default cpy ctor, ensures proper copy construction of Role
+     */
+    Role(Role& other) = default;
 
-  /**
-   * Default mv ctor, ensures proper move construction of Role
-   */
-  Role(Role&& other) = default;
+    /**
+     * Default mv ctor, ensures proper move construction of Role
+     */
+    Role(Role&& other) = default;
 
- protected:
-  /**
-   * Robot to which this role is currently assigned
-   */
-  std::optional<world_new::view::RobotView> currentRobot;
+   protected:
+    /**
+     * Robot to which this role is currently assigned
+     */
+    std::optional<world_new::view::RobotView> currentRobot;
 
-  /**
-   * Name of the role
-   */
-  std::string roleName{};
+    /**
+     * Name of the role
+     */
+    std::string roleName{};
 
-  /**
-   * State machine that keeps track of tactic states
-   */
-  collections::state_machine<Tactic, Status, StpInfo> robotTactics;
+    /**
+     * State machine that keeps track of tactic states
+     */
+    collections::state_machine<Tactic, Status, StpInfo> robotTactics;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/Role.hpp
+++ b/include/roboteam_ai/stp/Role.hpp
@@ -5,92 +5,95 @@
 #ifndef RTT_ROLE_HPP
 #define RTT_ROLE_HPP
 
-#include <utility>
 #include <vector>
 
 #include "Tactic.h"
 
 namespace rtt::ai::stp {
 /**
- * Role class used in STP, pretty self explanatory
- * essentially a state machine of Tactics
+ * Role class used in STP
+ * Every robot needs to have a role
+ * A role is essentially a state machine of Tactics
  */
 class Role {
-public:
-    Role(std::string name)
-        : roleName{std::move(name)} {}
+ public:
+  /**
+   * Constructor that has a name as its parameter
+   * @param name the name of the role
+   */
+  explicit Role(std::string name) : roleName{std::move(name)} {}
 
-    /**
-    * Function that's called every tick, default implementation is robotTactics.update();
-    * @param info TacticInfo to be passed to update()
-    * @return The status that the current tactic returns
-    */
-    [[nodiscard]] virtual Status update(StpInfo const &info) noexcept;
+  /**
+   * Function that's called every tick, default implementation is robotTactics.update();
+   * @param info TacticInfo to be passed to update()
+   * @return The status that the current tactic returns
+   */
+  [[nodiscard]] virtual Status update(StpInfo const& info) noexcept;
 
-    /**
-    * @return True if all tactics returned Status::finish
-    */
-    [[nodiscard]] bool finished() const noexcept;
+  /**
+   * @return True if all tactics returned Status::finish
+   */
+  [[nodiscard]] bool finished() const noexcept;
 
-    /**
-    * Gets the name
-    * @return name of the role
-    */
-    std::string getName() { return roleName; }
+  /**
+   * Gets the name
+   * @return name of the role
+   */
+  std::string getName() { return roleName; }
 
-    /**
-    * Gets the current robot
-    * @return view to the robot this role belongs to, optional.
-    */
-    [[nodiscard]] std::optional<world_new::view::RobotView> const& getCurrentRobot() const;
+  /**
+   * Gets the current robot
+   * @return view to the robot this role belongs to, optional.
+   */
+  [[nodiscard]] std::optional<world_new::view::RobotView> const& getCurrentRobot() const;
 
-    /**
-    * Gets the tactic whose turn it is
-    * @return Tactic*
-    */
-    [[nodiscard]] Tactic* getCurrentTactic();
+  /**
+   * Gets the tactic whose turn it is
+   * @return Tactic*
+   */
+  [[nodiscard]] Tactic* getCurrentTactic();
 
-    /**
-    * Forces the Role to skip to the next tactic in the state machine
-    */
-    void forceNextTactic() noexcept;
+  /**
+   * Forces the Role to skip to the next tactic in the state machine
+   */
+  void forceNextTactic() noexcept;
 
-    /**
-     * Resets the tactics, skills and robot of this role so re-dealing of robots works as expected
-     */
-    void reset() noexcept;
+  /**
+   * Resets the tactics, skills and robot of this role so re-dealing of robots works as expected
+   */
+  void reset() noexcept;
 
-    /**
-     * Virtual default dtor, ensures proper destruction of Role
-     */
-    virtual ~Role() = default;
+  /**
+   * Virtual default dtor, ensures proper destruction of Role
+   */
+  virtual ~Role() = default;
 
-    /**
-     * Default cpy ctor, ensures proper copy construction of Role
-     */
-    Role(Role& other) = default;
-    /**
-     * Default mv ctor, ensures proper move construction of Role
-     */
-    Role(Role&& other) = default;
+  /**
+   * Default cpy ctor, ensures proper copy construction of Role
+   */
+  Role(Role& other) = default;
 
-protected:
-    /**
-     * Robot to which this role is currently assigned
-     */
-    std::optional<world_new::view::RobotView> currentRobot;
+  /**
+   * Default mv ctor, ensures proper move construction of Role
+   */
+  Role(Role&& other) = default;
 
-    /**
-     * Name of the role
-     */
-    std::string roleName{};
+ protected:
+  /**
+   * Robot to which this role is currently assigned
+   */
+  std::optional<world_new::view::RobotView> currentRobot;
 
-    /**
-     * State machine that keeps track of tactic states
-     */
-    collections::state_machine<Tactic, Status, StpInfo> robotTactics;
+  /**
+   * Name of the role
+   */
+  std::string roleName{};
+
+  /**
+   * State machine that keeps track of tactic states
+   */
+  collections::state_machine<Tactic, Status, StpInfo> robotTactics;
 };
-
 }  // namespace rtt::ai::stp
 
 #endif  // RTT_ROLE_HPP

--- a/include/roboteam_ai/stp/Skill.h
+++ b/include/roboteam_ai/stp/Skill.h
@@ -23,7 +23,7 @@ class Skill {
     Status currentStatus;
 
     /**
-     * Robot command that will eventually be send to the robot
+     * Robot command that will eventually be sent to the robot
      */
     proto::RobotCommand command;
 

--- a/include/roboteam_ai/stp/Skill.h
+++ b/include/roboteam_ai/stp/Skill.h
@@ -16,94 +16,94 @@ namespace rtt::ai::stp {
  * Base skill class, inherit from it for making your own skill
  */
 class Skill {
- protected:
-  /**
-   * Status of the last time update() was called
-   */
-  Status currentStatus;
+   protected:
+    /**
+     * Status of the last time update() was called
+     */
+    Status currentStatus;
 
-  /**
-   * Robot command that will eventually be send to the robot
-   */
-  proto::RobotCommand command;
+    /**
+     * Robot command that will eventually be send to the robot
+     */
+    proto::RobotCommand command;
 
-  /**
-   * Robot this skill controls
-   */
-  std::optional<world_new::view::RobotView> robot;
+    /**
+     * Robot this skill controls
+     */
+    std::optional<world_new::view::RobotView> robot;
 
-  /**
-   * Publishes the current robot command, limits it and refreshes it
-   */
-  virtual void publishRobotCommand(world_new::World const* data) noexcept;
+    /**
+     * Publishes the current robot command, limits it and refreshes it
+     */
+    virtual void publishRobotCommand(world_new::World const* data) noexcept;
 
-  /**
-   * Rotates the robot command to the other side of the field
-   */
-  virtual void rotateRobotCommand() noexcept;
+    /**
+     * Rotates the robot command to the other side of the field
+     */
+    virtual void rotateRobotCommand() noexcept;
 
-  /**
-   * Resets the internal robot command
-   */
-  virtual void refreshRobotCommand() noexcept;
+    /**
+     * Resets the internal robot command
+     */
+    virtual void refreshRobotCommand() noexcept;
 
-  /**
-   * Applies constraints to the internal robot command
-   */
-  virtual void limitRobotCommand() noexcept;
+    /**
+     * Applies constraints to the internal robot command
+     */
+    virtual void limitRobotCommand() noexcept;
 
-  /**
-   * Limits the velocity
-   */
-  virtual void limitVel() noexcept;
+    /**
+     * Limits the velocity
+     */
+    virtual void limitVel() noexcept;
 
-  /**
-   * Limits the angular velocity
-   */
-  virtual void limitAngularVel() noexcept;
+    /**
+     * Limits the angular velocity
+     */
+    virtual void limitAngularVel() noexcept;
 
-  /**
-   * Function that's called when the skill gets updated (every tick)
-   * @param info StpInfo structure that provides data to the skill
-   * @return Status according to its current execution
-   */
-  virtual Status onUpdate(StpInfo const& info) noexcept = 0;
+    /**
+     * Function that's called when the skill gets updated (every tick)
+     * @param info StpInfo structure that provides data to the skill
+     * @return Status according to its current execution
+     */
+    virtual Status onUpdate(StpInfo const& info) noexcept = 0;
 
- public:
-  /**
-   * Gets the status from the last time update() was called
-   * @return this->currentStatus
-   */
-  [[nodiscard]] Status getStatus() const;
+   public:
+    /**
+     * Gets the status from the last time update() was called
+     * @return this->currentStatus
+     */
+    [[nodiscard]] Status getStatus() const;
 
-  /**
-   * Calls onInitialize
-   * @return Status of initialization
-   */
-  virtual void initialize() noexcept;
+    /**
+     * Calls onInitialize
+     * @return Status of initialization
+     */
+    virtual void initialize() noexcept;
 
-  /**
-   * Function that's called when the skill gets updated (every tick)
-   * @param info StpInfo structure that provides data to the skill
-   * @return Status according to its current execution
-   */
-  virtual Status update(StpInfo const& info) noexcept;
+    /**
+     * Function that's called when the skill gets updated (every tick)
+     * @param info StpInfo structure that provides data to the skill
+     * @return Status according to its current execution
+     */
+    virtual Status update(StpInfo const& info) noexcept;
 
-  /**
-   * Calls onTerminate
-   * @return Status of termination
-   */
-  virtual void terminate() noexcept;
+    /**
+     * Calls onTerminate
+     * @return Status of termination
+     */
+    virtual void terminate() noexcept;
 
-  /**
-   * Virtual dtor that ensures proper destruction
-   */
-  virtual ~Skill() = default;
+    /**
+     * Virtual dtor that ensures proper destruction
+     */
+    virtual ~Skill() = default;
 
-  /**
-   * Gets the current skill name
-   */
-  virtual const char* getName() = 0;
+    /**
+     * Gets the current skill name
+     */
+    virtual const char* getName() = 0;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/Skill.h
+++ b/include/roboteam_ai/stp/Skill.h
@@ -6,120 +6,116 @@
 #define RTT_SKILL_H
 
 #include <roboteam_proto/RobotCommand.pb.h>
-#include <world_new/views/RobotView.hpp>
+
 #include "stp/StpInfo.h"
-#include "stp/new_constants/ControlConstants.h"
+#include "world_new/views/RobotView.hpp"
 
 namespace rtt::ai::stp {
+
 /**
  * Base skill class, inherit from it for making your own skill
  */
 class Skill {
-   protected:
-    /**
-     * Current status of the last time update() was called
-     */
-    Status currentStatus;
+ protected:
+  /**
+   * Status of the last time update() was called
+   */
+  Status currentStatus;
 
-    /**
-     * Robot command that will be used for operations, such as publishing
-     */
-    proto::RobotCommand command;
+  /**
+   * Robot command that will eventually be send to the robot
+   */
+  proto::RobotCommand command;
 
-    /**
-     * Robot view, which should be set from the SkillInfo
-     */
-    std::optional<world_new::view::RobotView> robot;
+  /**
+   * Robot this skill controls
+   */
+  std::optional<world_new::view::RobotView> robot;
 
-    /**
-     * Publishes the current robot command, limits it and refreshes it
-     */
-    virtual void publishRobotCommand(world_new::World const* data) noexcept;
+  /**
+   * Publishes the current robot command, limits it and refreshes it
+   */
+  virtual void publishRobotCommand(world_new::World const* data) noexcept;
 
-    /**
-     * Rotates the robot command to the other side of the field
-     */
-    virtual void rotateRobotCommand() noexcept;
+  /**
+   * Rotates the robot command to the other side of the field
+   */
+  virtual void rotateRobotCommand() noexcept;
 
-    /**
-     * Resets the internal robot command
-     */
-    virtual void refreshRobotCommand() noexcept;
+  /**
+   * Resets the internal robot command
+   */
+  virtual void refreshRobotCommand() noexcept;
 
-    /**
-     * Applies constraints to the internal robot command
-     */
-    virtual void limitRobotCommand() noexcept;
+  /**
+   * Applies constraints to the internal robot command
+   */
+  virtual void limitRobotCommand() noexcept;
 
-    /**
-     * Limits the velocity
-     */
-    virtual void limitVel() noexcept;
+  /**
+   * Limits the velocity
+   */
+  virtual void limitVel() noexcept;
 
-    /**
-     * Limits the angular velocity
-     */
-    virtual void limitAngularVel() noexcept;
+  /**
+   * Limits the angular velocity
+   */
+  virtual void limitAngularVel() noexcept;
 
-    /**
-     * Terminates the skill
-     * @return Status of termination
-     */
-    virtual void onTerminate() noexcept = 0;
+  /**
+   * Terminates the skill
+   * @return Status of termination
+   */
+  virtual void onTerminate() noexcept = 0;
 
-    /**
-     * Function that's called when the skill gets updated (every tick)
-     * @param info SkillInfo structure that provides data to the skill
-     * @return Status according to its current execution
-     */
-    virtual Status onUpdate(StpInfo const& info) noexcept = 0;
+  /**
+   * Function that's called when the skill gets updated (every tick)
+   * @param info StpInfo structure that provides data to the skill
+   * @return Status according to its current execution
+   */
+  virtual Status onUpdate(StpInfo const& info) noexcept = 0;
 
-    /**
-     * Initializes the skill
-     * @return Status of initialization
-     */
-    virtual void onInitialize() noexcept = 0;
+  /**
+   * Initializes the skill
+   * @return Status of initialization
+   */
+  virtual void onInitialize() noexcept = 0;
 
-    /**
-     * Resets all the robot controllers in the RobotController struct
-     */
-    void refreshRobotPositionControllers() const noexcept;
+ public:
+  /**
+   * Gets the status from the last time update() was called
+   * @return this->currentStatus
+   */
+  [[nodiscard]] Status getStatus() const;
 
-   public:
-    /**
-     * Gets the status from the last time update() was called
-     * @return this->currentStatus
-     */
-    [[nodiscard]] Status getStatus() const;
+  /**
+   * Calls onInitialize
+   * @return Status of initialization
+   */
+  virtual void initialize() noexcept;
 
-    /**
-     * Calls onInitialize
-     * @return Status of initialization
-     */
-    virtual void initialize() noexcept;
+  /**
+   * Function that's called when the skill gets updated (every tick)
+   * @param info StpInfo structure that provides data to the skill
+   * @return Status according to its current execution
+   */
+  virtual Status update(StpInfo const& info) noexcept;
 
-    /**
-     * Function that's called when the skill gets updated (every tick)
-     * @param info SkillInfo structure that provides data to the skill
-     * @return Status according to its current execution
-     */
-    virtual Status update(StpInfo const& info) noexcept;
+  /**
+   * Calls onTerminate
+   * @return Status of termination
+   */
+  virtual void terminate() noexcept;
 
-    /**
-     * Calls onTerminate
-     * @return Status of termination
-     */
-    virtual void terminate() noexcept;
+  /**
+   * Virtual dtor that ensures proper destruction
+   */
+  virtual ~Skill() = default;
 
-    /**
-     * Virtual dtor that ensures proper destruction
-     */
-    virtual ~Skill() = default;
-
-    /**
-     * Gets the current skill name
-     */
-    virtual const char* getName() = 0;
+  /**
+   * Gets the current skill name
+   */
+  virtual const char* getName() = 0;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/Skill.h
+++ b/include/roboteam_ai/stp/Skill.h
@@ -63,23 +63,11 @@ class Skill {
   virtual void limitAngularVel() noexcept;
 
   /**
-   * Terminates the skill
-   * @return Status of termination
-   */
-  virtual void onTerminate() noexcept = 0;
-
-  /**
    * Function that's called when the skill gets updated (every tick)
    * @param info StpInfo structure that provides data to the skill
    * @return Status according to its current execution
    */
   virtual Status onUpdate(StpInfo const& info) noexcept = 0;
-
-  /**
-   * Initializes the skill
-   * @return Status of initialization
-   */
-  virtual void onInitialize() noexcept = 0;
 
  public:
   /**

--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -35,147 +35,147 @@ constexpr int blockEnumSize = 3;
  * This data propagates all the way from plays down to skills
  */
 struct StpInfo {
- public:
-  const std::optional<world_new::view::RobotView>& getRobot() const { return robot; }
-  void setRobot(const std::optional<world_new::view::RobotView>& robot) { this->robot = robot; }
+   public:
+    const std::optional<world_new::view::RobotView>& getRobot() const { return robot; }
+    void setRobot(const std::optional<world_new::view::RobotView>& robot) { this->robot = robot; }
 
-  const std::optional<world_new::view::RobotView>& getEnemyRobot() const { return enemyRobot; }
-  void setEnemyRobot(const std::optional<world_new::view::RobotView>& enemyRobot) { this->enemyRobot = enemyRobot; }
+    const std::optional<world_new::view::RobotView>& getEnemyRobot() const { return enemyRobot; }
+    void setEnemyRobot(const std::optional<world_new::view::RobotView>& enemyRobot) { this->enemyRobot = enemyRobot; }
 
-  const std::optional<world::Field>& getField() const { return field; }
-  void setField(const std::optional<world::Field>& field) { this->field = field; }
+    const std::optional<world::Field>& getField() const { return field; }
+    void setField(const std::optional<world::Field>& field) { this->field = field; }
 
-  const std::optional<world_new::view::BallView>& getBall() const { return ball; }
-  void setBall(const std::optional<world_new::view::BallView>& ball) { this->ball = ball; }
+    const std::optional<world_new::view::BallView>& getBall() const { return ball; }
+    void setBall(const std::optional<world_new::view::BallView>& ball) { this->ball = ball; }
 
-  const std::optional<Vector2>& getPositionToMoveTo() const { return positionToMoveTo; }
-  void setPositionToMoveTo(const std::optional<Vector2>& position) { this->positionToMoveTo = position; }
+    const std::optional<Vector2>& getPositionToMoveTo() const { return positionToMoveTo; }
+    void setPositionToMoveTo(const std::optional<Vector2>& position) { this->positionToMoveTo = position; }
 
-  const std::optional<Vector2>& getPositionToShootAt() const { return positionToShootAt; }
-  void setPositionToShootAt(const std::optional<Vector2>& position) { this->positionToShootAt = position; }
+    const std::optional<Vector2>& getPositionToShootAt() const { return positionToShootAt; }
+    void setPositionToShootAt(const std::optional<Vector2>& position) { this->positionToShootAt = position; }
 
-  const std::optional<Vector2>& getPositionToDefend() const { return positionToDefend; }
-  void setPositionToDefend(const std::optional<Vector2>& position) { this->positionToDefend = position; }
+    const std::optional<Vector2>& getPositionToDefend() const { return positionToDefend; }
+    void setPositionToDefend(const std::optional<Vector2>& position) { this->positionToDefend = position; }
 
-  double getKickChipVelocity() const { return kickChipVelocity; }
-  void setKickChipVelocity(double kickChipVelocity) { this->kickChipVelocity = kickChipVelocity; }
+    double getKickChipVelocity() const { return kickChipVelocity; }
+    void setKickChipVelocity(double kickChipVelocity) { this->kickChipVelocity = kickChipVelocity; }
 
-  Angle getAngle() const { return angle; }
-  void setAngle(double angle) { this->angle = Angle(angle); }
+    Angle getAngle() const { return angle; }
+    void setAngle(double angle) { this->angle = Angle(angle); }
 
-  int getDribblerSpeed() const { return dribblerSpeed; }
-  void setDribblerSpeed(int dribblerSpeed) { this->dribblerSpeed = dribblerSpeed; }
+    int getDribblerSpeed() const { return dribblerSpeed; }
+    void setDribblerSpeed(int dribblerSpeed) { this->dribblerSpeed = dribblerSpeed; }
 
-  BlockDistance getBlockDistance() const { return blockDistance; }
-  void setBlockDistance(BlockDistance blockDistance) { this->blockDistance = blockDistance; }
+    BlockDistance getBlockDistance() const { return blockDistance; }
+    void setBlockDistance(BlockDistance blockDistance) { this->blockDistance = blockDistance; }
 
-  ShotType getShotType() const { return shotType; }
-  void setShotType(ShotType shotType) { this->shotType = shotType; }
+    ShotType getShotType() const { return shotType; }
+    void setShotType(ShotType shotType) { this->shotType = shotType; }
 
-  const std::optional<KickOrChip>& getKickOrChip() const { return kickOrChip; }
-  void setKickOrChip(const std::optional<KickOrChip>& kickOrChip) { StpInfo::kickOrChip = kickOrChip; }
+    const std::optional<KickOrChip>& getKickOrChip() const { return kickOrChip; }
+    void setKickOrChip(const std::optional<KickOrChip>& kickOrChip) { StpInfo::kickOrChip = kickOrChip; }
 
-  world_new::World* getCurrentWorld() const { return currentWorld; }
-  /// This function is used in a lambda, [[maybe_unused]] is to suppress 'unused' warnings
-  [[maybe_unused]] void setCurrentWorld(world_new::World* world) { currentWorld = world; }
+    world_new::World* getCurrentWorld() const { return currentWorld; }
+    /// This function is used in a lambda, [[maybe_unused]] is to suppress 'unused' warnings
+    [[maybe_unused]] void setCurrentWorld(world_new::World* world) { currentWorld = world; }
 
-  const std::optional<PIDType>& getPidType() const { return PidType; }
-  void setPidType(const std::optional<PIDType>& pidType) { PidType = pidType; }
+    const std::optional<PIDType>& getPidType() const { return PidType; }
+    void setPidType(const std::optional<PIDType>& pidType) { PidType = pidType; }
 
- private:
-  /**
-   * Current world pointer
-   */
-  world_new::World* currentWorld;
+   private:
+    /**
+     * Current world pointer
+     */
+    world_new::World* currentWorld;
 
-  /**
-   * Robot this tactic applies to
-   */
-  std::optional<world_new::view::RobotView> robot;
+    /**
+     * Robot this tactic applies to
+     */
+    std::optional<world_new::view::RobotView> robot;
 
-  /**
-   * EnemyRobot this tactic applies to
-   */
-  std::optional<world_new::view::RobotView> enemyRobot;
+    /**
+     * EnemyRobot this tactic applies to
+     */
+    std::optional<world_new::view::RobotView> enemyRobot;
 
-  /**
-   * Field
-   */
-  std::optional<world::Field> field;
+    /**
+     * Field
+     */
+    std::optional<world::Field> field;
 
-  /**
-   * View to the ball in the world this tactic executes on
-   */
-  std::optional<world_new::view::BallView> ball;
+    /**
+     * View to the ball in the world this tactic executes on
+     */
+    std::optional<world_new::view::BallView> ball;
 
-  /**
-   * Position to move to
-   */
-  std::optional<Vector2> positionToMoveTo;
+    /**
+     * Position to move to
+     */
+    std::optional<Vector2> positionToMoveTo;
 
-  /**
-   * Position to kick or chip at
-   */
-  std::optional<Vector2> positionToShootAt;
+    /**
+     * Position to kick or chip at
+     */
+    std::optional<Vector2> positionToShootAt;
 
-  /**
-   * Position to defend
-   */
-  std::optional<Vector2> positionToDefend;
+    /**
+     * Position to defend
+     */
+    std::optional<Vector2> positionToDefend;
 
-  /**
-   * Velocity of the kick/chip
-   */
-  double kickChipVelocity = 0.0;
+    /**
+     * Velocity of the kick/chip
+     */
+    double kickChipVelocity = 0.0;
 
-  /**
-   * Type of the kick/chip
-   */
-  ShotType shotType{};
+    /**
+     * Type of the kick/chip
+     */
+    ShotType shotType{};
 
-  /**
-   * Reference angle of the robot
-   */
-  Angle angle = Angle(0.0);
+    /**
+     * Reference angle of the robot
+     */
+    Angle angle = Angle(0.0);
 
-  /**
-   * Speed of the dribbler in %
-   */
-  int dribblerSpeed = 0;
+    /**
+     * Speed of the dribbler in %
+     */
+    int dribblerSpeed = 0;
 
-  /**
-   * When blocking off a position, the robot is on line between a targetPosition to block, and the enemy robot.
-   * Used to decide how close this robot should be to enemy robot
-   */
-  BlockDistance blockDistance;
+    /**
+     * When blocking off a position, the robot is on line between a targetPosition to block, and the enemy robot.
+     * Used to decide how close this robot should be to enemy robot
+     */
+    BlockDistance blockDistance;
 
-  /**
-   * Set the shot to be a kick or chip
-   */
-  std::optional<KickOrChip> kickOrChip;
+    /**
+     * Set the shot to be a kick or chip
+     */
+    std::optional<KickOrChip> kickOrChip;
 
-  /**
-   * Enum for deciding which PID should be chosen
-   */
-  std::optional<PIDType> PidType{PIDType::DEFAULT};
+    /**
+     * Enum for deciding which PID should be chosen
+     */
+    std::optional<PIDType> PidType{PIDType::DEFAULT};
 };
 
 /**
  * Util operator<< that allows us to print the status enum
  */
 static std::ostream& operator<<(std::ostream& os, Status status) {
-  switch (status) {
-    case Status::Waiting:
-      return os << "Status::Waiting";
-    case Status::Success:
-      return os << "Status::Success";
-    case Status::Failure:
-      return os << "Status::Failure";
-    case Status::Running:
-      return os << "Status::Running";
-    default:
-      return os << "INVALID STATUS";
-  }
+    switch (status) {
+        case Status::Waiting:
+            return os << "Status::Waiting";
+        case Status::Success:
+            return os << "Status::Success";
+        case Status::Failure:
+            return os << "Status::Failure";
+        case Status::Running:
+            return os << "Status::Running";
+        default:
+            return os << "INVALID STATUS";
+    }
 }
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -5,221 +5,178 @@
 #ifndef RTT_STPINFO_H
 #define RTT_STPINFO_H
 
-#include <roboteam_utils/Circle.h>
-#include <roboteam_utils/Rectangle.h>
-#include <world/Field.h>
-
+#include "world/Field.h"
 #include "world_new/views/BallView.hpp"
 #include "world_new/views/RobotView.hpp"
 
 namespace rtt::ai::stp {
 
 /**
- * Enum class used for status updates
+ * BlockDistance: The distance the robot should block at with the last value being the amount of distances
+ * KickOrChip: Whether the robot should kick or chip in a certain situation
+ * PIDType: The PID type the robot needs to use at a certain time
+ * ShotType: The type of the shot
+ * Status: The states STP can return
  */
-enum class Status {
-    /**
-     * Waiting for something
-     */
-    Waiting,
-    /**
-     * Skill / tactic has finalized running
-     */
-    Success,
-    /**
-     * Skill has failed
-     */
-    Failure,
-    /**
-     * Skill is executing
-     */
-    Running
-};
+enum class BlockDistance { CLOSE = 1, HALFWAY, FAR };
+enum class KickOrChip { KICK, CHIP };
+enum class PIDType { DEFAULT, RECEIVE, INTERCEPT, KEEPER, KEEPER_INTERCEPT };
+enum class ShotType { PASS, TARGET, MAX };
+enum class Status { Waiting, Success, Failure, Running };
+
 /**
- * Enum class used for status updates
+ * BlockEnumSize is the size of the BlockDistance enum
+ * This is used for some calculations (thanks Jesse) on the actual distance in meters
+ */
+constexpr int blockEnumSize = 3;
+
+/**
+ * StpInfo bundles all info a robot could need in one struct
+ * This data propagates all the way from plays down to skills
+ */
+struct StpInfo {
+ public:
+  const std::optional<world_new::view::RobotView>& getRobot() const { return robot; }
+  void setRobot(const std::optional<world_new::view::RobotView>& robot) { this->robot = robot; }
+
+  const std::optional<world_new::view::RobotView>& getEnemyRobot() const { return enemyRobot; }
+  void setEnemyRobot(const std::optional<world_new::view::RobotView>& enemyRobot) { this->enemyRobot = enemyRobot; }
+
+  const std::optional<world::Field>& getField() const { return field; }
+  void setField(const std::optional<world::Field>& field) { this->field = field; }
+
+  const std::optional<world_new::view::BallView>& getBall() const { return ball; }
+  void setBall(const std::optional<world_new::view::BallView>& ball) { this->ball = ball; }
+
+  const std::optional<Vector2>& getPositionToMoveTo() const { return positionToMoveTo; }
+  void setPositionToMoveTo(const std::optional<Vector2>& position) { this->positionToMoveTo = position; }
+
+  const std::optional<Vector2>& getPositionToShootAt() const { return positionToShootAt; }
+  void setPositionToShootAt(const std::optional<Vector2>& position) { this->positionToShootAt = position; }
+
+  const std::optional<Vector2>& getPositionToDefend() const { return positionToDefend; }
+  void setPositionToDefend(const std::optional<Vector2>& position) { this->positionToDefend = position; }
+
+  double getKickChipVelocity() const { return kickChipVelocity; }
+  void setKickChipVelocity(double kickChipVelocity) { this->kickChipVelocity = kickChipVelocity; }
+
+  Angle getAngle() const { return angle; }
+  void setAngle(double angle) { this->angle = Angle(angle); }
+
+  int getDribblerSpeed() const { return dribblerSpeed; }
+  void setDribblerSpeed(int dribblerSpeed) { this->dribblerSpeed = dribblerSpeed; }
+
+  BlockDistance getBlockDistance() const { return blockDistance; }
+  void setBlockDistance(BlockDistance blockDistance) { this->blockDistance = blockDistance; }
+
+  ShotType getShotType() const { return shotType; }
+  void setShotType(ShotType shotType) { this->shotType = shotType; }
+
+  const std::optional<KickOrChip>& getKickOrChip() const { return kickOrChip; }
+  void setKickOrChip(const std::optional<KickOrChip>& kickOrChip) { StpInfo::kickOrChip = kickOrChip; }
+
+  world_new::World* getCurrentWorld() const { return currentWorld; }
+  /// This function is used in a lambda, [[maybe_unused]] is to suppress 'unused' warnings
+  [[maybe_unused]] void setCurrentWorld(world_new::World* world) { currentWorld = world; }
+
+  const std::optional<PIDType>& getPidType() const { return PidType; }
+  void setPidType(const std::optional<PIDType>& pidType) { PidType = pidType; }
+
+ private:
+  /**
+   * Current world pointer
+   */
+  world_new::World* currentWorld;
+
+  /**
+   * Robot this tactic applies to
+   */
+  std::optional<world_new::view::RobotView> robot;
+
+  /**
+   * EnemyRobot this tactic applies to
+   */
+  std::optional<world_new::view::RobotView> enemyRobot;
+
+  /**
+   * Field
+   */
+  std::optional<world::Field> field;
+
+  /**
+   * View to the ball in the world this tactic executes on
+   */
+  std::optional<world_new::view::BallView> ball;
+
+  /**
+   * Position to move to
+   */
+  std::optional<Vector2> positionToMoveTo;
+
+  /**
+   * Position to kick or chip at
+   */
+  std::optional<Vector2> positionToShootAt;
+
+  /**
+   * Position to defend
+   */
+  std::optional<Vector2> positionToDefend;
+
+  /**
+   * Velocity of the kick/chip
+   */
+  double kickChipVelocity = 0.0;
+
+  /**
+   * Type of the kick/chip
+   */
+  ShotType shotType{};
+
+  /**
+   * Reference angle of the robot
+   */
+  Angle angle = Angle(0.0);
+
+  /**
+   * Speed of the dribbler in %
+   */
+  int dribblerSpeed = 0;
+
+  /**
+   * When blocking off a position, the robot is on line between a targetPosition to block, and the enemy robot.
+   * Used to decide how close this robot should be to enemy robot
+   */
+  BlockDistance blockDistance;
+
+  /**
+   * Set the shot to be a kick or chip
+   */
+  std::optional<KickOrChip> kickOrChip;
+
+  /**
+   * Enum for deciding which PID should be chosen
+   */
+  std::optional<PIDType> PidType{PIDType::DEFAULT};
+};
+
+/**
+ * Util operator<< that allows us to print the status enum
  */
 static std::ostream& operator<<(std::ostream& os, Status status) {
-    switch (status) {
-        case Status::Waiting:
-            return os << "Status::Waiting";
-        case Status::Success:
-            return os << "Status::Success";
-        case Status::Failure:
-            return os << "Status::Failure";
-        case Status::Running:
-            return os << "Status::Running";
-        default:
-            return os << "INVALID STATUS";
-    }
+  switch (status) {
+    case Status::Waiting:
+      return os << "Status::Waiting";
+    case Status::Success:
+      return os << "Status::Success";
+    case Status::Failure:
+      return os << "Status::Failure";
+    case Status::Running:
+      return os << "Status::Running";
+    default:
+      return os << "INVALID STATUS";
+  }
 }
-
-/**
- * Class used for the Areas to avoid in TacticInfo
- * @tparam T Type of the shape for the areas to avoid
- */
-template <typename T>
-struct Areas {
-    std::vector<T> areasToAvoid;
-
-    /**
-     * Checks whether the Robot is or would be in any of the shapes
-     * @param pos Center of the robot
-     * @return any(robot in shape for shape in areas)
-     */
-    [[nodiscard]] bool isInAny(Vector2 const& pos) const noexcept {
-        Circle circle{pos, stp::control_constants::ROBOT_RADIUS};
-        return std::any_of(areasToAvoid.begin(), areasToAvoid.end(), [&](auto const& area) { return area.intersects(circle); });
-    }
-};
-
-constexpr static int blockEnumSize = 3; // The number of elements in the blockDistance enum
-enum BlockDistance { CLOSE = 1, HALFWAY, FAR }; // If you change this be sure to change blockLength also
-enum KickChipType { PASS, TARGET, MAX };
-enum KickChip {KICK, CHIP};
-enum PIDType {DEFAULT, RECEIVE, INTERCEPT, KEEPER, KEEPER_INTERCEPT};
-
-struct StpInfo {
-   public:
-    const std::optional<world_new::view::RobotView>& getRobot() const { return robot; }
-    void setRobot(const std::optional<world_new::view::RobotView>& robot) { this->robot = robot; }
-
-    const std::optional<world_new::view::RobotView>& getEnemyRobot() const { return enemyRobot; }
-    void setEnemyRobot(const std::optional<world_new::view::RobotView>& enemyRobot) { this->enemyRobot = enemyRobot; }
-
-    const std::optional<world::Field>& getField() const { return field; }
-    void setField(const std::optional<world::Field>& field) { this->field = field; }
-
-    const std::optional<world_new::view::BallView>& getBall() const { return ball; }
-    void setBall(const std::optional<world_new::view::BallView>& ball) { this->ball = ball; }
-
-    const std::optional<Vector2>& getPositionToMoveTo() const { return positionToMoveTo; }
-    void setPositionToMoveTo(const std::optional<Vector2>& position) { this->positionToMoveTo = position; }
-
-    const std::optional<Vector2>& getPositionToShootAt() const { return positionToShootAt; }
-    void setPositionToShootAt(const std::optional<Vector2>& position) { this->positionToShootAt = position; }
-
-    const std::optional<Vector2>& getPositionToDefend() const { return positionToDefend; }
-    void setPositionToDefend(const std::optional<Vector2>& position) { this->positionToDefend = position; }
-
-    double getKickChipVelocity() const { return kickChipVelocity; }
-    void setKickChipVelocity(double kickChipVelocity) { this->kickChipVelocity = kickChipVelocity; }
-
-    Angle getAngle() const { return angle; }
-    void setAngle(double angle) { this->angle = Angle(angle); }
-
-    int getDribblerSpeed() const { return dribblerSpeed; }
-    void setDribblerSpeed(int dribblerSpeed) { this->dribblerSpeed = dribblerSpeed; }
-
-    BlockDistance getBlockDistance() const { return blockDistance; }
-    void setBlockDistance(BlockDistance blockDistance) { this->blockDistance = blockDistance; }
-
-    KickChipType getKickChipType() const { return kickChipType; }
-    void setKickChipType(KickChipType kickChipType) { this->kickChipType = kickChipType; }
-
-    const std::optional<double> &getAvoidBallDistance() const { return avoidBallDistance; }
-    void setAvoidBallDistance(const std::optional<double> &avoidBallDistance) { this->avoidBallDistance = avoidBallDistance; }
-
-    const std::optional<KickChip> &getShootType() const { return shootType; }
-    void setShootType(const std::optional<KickChip> &shootType) { StpInfo::shootType = shootType; }
-
-    world_new::World* getCurrentWorld() const {
-        return currentWorld;
-    }
-
-    void setCurrentWorld(world_new::World* world) {
-        currentWorld = world;
-    }
-
-    const std::optional<PIDType> &getPidType() const {
-        return PidType;
-    }
-
-    void setPidType(const std::optional<PIDType> &pidType) {
-        PidType = pidType;
-    }
-
-   private:
-    /**
-     * Current world pointer
-     */
-     world_new::World* currentWorld;
-
-    /**
-     * Robot this tactic applies to
-     */
-    std::optional<world_new::view::RobotView> robot;
-
-    /**
-     * EnemyRobot this tactic applies to
-     */
-    std::optional<world_new::view::RobotView> enemyRobot;
-
-    /**
-     * Field
-     */
-    std::optional<world::Field> field;
-
-    /**
-     * View to the ball in the world this tactic executes on
-     */
-    std::optional<world_new::view::BallView> ball;
-
-    /**
-     * Position to move to
-     */
-    std::optional<Vector2> positionToMoveTo;
-
-    /**
-     * Position to kick or chip at
-     */
-    std::optional<Vector2> positionToShootAt;
-
-    /**
-     * Position to defend
-     */
-    std::optional<Vector2> positionToDefend;
-
-    /**
-     * Velocity of the kick/chip
-     */
-    double kickChipVelocity = 0.0;
-
-    /**
-     * Type of the kick/chip
-     */
-    KickChipType kickChipType{};
-
-    /**
-     * Reference angle of the robot
-     */
-    Angle angle = Angle(0.0);
-
-    /**
-     * Speed of the dribbler in %
-     */
-    int dribblerSpeed = 0;
-
-    /**
-     * When blocking off a position, the robot is on line between a targetPosition to block, and the enemy robot.
-     * Used to decide how close this robot should be to enemy robot
-     */
-    BlockDistance blockDistance;
-
-    /**
-     * When avoiding the ball, the robot will try to keep this distance (in meters) between the ball and the robot)
-     */
-    std::optional<double> avoidBallDistance;
-
-    /**
-     * Set the shot to be a kick or chip
-     */
-    std::optional<KickChip> shootType;
-
-    /**
-     * Enum for deciding which PID should be chosen
-     */
-     std::optional<PIDType> PidType {DEFAULT};
-};
 }  // namespace rtt::ai::stp
 
 #endif  // RTT_STPINFO_H

--- a/include/roboteam_ai/stp/Tactic.h
+++ b/include/roboteam_ai/stp/Tactic.h
@@ -15,109 +15,109 @@ namespace rtt::ai::stp {
 class Skill;
 
 class Tactic {
- protected:
-  /**
-   * Status of tactic, from last time update() was called
-   */
-  Status currentStatus{};
+   protected:
+    /**
+     * Status of tactic, from last time update() was called
+     */
+    Status currentStatus{};
 
-  /**
-   * This function should calculate any extra information that the skills might need to be executed.
-   * Things that should be calculated are for example how hard the kicker should shoot to get to the desired position
-   * or how fast the dribbler should be spinning.
-   *
-   * Though this method is responsible for ensuring everything is calculated, it helps to use helpers so this
-   * function doesn't become a massive hack
-   * @param info StpInfo struct that contains the info passed down from Role
-   * @return an StpInfo struct with extra information for the skill
-   */
-  virtual std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept = 0;
+    /**
+     * This function should calculate any extra information that the skills might need to be executed.
+     * Things that should be calculated are for example how hard the kicker should shoot to get to the desired position
+     * or how fast the dribbler should be spinning.
+     *
+     * Though this method is responsible for ensuring everything is calculated, it helps to use helpers so this
+     * function doesn't become a massive hack
+     * @param info StpInfo struct that contains the info passed down from Role
+     * @return an StpInfo struct with extra information for the skill
+     */
+    virtual std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept = 0;
 
-  /**
-   * The condition when the current tactic fails
-   * @param info the tactic info passed down from the play
-   * @return true if the tactic's prerequisites are no longer met (e.g. losing the ball)
-   */
-  virtual bool isTacticFailing(const StpInfo &info) noexcept = 0;
+    /**
+     * The condition when the current tactic fails
+     * @param info the tactic info passed down from the play
+     * @return true if the tactic's prerequisites are no longer met (e.g. losing the ball)
+     */
+    virtual bool isTacticFailing(const StpInfo &info) noexcept = 0;
 
-  /**
-   * When the state should reset
-   * @param info the tactic info passed down from the play
-   * @return true if the active skill cannot execute (it's prerequisites are no longer met)
-   */
-  virtual bool shouldTacticReset(const StpInfo &info) noexcept = 0;
+    /**
+     * When the state should reset
+     * @param info the tactic info passed down from the play
+     * @return true if the active skill cannot execute (it's prerequisites are no longer met)
+     */
+    virtual bool shouldTacticReset(const StpInfo &info) noexcept = 0;
 
-  /**
-   * Check if the current tactic is an end tactic - only Running or Failure status
-   * @return true if the current tactic cannot succeed (i.e. is an end tactic)
-   */
-  virtual bool isEndTactic() noexcept = 0;
+    /**
+     * Check if the current tactic is an end tactic - only Running or Failure status
+     * @return true if the current tactic cannot succeed (i.e. is an end tactic)
+     */
+    virtual bool isEndTactic() noexcept = 0;
 
-  /**
-   * The state machine of skills
-   */
-  rtt::collections::state_machine<Skill, Status, StpInfo> skills;
+    /**
+     * The state machine of skills
+     */
+    rtt::collections::state_machine<Skill, Status, StpInfo> skills;
 
- public:
-  /**
-   * Gets this->currentStatus
-   */
-  [[nodiscard]] Status getStatus() const;
+   public:
+    /**
+     * Gets this->currentStatus
+     */
+    [[nodiscard]] Status getStatus() const;
 
-  /**
-   * Calls onInitialize of the tactic
-   */
-  void initialize() noexcept;
+    /**
+     * Calls onInitialize of the tactic
+     */
+    void initialize() noexcept;
 
-  /**
-   * Check if state machine is done, calls calculateInfoForSkill, calls update on the state machine with SkillInfo and calls onUpdate of this tactic for extra customization
-   * @param info info passed by the Role
-   * @return Status of the skill that is currently being ticked
-   */
-  Status update(StpInfo const &info) noexcept;
+    /**
+     * Check if state machine is done, calls calculateInfoForSkill, calls update on the state machine with SkillInfo and calls onUpdate of this tactic for extra customization
+     * @param info info passed by the Role
+     * @return Status of the skill that is currently being ticked
+     */
+    Status update(StpInfo const &info) noexcept;
 
-  /**
-   * Calls onTerminate
-   */
-  void terminate() noexcept;
+    /**
+     * Calls onTerminate
+     */
+    void terminate() noexcept;
 
-  /**
-   * Ensure proper destruction of Tactic classes
-   */
-  virtual ~Tactic() = default;
+    /**
+     * Ensure proper destruction of Tactic classes
+     */
+    virtual ~Tactic() = default;
 
-  /**
-   * Default ctor, ensures proper construction of Tactic
-   */
-  Tactic() = default;
+    /**
+     * Default ctor, ensures proper construction of Tactic
+     */
+    Tactic() = default;
 
-  /**
-   * Default move-ctor, ensures proper move-construction of Tactic
-   */
-  Tactic(Tactic &&other) = default;
+    /**
+     * Default move-ctor, ensures proper move-construction of Tactic
+     */
+    Tactic(Tactic &&other) = default;
 
-  /**
-   * Reset the state machine
-   */
-  void reset() noexcept;
+    /**
+     * Reset the state machine
+     */
+    void reset() noexcept;
 
-  /**
-   * Gets the current tactic name
-   */
-  virtual const char *getName() = 0;
+    /**
+     * Gets the current tactic name
+     */
+    virtual const char *getName() = 0;
 
-  /**
-   * Gets the skill whose turn it is
-   * @return Skill*
-   */
-  Skill *getCurrentSkill();
+    /**
+     * Gets the skill whose turn it is
+     * @return Skill*
+     */
+    Skill *getCurrentSkill();
 
-  /**
-   * Forces a tactic to be success, when we have the ball for example.
-   * @param info to do calculations on
-   * @return a bool whether the tactic is forced successful or not
-   */
-  virtual bool forceTacticSuccess(const StpInfo &info) noexcept;
+    /**
+     * Forces a tactic to be success, when we have the ball for example.
+     * @param info to do calculations on
+     * @return a bool whether the tactic is forced successful or not
+     */
+    virtual bool forceTacticSuccess(const StpInfo &info) noexcept;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/Tactic.h
+++ b/include/roboteam_ai/stp/Tactic.h
@@ -5,8 +5,6 @@
 #ifndef RTT_TACTIC_H
 #define RTT_TACTIC_H
 
-#include <roboteam_utils/Print.h>
-
 #include <roboteam_utils/containers/state_machine.hpp>
 #include <vector>
 
@@ -17,122 +15,124 @@ namespace rtt::ai::stp {
 class Skill;
 
 class Tactic {
-   protected:
-    /**
-     * Current status of tactic, from last time update() was called
-     */
-    Status currentStatus;
+ protected:
+  /**
+   * Status of tactic, from last time update() was called
+   */
+  Status currentStatus;
 
-    /**
-     * This function should calculate any extra information that the skills might need to be executed.
-     * Things that should be calculated are for example how hard the kicker should shoot to get to the desired position
-     * or how fast the dribbler should be spinning.
-     *
-     * Though this method is responsible for ensuring everything is calculated, it helps to use helpers so this
-     * function doesn't become a massive hack
-     */
-    virtual std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept = 0;
+  /**
+   * This function should calculate any extra information that the skills might need to be executed.
+   * Things that should be calculated are for example how hard the kicker should shoot to get to the desired position
+   * or how fast the dribbler should be spinning.
+   *
+   * Though this method is responsible for ensuring everything is calculated, it helps to use helpers so this
+   * function doesn't become a massive hack
+   * @param info StpInfo struct that contains the info passed down from Role
+   * @return an StpInfo struct with extra information for the skill
+   */
+  virtual std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept = 0;
 
-    /**
-     * called on initialization of this tactic
-     */
-    virtual void onInitialize() noexcept = 0;
+  /**
+   * called on initialization of this tactic
+   */
+  virtual void onInitialize() noexcept = 0;
 
-    /**
-     * called on update of this tactic
-     */
-    virtual void onUpdate(Status const &status) noexcept = 0;
+  /**
+   * called on update of this tactic
+   */
+  virtual void onUpdate(Status const &status) noexcept = 0;
 
-    /**
-     * called on terminate of this tactic
-     */
-    virtual void onTerminate() noexcept = 0;
+  /**
+   * called on terminate of this tactic
+   */
+  virtual void onTerminate() noexcept = 0;
 
-    /**
-     * The condition when the current tactic fails
-     * @param info the tactic info passed down from the play
-     * @return true if the tactic's prerequisites are no longer met (e.g. losing the ball)
-     */
-    virtual bool isTacticFailing(const StpInfo &info) noexcept = 0;
+  /**
+   * The condition when the current tactic fails
+   * @param info the tactic info passed down from the play
+   * @return true if the tactic's prerequisites are no longer met (e.g. losing the ball)
+   */
+  virtual bool isTacticFailing(const StpInfo &info) noexcept = 0;
 
-    /**
-     * When the state should reset
-     * @param info the tactic info passed down from the play
-     * @return true if the active skill cannot execute (it's prerequisites are no longer met)
-     */
-    virtual bool shouldTacticReset(const StpInfo &info) noexcept = 0;
+  /**
+   * When the state should reset
+   * @param info the tactic info passed down from the play
+   * @return true if the active skill cannot execute (it's prerequisites are no longer met)
+   */
+  virtual bool shouldTacticReset(const StpInfo &info) noexcept = 0;
 
-    /**
-     * Check if the current tactic is an end tactic - only Running or Failure status
-     * @return true if the current tactic cannot succeed (i.e. is an end tactic)
-     */
-    virtual bool isEndTactic() noexcept = 0;
+  /**
+   * Check if the current tactic is an end tactic - only Running or Failure status
+   * @return true if the current tactic cannot succeed (i.e. is an end tactic)
+   */
+  virtual bool isEndTactic() noexcept = 0;
 
-    /**
-     * The state machine of skills
-     */
-    rtt::collections::state_machine<Skill, Status, StpInfo> skills;
+  /**
+   * The state machine of skills
+   */
+  rtt::collections::state_machine<Skill, Status, StpInfo> skills;
 
-   public:
-    /**
-     * Gets this->currentStatus
-     */
-    [[nodiscard]] Status getStatus() const;
+ public:
+  /**
+   * Gets this->currentStatus
+   */
+  [[nodiscard]] Status getStatus() const;
 
-    /**
-     * Calls onInitialize of the tactic
-     */
-    virtual void initialize() noexcept;
+  /**
+   * Calls onInitialize of the tactic
+   */
+  virtual void initialize() noexcept;
 
-    /**
-     * Check if state machine is done, calls calculateInfoForSkill, calls update on the state machine with SkillInfo and calls onUpdate of this tactic for extra customization
-     * @param info info passed by the Role
-     * @return Status of the skill that is currently being ticked
-     */
-    virtual Status update(StpInfo const &info) noexcept;
+  /**
+   * Check if state machine is done, calls calculateInfoForSkill, calls update on the state machine with SkillInfo and calls onUpdate of this tactic for extra customization
+   * @param info info passed by the Role
+   * @return Status of the skill that is currently being ticked
+   */
+  virtual Status update(StpInfo const &info) noexcept;
 
-    /**
-     * Calls onTerminate
-     */
-    virtual void terminate() noexcept;
+  /**
+   * Calls onTerminate
+   */
+  virtual void terminate() noexcept;
 
-    /**
-     * Ensure proper destruction of Tactic classes
-     */
-    virtual ~Tactic() = default;
+  /**
+   * Ensure proper destruction of Tactic classes
+   */
+  virtual ~Tactic() = default;
 
-    /**
-     * Default ctor, ensures proper construction of Tactic
-     */
-    Tactic() = default;
+  /**
+   * Default ctor, ensures proper construction of Tactic
+   */
+  Tactic() = default;
 
-    /**
-     * Default move-ctor, ensures proper move-construction of Tactic
-     */
-    Tactic(Tactic &&other) = default;
+  /**
+   * Default move-ctor, ensures proper move-construction of Tactic
+   */
+  Tactic(Tactic &&other) = default;
 
-    /**
-     * Reset the state machine
-     */
-    void reset() noexcept;
+  /**
+   * Reset the state machine
+   */
+  void reset() noexcept;
 
-    /**
-     * Gets the current tactic name
-     */
-    virtual const char *getName() = 0;
+  /**
+   * Gets the current tactic name
+   */
+  virtual const char *getName() = 0;
 
-    /**
-     * Gets the skill whose turn it is
-     * @return Skill*
-     */
-    Skill *getCurrentSkill();
+  /**
+   * Gets the skill whose turn it is
+   * @return Skill*
+   */
+  Skill *getCurrentSkill();
 
-    /**
-     * Forces a tactic to be success, when we have the ball for example.
-     * @param info to do calculations on
-     * @return a bool whether the tactic is forced successful or not
-     */
-    virtual bool forceTacticSuccess(const StpInfo &info) noexcept;
+  /**
+   * Forces a tactic to be success, when we have the ball for example.
+   * @param info to do calculations on
+   * @return a bool whether the tactic is forced successful or not
+   */
+  virtual bool forceTacticSuccess(const StpInfo &info) noexcept;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/Tactic.h
+++ b/include/roboteam_ai/stp/Tactic.h
@@ -19,7 +19,7 @@ class Tactic {
   /**
    * Status of tactic, from last time update() was called
    */
-  Status currentStatus;
+  Status currentStatus{};
 
   /**
    * This function should calculate any extra information that the skills might need to be executed.
@@ -32,21 +32,6 @@ class Tactic {
    * @return an StpInfo struct with extra information for the skill
    */
   virtual std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept = 0;
-
-  /**
-   * called on initialization of this tactic
-   */
-  virtual void onInitialize() noexcept = 0;
-
-  /**
-   * called on update of this tactic
-   */
-  virtual void onUpdate(Status const &status) noexcept = 0;
-
-  /**
-   * called on terminate of this tactic
-   */
-  virtual void onTerminate() noexcept = 0;
 
   /**
    * The condition when the current tactic fails
@@ -82,19 +67,19 @@ class Tactic {
   /**
    * Calls onInitialize of the tactic
    */
-  virtual void initialize() noexcept;
+  void initialize() noexcept;
 
   /**
    * Check if state machine is done, calls calculateInfoForSkill, calls update on the state machine with SkillInfo and calls onUpdate of this tactic for extra customization
    * @param info info passed by the Role
    * @return Status of the skill that is currently being ticked
    */
-  virtual Status update(StpInfo const &info) noexcept;
+  Status update(StpInfo const &info) noexcept;
 
   /**
    * Calls onTerminate
    */
-  virtual void terminate() noexcept;
+  void terminate() noexcept;
 
   /**
    * Ensure proper destruction of Tactic classes

--- a/include/roboteam_ai/stp/invariants/BallCloseToThemInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallCloseToThemInvariant.h
@@ -6,35 +6,33 @@
 #define RTT_BALLCLOSETOTHEMINVARIANT_H
 
 #include <NFParam/Param.h>
+
 #include "BaseInvariant.h"
 
 namespace rtt::ai::stp::invariant {
 
 class BallCloseToThemInvariant : public BaseInvariant {
-public:
-    BallCloseToThemInvariant() noexcept;
+ public:
+  BallCloseToThemInvariant() noexcept;
 
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "BallCloseToThem";
-    }
+  const char* getName() override { return "BallCloseToThem"; }
 
-private:
-    /**
-     * Calculates the actual metric value using the piecewise linear function member
-     * @param x the x of the function
-     * @return metric value between 0-255
-     */
-    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+ private:
+  /**
+   * Calculates the actual metric value using the piecewise linear function member
+   * @param x the x of the function
+   * @return metric value between 0-255
+   */
+  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-    /**
-     * Unique pointer to the piecewise linear function that calculates the fuzzy value
-     */
-    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+  /**
+   * Unique pointer to the piecewise linear function that calculates the fuzzy value
+   */
+  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_BALLCLOSETOTHEMINVARIANT_H
+#endif  // RTT_BALLCLOSETOTHEMINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/BallCloseToThemInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallCloseToThemInvariant.h
@@ -12,25 +12,25 @@
 namespace rtt::ai::stp::invariant {
 
 class BallCloseToThemInvariant : public BaseInvariant {
- public:
-  BallCloseToThemInvariant() noexcept;
+   public:
+    BallCloseToThemInvariant() noexcept;
 
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "BallCloseToThem"; }
+    const char* getName() override { return "BallCloseToThem"; }
 
- private:
-  /**
-   * Calculates the actual metric value using the piecewise linear function member
-   * @param x the x of the function
-   * @return metric value between 0-255
-   */
-  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+   private:
+    /**
+     * Calculates the actual metric value using the piecewise linear function member
+     * @param x the x of the function
+     * @return metric value between 0-255
+     */
+    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-  /**
-   * Unique pointer to the piecewise linear function that calculates the fuzzy value
-   */
-  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    /**
+     * Unique pointer to the piecewise linear function that calculates the fuzzy value
+     */
+    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 
 }  // namespace rtt::ai::stp::invariant

--- a/include/roboteam_ai/stp/invariants/BallCloseToUsInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallCloseToUsInvariant.h
@@ -11,25 +11,25 @@
 
 namespace rtt::ai::stp::invariant {
 class BallCloseToUsInvariant : public BaseInvariant {
- public:
-  BallCloseToUsInvariant() noexcept;
+   public:
+    BallCloseToUsInvariant() noexcept;
 
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "BallCloseToUs"; }
+    const char* getName() override { return "BallCloseToUs"; }
 
- private:
-  /**
-   * Calculates the actual metric value using the piecewise linear function member
-   * @param x the x of the function
-   * @return metric value between 0-255
-   */
-  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+   private:
+    /**
+     * Calculates the actual metric value using the piecewise linear function member
+     * @param x the x of the function
+     * @return metric value between 0-255
+     */
+    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-  /**
-   * Unique pointer to the piecewise linear function that calculates the fuzzy value
-   */
-  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    /**
+     * Unique pointer to the piecewise linear function that calculates the fuzzy value
+     */
+    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallCloseToUsInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallCloseToUsInvariant.h
@@ -6,32 +6,30 @@
 #define RTT_BALLCLOSETOUSINVARIANT_H
 
 #include <NFParam/Param.h>
+
 #include "BaseInvariant.h"
 
 namespace rtt::ai::stp::invariant {
 class BallCloseToUsInvariant : public BaseInvariant {
-   public:
-    BallCloseToUsInvariant() noexcept;
+ public:
+  BallCloseToUsInvariant() noexcept;
 
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "BallCloseToUs";
-    }
+  const char* getName() override { return "BallCloseToUs"; }
 
-   private:
-    /**
-     * Calculates the actual metric value using the piecewise linear function member
-     * @param x the x of the function
-     * @return metric value between 0-255
-     */
-    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+ private:
+  /**
+   * Calculates the actual metric value using the piecewise linear function member
+   * @param x the x of the function
+   * @return metric value between 0-255
+   */
+  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-    /**
-     * Unique pointer to the piecewise linear function that calculates the fuzzy value
-     */
-    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+  /**
+   * Unique pointer to the piecewise linear function that calculates the fuzzy value
+   */
+  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallClosestToUsInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallClosestToUsInvariant.h
@@ -9,10 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class BallClosestToUsInvariant : public BaseInvariant {
-   public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override { return "BallClosestToUs"; }
+  const char* getName() override { return "BallClosestToUs"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallClosestToUsInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallClosestToUsInvariant.h
@@ -9,10 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class BallClosestToUsInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "BallClosestToUs"; }
+    const char* getName() override { return "BallClosestToUs"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallGotShotInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallGotShotInvariant.h
@@ -6,32 +6,30 @@
 #define RTT_BALLGOTSHOTINVARIANT_H
 
 #include <NFParam/Param.h>
+
 #include "BaseInvariant.h"
 
 namespace rtt::ai::stp::invariant {
 class BallGotShotInvariant : public BaseInvariant {
-   public:
-    BallGotShotInvariant() noexcept;
+ public:
+  BallGotShotInvariant() noexcept;
 
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "BallGotShot";
-    }
+  const char* getName() override { return "BallGotShot"; }
 
-   private:
-    /**
-     * Calculates the actual metric value using the piecewise linear function member
-     * @param x the x of the function
-     * @return metric value between 0-255
-     */
-    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+ private:
+  /**
+   * Calculates the actual metric value using the piecewise linear function member
+   * @param x the x of the function
+   * @return metric value between 0-255
+   */
+  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-    /**
-     * Unique pointer to the piecewise linear function that calculates the fuzzy value
-     */
-    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+  /**
+   * Unique pointer to the piecewise linear function that calculates the fuzzy value
+   */
+  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallGotShotInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallGotShotInvariant.h
@@ -11,25 +11,25 @@
 
 namespace rtt::ai::stp::invariant {
 class BallGotShotInvariant : public BaseInvariant {
- public:
-  BallGotShotInvariant() noexcept;
+   public:
+    BallGotShotInvariant() noexcept;
 
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "BallGotShot"; }
+    const char* getName() override { return "BallGotShot"; }
 
- private:
-  /**
-   * Calculates the actual metric value using the piecewise linear function member
-   * @param x the x of the function
-   * @return metric value between 0-255
-   */
-  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+   private:
+    /**
+     * Calculates the actual metric value using the piecewise linear function member
+     * @param x the x of the function
+     * @return metric value between 0-255
+     */
+    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-  /**
-   * Unique pointer to the piecewise linear function that calculates the fuzzy value
-   */
-  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    /**
+     * Unique pointer to the piecewise linear function that calculates the fuzzy value
+     */
+    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallIsFreeInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallIsFreeInvariant.h
@@ -12,10 +12,10 @@ namespace rtt::ai::stp::invariant {
  * Check if the ball is currently not owned by any team
  */
 class BallIsFreeInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "BallIsFree"; }
+    const char* getName() override { return "BallIsFree"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallIsFreeInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallIsFreeInvariant.h
@@ -8,19 +8,15 @@
 #include "BaseInvariant.h"
 
 namespace rtt::ai::stp::invariant {
-/** 
+/**
  * Check if the ball is currently not owned by any team
  */
 class BallIsFreeInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "BallIsFree";
-    }
+  const char* getName() override { return "BallIsFree"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_BALLISFREEINVARIANT_H
+#endif  // RTT_BALLISFREEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/BallMovesSlowInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallMovesSlowInvariant.h
@@ -11,28 +11,25 @@
 
 namespace rtt::ai::stp::invariant {
 class BallMovesSlowInvariant : public BaseInvariant {
-   public:
-    BallMovesSlowInvariant() noexcept;
+ public:
+  BallMovesSlowInvariant() noexcept;
 
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-    {
-        return "BallMovesSlow";
-    }
-	
-   private:
-    /**
-     * Calculates the actual metric value using the piecewise linear function member
-     * @param x the x of the function
-     * @return metric value between 0-255
-     */
-    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+  const char* getName() override { return "BallMovesSlow"; }
 
-    /**
-     * Unique pointer to the piecewise linear function that calculates the fuzzy value
-     */
-    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+ private:
+  /**
+   * Calculates the actual metric value using the piecewise linear function member
+   * @param x the x of the function
+   * @return metric value between 0-255
+   */
+  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+
+  /**
+   * Unique pointer to the piecewise linear function that calculates the fuzzy value
+   */
+  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallMovesSlowInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallMovesSlowInvariant.h
@@ -11,25 +11,25 @@
 
 namespace rtt::ai::stp::invariant {
 class BallMovesSlowInvariant : public BaseInvariant {
- public:
-  BallMovesSlowInvariant() noexcept;
+   public:
+    BallMovesSlowInvariant() noexcept;
 
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "BallMovesSlow"; }
+    const char* getName() override { return "BallMovesSlow"; }
 
- private:
-  /**
-   * Calculates the actual metric value using the piecewise linear function member
-   * @param x the x of the function
-   * @return metric value between 0-255
-   */
-  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+   private:
+    /**
+     * Calculates the actual metric value using the piecewise linear function member
+     * @param x the x of the function
+     * @return metric value between 0-255
+     */
+    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-  /**
-   * Unique pointer to the piecewise linear function that calculates the fuzzy value
-   */
-  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    /**
+     * Unique pointer to the piecewise linear function that calculates the fuzzy value
+     */
+    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallOnOurSideInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallOnOurSideInvariant.h
@@ -9,13 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class BallOnOurSideInvariant : public BaseInvariant {
-   public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "BallOnOurSideInvariant";
-    }
+  const char* getName() override { return "BallOnOurSideInvariant"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallOnOurSideInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallOnOurSideInvariant.h
@@ -9,10 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class BallOnOurSideInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "BallOnOurSideInvariant"; }
+    const char* getName() override { return "BallOnOurSideInvariant"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BallShotOrCloseToThemInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallShotOrCloseToThemInvariant.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::invariant {
 
 class BallShotOrCloseToThemInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override { return "BallShotOrCloseToThem"; }
+  const char* getName() override { return "BallShotOrCloseToThem"; }
 };
 
-}   // namespace rtt::ai::stp::invariant
+}  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_BALLSHOTORCLOSETOTHEMINVARIANT_H
+#endif  // RTT_BALLSHOTORCLOSETOTHEMINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/BallShotOrCloseToThemInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BallShotOrCloseToThemInvariant.h
@@ -10,10 +10,10 @@
 namespace rtt::ai::stp::invariant {
 
 class BallShotOrCloseToThemInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "BallShotOrCloseToThem"; }
+    const char* getName() override { return "BallShotOrCloseToThem"; }
 };
 
 }  // namespace rtt::ai::stp::invariant

--- a/include/roboteam_ai/stp/invariants/BaseInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BaseInvariant.h
@@ -9,30 +9,31 @@
 
 namespace rtt::ai::stp::invariant {
 class BaseInvariant {
-   public:
-    /**
-     * Converts the fuzzy return to a boolean return
-     * @param world the world
-     * @param field the field
-     * @param cutOff the cutoff number, if the truth value is higher than this number the invariant returns true
-     * @return returns true when greater than cutoff and false when smaller than cutoff
-     */
-    [[nodiscard]] bool checkInvariant(world_new::view::WorldDataView world, const world::Field *field, const uint8_t cutOff = stp::control_constants::FUZZY_DEFAULT_CUTOFF) const noexcept;
+ public:
+  /**
+   * Converts the fuzzy return to a boolean return
+   * @param world the world
+   * @param field the field
+   * @param cutOff the cutoff number, if the truth value is higher than this number the invariant returns true
+   * @return returns true when greater than cutoff and false when smaller than cutoff
+   */
+  [[nodiscard]] bool checkInvariant(world_new::view::WorldDataView world, const world::Field *field,
+                                    const uint8_t cutOff = stp::control_constants::FUZZY_DEFAULT_CUTOFF) const noexcept;
 
-    /**
-     * Calculates the 'true-ness' of the invariant between 0 and 255. 0 == false, 255 == true
-     * @param world the world
-     * @param field the field
-     * @return the 'true-ness' of this invariant during this tick
-     */
-    [[nodiscard]] virtual uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept = 0;
+  /**
+   * Calculates the 'true-ness' of the invariant between 0 and 255. 0 == false, 255 == true
+   * @param world the world
+   * @param field the field
+   * @return the 'true-ness' of this invariant during this tick
+   */
+  [[nodiscard]] virtual uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept = 0;
 
-    /**
-     * dtor
-     */
-    virtual ~BaseInvariant() = default;
+  /**
+   * dtor
+   */
+  virtual ~BaseInvariant() = default;
 
-    virtual const char* getName() = 0;
+  virtual const char *getName() = 0;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/BaseInvariant.h
+++ b/include/roboteam_ai/stp/invariants/BaseInvariant.h
@@ -9,31 +9,31 @@
 
 namespace rtt::ai::stp::invariant {
 class BaseInvariant {
- public:
-  /**
-   * Converts the fuzzy return to a boolean return
-   * @param world the world
-   * @param field the field
-   * @param cutOff the cutoff number, if the truth value is higher than this number the invariant returns true
-   * @return returns true when greater than cutoff and false when smaller than cutoff
-   */
-  [[nodiscard]] bool checkInvariant(world_new::view::WorldDataView world, const world::Field *field,
-                                    const uint8_t cutOff = stp::control_constants::FUZZY_DEFAULT_CUTOFF) const noexcept;
+   public:
+    /**
+     * Converts the fuzzy return to a boolean return
+     * @param world the world
+     * @param field the field
+     * @param cutOff the cutoff number, if the truth value is higher than this number the invariant returns true
+     * @return returns true when greater than cutoff and false when smaller than cutoff
+     */
+    [[nodiscard]] bool checkInvariant(world_new::view::WorldDataView world, const world::Field *field,
+                                      const uint8_t cutOff = stp::control_constants::FUZZY_DEFAULT_CUTOFF) const noexcept;
 
-  /**
-   * Calculates the 'true-ness' of the invariant between 0 and 255. 0 == false, 255 == true
-   * @param world the world
-   * @param field the field
-   * @return the 'true-ness' of this invariant during this tick
-   */
-  [[nodiscard]] virtual uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept = 0;
+    /**
+     * Calculates the 'true-ness' of the invariant between 0 and 255. 0 == false, 255 == true
+     * @param world the world
+     * @param field the field
+     * @return the 'true-ness' of this invariant during this tick
+     */
+    [[nodiscard]] virtual uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept = 0;
 
-  /**
-   * dtor
-   */
-  virtual ~BaseInvariant() = default;
+    /**
+     * dtor
+     */
+    virtual ~BaseInvariant() = default;
 
-  virtual const char *getName() = 0;
+    virtual const char *getName() = 0;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/DistanceFromBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/DistanceFromBallInvariant.h
@@ -11,28 +11,25 @@
 
 namespace rtt::ai::stp::invariant {
 class DistanceFromBallInvariant : public BaseInvariant {
-   public:
-    DistanceFromBallInvariant() noexcept;
+ public:
+  DistanceFromBallInvariant() noexcept;
 
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "DistanceFromBallInvariant";
-    }
+  const char* getName() override { return "DistanceFromBallInvariant"; }
 
-   private:
-    /**
-     * Calculates the actual metric value using the piecewise linear function member
-     * @param x the x of the function
-     * @return metric value between 0-255
-     */
-    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+ private:
+  /**
+   * Calculates the actual metric value using the piecewise linear function member
+   * @param x the x of the function
+   * @return metric value between 0-255
+   */
+  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-    /**
-     * Unique pointer to the piecewise linear function that calculates the fuzzy value
-     */
-    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+  /**
+   * Unique pointer to the piecewise linear function that calculates the fuzzy value
+   */
+  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/DistanceFromBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/DistanceFromBallInvariant.h
@@ -11,25 +11,25 @@
 
 namespace rtt::ai::stp::invariant {
 class DistanceFromBallInvariant : public BaseInvariant {
- public:
-  DistanceFromBallInvariant() noexcept;
+   public:
+    DistanceFromBallInvariant() noexcept;
 
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "DistanceFromBallInvariant"; }
+    const char* getName() override { return "DistanceFromBallInvariant"; }
 
- private:
-  /**
-   * Calculates the actual metric value using the piecewise linear function member
-   * @param x the x of the function
-   * @return metric value between 0-255
-   */
-  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+   private:
+    /**
+     * Calculates the actual metric value using the piecewise linear function member
+     * @param x the x of the function
+     * @return metric value between 0-255
+     */
+    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-  /**
-   * Unique pointer to the piecewise linear function that calculates the fuzzy value
-   */
-  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    /**
+     * Unique pointer to the piecewise linear function that calculates the fuzzy value
+     */
+    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/FirstArrivalToBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/FirstArrivalToBallInvariant.h
@@ -10,15 +10,12 @@
 namespace rtt::ai::stp::invariant {
 
 class FirstArrivalToBallInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "FirstArrivalToBallInvariant";
-    }
+  const char* getName() override { return "FirstArrivalToBallInvariant"; }
 };
 
-} // namespace rtt::ai::stp::invariant
+}  // namespace rtt::ai::stp::invariant
 
-#endif // RTT_FIRSTARRIVALTOBALLINVARIANT_H
+#endif  // RTT_FIRSTARRIVALTOBALLINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/FirstArrivalToBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/FirstArrivalToBallInvariant.h
@@ -10,10 +10,10 @@
 namespace rtt::ai::stp::invariant {
 
 class FirstArrivalToBallInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "FirstArrivalToBallInvariant"; }
+    const char* getName() override { return "FirstArrivalToBallInvariant"; }
 };
 
 }  // namespace rtt::ai::stp::invariant

--- a/include/roboteam_ai/stp/invariants/FreedomOfRobotsInvariant.h
+++ b/include/roboteam_ai/stp/invariants/FreedomOfRobotsInvariant.h
@@ -12,25 +12,25 @@
 namespace rtt::ai::stp::invariant {
 
 class FreedomOfRobotsInvariant : public BaseInvariant {
- public:
-  FreedomOfRobotsInvariant() noexcept;
+   public:
+    FreedomOfRobotsInvariant() noexcept;
 
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "FreedomOfRobots"; }
+    const char* getName() override { return "FreedomOfRobots"; }
 
- private:
-  /**
-   * Calculates the actual metric value using the piecewise linear function member
-   * @param x the x of the function
-   * @return metric value between 0-255
-   */
-  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+   private:
+    /**
+     * Calculates the actual metric value using the piecewise linear function member
+     * @param x the x of the function
+     * @return metric value between 0-255
+     */
+    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-  /**
-   * Unique pointer to the piecewise linear function that calculates the fuzzy value
-   */
-  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    /**
+     * Unique pointer to the piecewise linear function that calculates the fuzzy value
+     */
+    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/FreedomOfRobotsInvariant.h
+++ b/include/roboteam_ai/stp/invariants/FreedomOfRobotsInvariant.h
@@ -6,35 +6,32 @@
 #define RTT_FREEDOMOFROBOTSINVARIANT_H
 
 #include <NFParam/Param.h>
+
 #include "BaseInvariant.h"
 
 namespace rtt::ai::stp::invariant {
 
 class FreedomOfRobotsInvariant : public BaseInvariant {
-public:
-    FreedomOfRobotsInvariant() noexcept;
+ public:
+  FreedomOfRobotsInvariant() noexcept;
 
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "FreedomOfRobots";
-    }
-	
-private:
-    /**
-     * Calculates the actual metric value using the piecewise linear function member
-     * @param x the x of the function
-     * @return metric value between 0-255
-     */
-    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+  const char* getName() override { return "FreedomOfRobots"; }
 
-    /**
-     * Unique pointer to the piecewise linear function that calculates the fuzzy value
-     */
-    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+ private:
+  /**
+   * Calculates the actual metric value using the piecewise linear function member
+   * @param x the x of the function
+   * @return metric value between 0-255
+   */
+  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+
+  /**
+   * Unique pointer to the piecewise linear function that calculates the fuzzy value
+   */
+  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_FREEDOMOFROBOTSINVARIANT_H
+#endif  // RTT_FREEDOMOFROBOTSINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/GoalVisionFromBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/GoalVisionFromBallInvariant.h
@@ -14,25 +14,25 @@ namespace rtt::ai::stp::invariant {
     Calculates goal vision percentage based on the position of the ball
 **/
 class GoalVisionFromBallInvariant : public BaseInvariant {
- public:
-  GoalVisionFromBallInvariant() noexcept;
+   public:
+    GoalVisionFromBallInvariant() noexcept;
 
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "GoalVisionFromBall"; }
+    const char* getName() override { return "GoalVisionFromBall"; }
 
- private:
-  /**
-   * Calculates the actual metric value using the piecewise linear function member
-   * @param x the x of the function
-   * @return metric value between 0-255
-   */
-  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+   private:
+    /**
+     * Calculates the actual metric value using the piecewise linear function member
+     * @param x the x of the function
+     * @return metric value between 0-255
+     */
+    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-  /**
-   * Unique pointer to the piecewise linear function that calculates the fuzzy value
-   */
-  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    /**
+     * Unique pointer to the piecewise linear function that calculates the fuzzy value
+     */
+    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/GoalVisionFromBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/GoalVisionFromBallInvariant.h
@@ -14,30 +14,26 @@ namespace rtt::ai::stp::invariant {
     Calculates goal vision percentage based on the position of the ball
 **/
 class GoalVisionFromBallInvariant : public BaseInvariant {
-public:
-    GoalVisionFromBallInvariant() noexcept;
+ public:
+  GoalVisionFromBallInvariant() noexcept;
 
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "GoalVisionFromBall";
-    }
+  const char* getName() override { return "GoalVisionFromBall"; }
 
-private:
-    /**
-     * Calculates the actual metric value using the piecewise linear function member
-     * @param x the x of the function
-     * @return metric value between 0-255
-     */
-    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+ private:
+  /**
+   * Calculates the actual metric value using the piecewise linear function member
+   * @param x the x of the function
+   * @return metric value between 0-255
+   */
+  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-    /**
-     * Unique pointer to the piecewise linear function that calculates the fuzzy value
-     */
-    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+  /**
+   * Unique pointer to the piecewise linear function that calculates the fuzzy value
+   */
+  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_GOALVISIONFROMBALLINVARIANT_H
+#endif  // RTT_GOALVISIONFROMBALLINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/GoalVisionInvariant.h
+++ b/include/roboteam_ai/stp/invariants/GoalVisionInvariant.h
@@ -11,33 +11,29 @@
 
 namespace rtt::ai::stp::invariant {
 /**
-    Calculates goal vision percentage based on the positions of all our robots
-**/
+ * Calculates goal vision percentage based on the positions of all our robots
+ */
 class GoalVisionInvariant : public BaseInvariant {
-   public:
-    GoalVisionInvariant() noexcept;
+ public:
+  GoalVisionInvariant() noexcept;
 
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "GoalVisionInvariant";
-    }
-	
-   private:
-    /**
-     * Calculates the actual metric value using the piecewise linear function member
-     * @param x the x of the function
-     * @return metric value between 0-255
-     */
-    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+  const char* getName() override { return "GoalVisionInvariant"; }
 
-    /**
-     * Unique pointer to the piecewise linear function that calculates the fuzzy value
-     */
-    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+ private:
+  /**
+   * Calculates the actual metric value using the piecewise linear function member
+   * @param x the x of the function
+   * @return metric value between 0-255
+   */
+  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+
+  /**
+   * Unique pointer to the piecewise linear function that calculates the fuzzy value
+   */
+  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
-
 }  // namespace rtt::ai::stp::invariant
 
 #endif  // RTT_GOALVISIONINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/GoalVisionInvariant.h
+++ b/include/roboteam_ai/stp/invariants/GoalVisionInvariant.h
@@ -14,25 +14,25 @@ namespace rtt::ai::stp::invariant {
  * Calculates goal vision percentage based on the positions of all our robots
  */
 class GoalVisionInvariant : public BaseInvariant {
- public:
-  GoalVisionInvariant() noexcept;
+   public:
+    GoalVisionInvariant() noexcept;
 
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "GoalVisionInvariant"; }
+    const char* getName() override { return "GoalVisionInvariant"; }
 
- private:
-  /**
-   * Calculates the actual metric value using the piecewise linear function member
-   * @param x the x of the function
-   * @return metric value between 0-255
-   */
-  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+   private:
+    /**
+     * Calculates the actual metric value using the piecewise linear function member
+     * @param x the x of the function
+     * @return metric value between 0-255
+     */
+    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-  /**
-   * Unique pointer to the piecewise linear function that calculates the fuzzy value
-   */
-  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    /**
+     * Unique pointer to the piecewise linear function that calculates the fuzzy value
+     */
+    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/NoGoalVisionFromBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/NoGoalVisionFromBallInvariant.h
@@ -14,25 +14,25 @@ namespace rtt::ai::stp::invariant {
     Calculates the goal vision percentage based on the position of the ball and inverts this value
 */
 class NoGoalVisionFromBallInvariant : public BaseInvariant {
- public:
-  NoGoalVisionFromBallInvariant() noexcept;
+   public:
+    NoGoalVisionFromBallInvariant() noexcept;
 
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "NoGoalVisionFromBall"; }
+    const char* getName() override { return "NoGoalVisionFromBall"; }
 
- private:
-  /**
-   * Calculates the actual metric value using the piecewise linear function member
-   * @param x the x of the function
-   * @return metric value between 0-255
-   */
-  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+   private:
+    /**
+     * Calculates the actual metric value using the piecewise linear function member
+     * @param x the x of the function
+     * @return metric value between 0-255
+     */
+    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-  /**
-   * Unique pointer to the piecewise linear function that calculates the fuzzy value
-   */
-  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    /**
+     * Unique pointer to the piecewise linear function that calculates the fuzzy value
+     */
+    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/NoGoalVisionFromBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/NoGoalVisionFromBallInvariant.h
@@ -14,30 +14,26 @@ namespace rtt::ai::stp::invariant {
     Calculates the goal vision percentage based on the position of the ball and inverts this value
 */
 class NoGoalVisionFromBallInvariant : public BaseInvariant {
-   public:
-    NoGoalVisionFromBallInvariant() noexcept;
+ public:
+  NoGoalVisionFromBallInvariant() noexcept;
 
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "NoGoalVisionFromBall";
-    }
+  const char* getName() override { return "NoGoalVisionFromBall"; }
 
-   private:
-    /**
-     * Calculates the actual metric value using the piecewise linear function member
-     * @param x the x of the function
-     * @return metric value between 0-255
-     */
-    [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+ private:
+  /**
+   * Calculates the actual metric value using the piecewise linear function member
+   * @param x the x of the function
+   * @return metric value between 0-255
+   */
+  [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
 
-    /**
-     * Unique pointer to the piecewise linear function that calculates the fuzzy value
-     */
-    std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+  /**
+   * Unique pointer to the piecewise linear function that calculates the fuzzy value
+   */
+  std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
 };
-
 }  // namespace rtt::ai::stp::invariant
 
 #endif  // RTT_NOGOALVISIONFROMBALLINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/WeHaveBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/WeHaveBallInvariant.h
@@ -9,10 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class WeHaveBallInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "WeHaveBall"; }
+    const char* getName() override { return "WeHaveBall"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/WeHaveBallInvariant.h
+++ b/include/roboteam_ai/stp/invariants/WeHaveBallInvariant.h
@@ -9,13 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class WeHaveBallInvariant : public BaseInvariant {
-   public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-    const char* getName() override
-    {
-        return "WeHaveBall";
-    }
+  const char* getName() override { return "WeHaveBall"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/WeHaveMajorityInvariant.h
+++ b/include/roboteam_ai/stp/invariants/WeHaveMajorityInvariant.h
@@ -8,15 +8,12 @@
 #include "BaseInvariant.h"
 
 namespace rtt::ai::stp::invariant {
-    class WeHaveMajorityInvariant : public BaseInvariant {
-    public:
-        [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+class WeHaveMajorityInvariant : public BaseInvariant {
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-        const char* getName() override
-        {
-            return "WeHaveMajority";
-        }
-    };
-}   // namespace rtt::ai::stp::invariant
+  const char* getName() override { return "WeHaveMajority"; }
+};
+}  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_WEHAVEMAJORITYINVARIANT_H
+#endif  // RTT_WEHAVEMAJORITYINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/WeHaveMajorityInvariant.h
+++ b/include/roboteam_ai/stp/invariants/WeHaveMajorityInvariant.h
@@ -9,10 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class WeHaveMajorityInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "WeHaveMajority"; }
+    const char* getName() override { return "WeHaveMajority"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/BallPlacementThemGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/BallPlacementThemGameStateInvariant.h
@@ -9,10 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class BallPlacementThemGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::BallPlacementThem"; }
+    const char* getName() override { return "gs::BallPlacementThem"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/BallPlacementThemGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/BallPlacementThemGameStateInvariant.h
@@ -9,13 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class BallPlacementThemGameStateInvariant : public BaseInvariant {
-   public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::BallPlacementThem";
-	}
+  const char* getName() override { return "gs::BallPlacementThem"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/BallPlacementUsGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/BallPlacementUsGameStateInvariant.h
@@ -9,10 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class BallPlacementUsGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::BallPlacementUs"; }
+    const char* getName() override { return "gs::BallPlacementUs"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/BallPlacementUsGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/BallPlacementUsGameStateInvariant.h
@@ -9,13 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class BallPlacementUsGameStateInvariant : public BaseInvariant {
-   public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::BallPlacementUs";
-	}
+  const char* getName() override { return "gs::BallPlacementUs"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/FreeKickThemGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/FreeKickThemGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state free kick them prepare
  */
 class FreeKickThemGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::FreeKickThem"; }
+    const char* getName() override { return "gs::FreeKickThem"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/FreeKickThemGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/FreeKickThemGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state free kick them prepare
  */
 class FreeKickThemGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::FreeKickThem";
-	}
+  const char* getName() override { return "gs::FreeKickThem"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_FREEKICKTHEMGAMESTATEINVARIANT_H
+#endif  // RTT_FREEKICKTHEMGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/FreeKickUsGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/FreeKickUsGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state free kick us prepare
  */
 class FreeKickUsGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::FreeKickUs"; }
+    const char* getName() override { return "gs::FreeKickUs"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/FreeKickUsGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/FreeKickUsGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state free kick us prepare
  */
 class FreeKickUsGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::FreeKickUs";
-	}
+  const char* getName() override { return "gs::FreeKickUs"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_FREEKICKUSGAMESTATEINVARIANT_H
+#endif  // RTT_FREEKICKUSGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/HaltGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/HaltGameStateInvariant.h
@@ -9,10 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class HaltGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::Halt"; }
+    const char* getName() override { return "gs::Halt"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/HaltGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/HaltGameStateInvariant.h
@@ -9,13 +9,10 @@
 
 namespace rtt::ai::stp::invariant {
 class HaltGameStateInvariant : public BaseInvariant {
-   public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::Halt";
-	}
+  const char* getName() override { return "gs::Halt"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/KickOffThemGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/KickOffThemGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state kick off them
  */
 class KickOffThemGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::KickOffThem"; }
+    const char* getName() override { return "gs::KickOffThem"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/KickOffThemGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/KickOffThemGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state kick off them
  */
 class KickOffThemGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::KickOffThem";
-	}
+  const char* getName() override { return "gs::KickOffThem"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_KICKOFFTHEMGAMESTATEINVARIANT_H
+#endif  // RTT_KICKOFFTHEMGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/KickOffThemPrepareGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/KickOffThemPrepareGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state kick off them prepare
  */
 class KickOffThemPrepareGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::KickOffThem"; }
+    const char* getName() override { return "gs::KickOffThem"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/KickOffThemPrepareGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/KickOffThemPrepareGameStateInvariant.h
@@ -12,16 +12,12 @@ namespace rtt::ai::stp::invariant {
 /**
  * Invariant for the game state kick off them prepare
  */
-    class KickOffThemPrepareGameStateInvariant : public BaseInvariant {
-    public:
-        [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+class KickOffThemPrepareGameStateInvariant : public BaseInvariant {
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-        const char* getName() override
-        {
-            return "gs::KickOffThem";
-        }
-    };
-
+  const char* getName() override { return "gs::KickOffThem"; }
+};
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_KICKOFFUSPREPAREGAMESTATEINVARIANT_H
+#endif  // RTT_KICKOFFUSPREPAREGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/KickOffUsGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/KickOffUsGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state kick off us
  */
 class KickOffUsGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::KickOffUs"; }
+    const char* getName() override { return "gs::KickOffUs"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/KickOffUsGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/KickOffUsGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state kick off us
  */
 class KickOffUsGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::KickOffUs";
-	}
+  const char* getName() override { return "gs::KickOffUs"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_KICKOFFUSGAMESTATEINVARIANT_H
+#endif  // RTT_KICKOFFUSGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/KickOffUsPrepareGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/KickOffUsPrepareGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state kick off us prepare
  */
 class KickOffUsPrepareGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::KickOffUsPrepare";
-	}
+  const char* getName() override { return "gs::KickOffUsPrepare"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_KICKOFFUSPREPAREGAMESTATEINVARIANT_H
+#endif  // RTT_KICKOFFUSPREPAREGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/KickOffUsPrepareGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/KickOffUsPrepareGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state kick off us prepare
  */
 class KickOffUsPrepareGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::KickOffUsPrepare"; }
+    const char* getName() override { return "gs::KickOffUsPrepare"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/NormalOrFreeKickUsGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/NormalOrFreeKickUsGameStateInvariant.h
@@ -10,14 +10,11 @@
 namespace rtt::ai::stp::invariant {
 
 class NormalOrFreeKickUsGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::NormalOrFreeKickUs";
-	}
+  const char* getName() override { return "gs::NormalOrFreeKickUs"; }
 };
-}
+}  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_NORMALORFREEKICKUSGAMESTATEINVARIANT_H
+#endif  // RTT_NORMALORFREEKICKUSGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/NormalOrFreeKickUsGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/NormalOrFreeKickUsGameStateInvariant.h
@@ -10,10 +10,10 @@
 namespace rtt::ai::stp::invariant {
 
 class NormalOrFreeKickUsGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::NormalOrFreeKickUs"; }
+    const char* getName() override { return "gs::NormalOrFreeKickUs"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/NormalPlayGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/NormalPlayGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state normal play
  */
 class NormalPlayGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::NormalPlay"; }
+    const char* getName() override { return "gs::NormalPlay"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/NormalPlayGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/NormalPlayGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state normal play
  */
 class NormalPlayGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::NormalPlay";
-	}
+  const char* getName() override { return "gs::NormalPlay"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_NORMALPLAYGAMESTATEINVARIANT_H
+#endif  // RTT_NORMALPLAYGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/PenaltyThemGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/PenaltyThemGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state penalty them
  */
 class PenaltyThemGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::PenaltyThem";
-	}
+  const char* getName() override { return "gs::PenaltyThem"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_PENALTYTHEMGAMESTATEINVARIANT_H
+#endif  // RTT_PENALTYTHEMGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/PenaltyThemGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/PenaltyThemGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state penalty them
  */
 class PenaltyThemGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::PenaltyThem"; }
+    const char* getName() override { return "gs::PenaltyThem"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/PenaltyThemPrepareGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/PenaltyThemPrepareGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state penalty them prepare
  */
 class PenaltyThemPrepareGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::PenaltyThemPrepare"; }
+    const char* getName() override { return "gs::PenaltyThemPrepare"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/PenaltyThemPrepareGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/PenaltyThemPrepareGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state penalty them prepare
  */
 class PenaltyThemPrepareGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::PenaltyThemPrepare";
-	}
+  const char* getName() override { return "gs::PenaltyThemPrepare"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_PENALTYTHEMPREPAREGAMESTATEINVARIANT_H
+#endif  // RTT_PENALTYTHEMPREPAREGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/PenaltyUsGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/PenaltyUsGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state penalty us
  */
 class PenaltyUsGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::PenaltyUs"; }
+    const char* getName() override { return "gs::PenaltyUs"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/PenaltyUsGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/PenaltyUsGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state penalty us
  */
 class PenaltyUsGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::PenaltyUs";
-	}
+  const char* getName() override { return "gs::PenaltyUs"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_PENALTYUSGAMESTATEINVARIANT_H
+#endif  // RTT_PENALTYUSGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/PenaltyUsPrepareGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/PenaltyUsPrepareGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state penalty us prepare
  */
 class PenaltyUsPrepareGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::PenaltyUsPrepare";
-	}
+  const char* getName() override { return "gs::PenaltyUsPrepare"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_PENALTYUSPREPAREGAMESTATEINVARIANT_H
+#endif  // RTT_PENALTYUSPREPAREGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/PenaltyUsPrepareGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/PenaltyUsPrepareGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state penalty us prepare
  */
 class PenaltyUsPrepareGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::PenaltyUsPrepare"; }
+    const char* getName() override { return "gs::PenaltyUsPrepare"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/StopGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/StopGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state stop
  */
 class StopGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::Stop";
-	}
+  const char* getName() override { return "gs::Stop"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_STOPGAMESTATEINVARIANT_H
+#endif  // RTT_STOPGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/StopGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/StopGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state stop
  */
 class StopGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::Stop"; }
+    const char* getName() override { return "gs::Stop"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/invariants/game_states/TimeOutGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/TimeOutGameStateInvariant.h
@@ -13,15 +13,11 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state timeout
  */
 class TimeOutGameStateInvariant : public BaseInvariant {
-public:
-    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field *field) const noexcept override;
+ public:
+  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-	const char* getName() override
-	{
-		return "gs::TimeOut";
-	}
+  const char* getName() override { return "gs::TimeOut"; }
 };
-
 }  // namespace rtt::ai::stp::invariant
 
-#endif //RTT_TIMEOUTGAMESTATEINVARIANT_H
+#endif  // RTT_TIMEOUTGAMESTATEINVARIANT_H

--- a/include/roboteam_ai/stp/invariants/game_states/TimeOutGameStateInvariant.h
+++ b/include/roboteam_ai/stp/invariants/game_states/TimeOutGameStateInvariant.h
@@ -13,10 +13,10 @@ namespace rtt::ai::stp::invariant {
  * Invariant for the game state timeout
  */
 class TimeOutGameStateInvariant : public BaseInvariant {
- public:
-  [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
+   public:
+    [[nodiscard]] uint8_t metricCheck(world_new::view::WorldDataView world, const world::Field* field) const noexcept override;
 
-  const char* getName() override { return "gs::TimeOut"; }
+    const char* getName() override { return "gs::TimeOut"; }
 };
 }  // namespace rtt::ai::stp::invariant
 

--- a/include/roboteam_ai/stp/new_constants/ControlConstants.h
+++ b/include/roboteam_ai/stp/new_constants/ControlConstants.h
@@ -25,7 +25,7 @@ extern const double CENTER_TO_FRONT;
 // Dribbler constants
 extern const double TURN_ON_DRIBBLER_DISTANCE;
 
-// Team constants TODO: Maybe this should be in a different constants file
+// Team constants
 inline constexpr uint8_t MAX_ROBOT_COUNT = 11;
 
 // Ball constants

--- a/include/roboteam_ai/stp/new_constants/ControlConstants.h
+++ b/include/roboteam_ai/stp/new_constants/ControlConstants.h
@@ -42,6 +42,7 @@ extern const double ENEMY_CLOSE_TO_BALL_DISTANCE;
 extern const double MAX_VEL_CMD;
 extern const double MAX_DRIBBLER_CMD;
 extern const double ANGLE_RATE;
+extern const double MAX_VEL_WHEN_HAS_BALL;
 
 // HasBall margins
 extern const double HAS_BALL_ANGLE_ERROR_MARGIN;

--- a/include/roboteam_ai/stp/new_plays/AggressiveFormation.h
+++ b/include/roboteam_ai/stp/new_plays/AggressiveFormation.h
@@ -10,46 +10,46 @@
 namespace rtt::ai::stp::play {
 
 class AggressiveFormation : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  AggressiveFormation();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    AggressiveFormation();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Decides the input for the robot dealer. The result will be used to distribute the roles
-   * @return a mapping between roles and robot flags, used by the robot dealer to assign roles
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Decides the input for the robot dealer. The result will be used to distribute the roles
+     * @return a mapping between roles and robot flags, used by the robot dealer to assign roles
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  /**
-   * This function is used to determine if -- when a role is in an endTactic -- the endTactic should be skipped.
-   * An example could be BlockRobot and Intercept. You block a robot (endTactic) until a ball is shot and then the robot
-   * closest to the ball should try to intercept (skip the BlockRobot tactic to execute Intercept)
-   */
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    /**
+     * This function is used to determine if -- when a role is in an endTactic -- the endTactic should be skipped.
+     * An example could be BlockRobot and Intercept. You block a robot (endTactic) until a ball is shot and then the robot
+     * closest to the ball should try to intercept (skip the BlockRobot tactic to execute Intercept)
+     */
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/AggressiveFormation.h
+++ b/include/roboteam_ai/stp/new_plays/AggressiveFormation.h
@@ -5,45 +5,51 @@
 #ifndef RTT_AGGRESSIVEFORMATION_H
 #define RTT_AGGRESSIVEFORMATION_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class AggressiveFormation : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    AggressiveFormation();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  AggressiveFormation();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Decides the input for the robot dealer. The result will be used to distribute the roles
+   * @return a mapping between roles and robot flags, used by the robot dealer to assign roles
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-   protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  /**
+   * This function is used to determine if -- when a role is in an endTactic -- the endTactic should be skipped.
+   * An example could be BlockRobot and Intercept. You block a robot (endTactic) until a ball is shot and then the robot
+   * closest to the ball should try to intercept (skip the BlockRobot tactic to execute Intercept)
+   */
+  bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/Attack.h
+++ b/include/roboteam_ai/stp/new_plays/Attack.h
@@ -10,64 +10,69 @@
 namespace rtt::ai::stp::play {
 
 class Attack : public Play {
-public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    Attack();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  Attack();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World *world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char *getName() override;
 
-protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  /**
+   * This function is used to determine if -- when a role is in an endTactic -- the endTactic should be skipped.
+   * An example could be BlockRobot and Intercept. You block a robot (endTactic) until a ball is shot and then the robot
+   * closest to the ball should try to intercept (skip the BlockRobot tactic to execute Intercept)
+   */
+  bool shouldRoleSkipEndTactic() override;
 
-private:
-    /**
-     * Calculate point in goal to aim for
-     * @return Target point
-     */
-    Vector2 calculateGoalTarget() noexcept;
+ private:
+  /**
+   * Calculate point in goal to aim for
+   * @return Target point
+   */
+  Vector2 calculateGoalTarget() noexcept;
 
-    /**
-     * Calculate points we want to aim for
-     * @param field Field
-     * @param fromPoint Position to shoot from
-     * @return Line between the two aim points
-     */
-    Line getAimPoints(const world::Field &field, const Vector2 &fromPoint);
+  /**
+   * Calculate points we want to aim for
+   * @param field Field
+   * @param fromPoint Position to shoot from
+   * @return Line between the two aim points
+   */
+  Line getAimPoints(const world::Field &field, const Vector2 &fromPoint);
 
-    /**
-     * Returns the longest line from openSegments
-     * @param openSegments Vector of lines
-     * @return Longest line from openSegments
-     */
-    const Line &getLongestSegment(const std::vector<Line> &openSegments);
+  /**
+   * Returns the longest line from openSegments
+   * @param openSegments Vector of lines
+   * @return Longest line from openSegments
+   */
+  const Line &getLongestSegment(const std::vector<Line> &openSegments);
 };
 
-} // namespace rtt::ai::stp::play
+}  // namespace rtt::ai::stp::play
 
-#endif //RTT_ATTACK_H
+#endif  // RTT_ATTACK_H

--- a/include/roboteam_ai/stp/new_plays/Attack.h
+++ b/include/roboteam_ai/stp/new_plays/Attack.h
@@ -10,67 +10,67 @@
 namespace rtt::ai::stp::play {
 
 class Attack : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  Attack();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    Attack();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World *world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World *world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char *getName() override;
+    /**
+     * Gets the play name
+     */
+    const char *getName() override;
 
- protected:
-  /**
-   * This function is used to determine if -- when a role is in an endTactic -- the endTactic should be skipped.
-   * An example could be BlockRobot and Intercept. You block a robot (endTactic) until a ball is shot and then the robot
-   * closest to the ball should try to intercept (skip the BlockRobot tactic to execute Intercept)
-   */
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    /**
+     * This function is used to determine if -- when a role is in an endTactic -- the endTactic should be skipped.
+     * An example could be BlockRobot and Intercept. You block a robot (endTactic) until a ball is shot and then the robot
+     * closest to the ball should try to intercept (skip the BlockRobot tactic to execute Intercept)
+     */
+    bool shouldRoleSkipEndTactic() override;
 
- private:
-  /**
-   * Calculate point in goal to aim for
-   * @return Target point
-   */
-  Vector2 calculateGoalTarget() noexcept;
+   private:
+    /**
+     * Calculate point in goal to aim for
+     * @return Target point
+     */
+    Vector2 calculateGoalTarget() noexcept;
 
-  /**
-   * Calculate points we want to aim for
-   * @param field Field
-   * @param fromPoint Position to shoot from
-   * @return Line between the two aim points
-   */
-  Line getAimPoints(const world::Field &field, const Vector2 &fromPoint);
+    /**
+     * Calculate points we want to aim for
+     * @param field Field
+     * @param fromPoint Position to shoot from
+     * @return Line between the two aim points
+     */
+    Line getAimPoints(const world::Field &field, const Vector2 &fromPoint);
 
-  /**
-   * Returns the longest line from openSegments
-   * @param openSegments Vector of lines
-   * @return Longest line from openSegments
-   */
-  const Line &getLongestSegment(const std::vector<Line> &openSegments);
+    /**
+     * Returns the longest line from openSegments
+     * @param openSegments Vector of lines
+     * @return Longest line from openSegments
+     */
+    const Line &getLongestSegment(const std::vector<Line> &openSegments);
 };
 
 }  // namespace rtt::ai::stp::play

--- a/include/roboteam_ai/stp/new_plays/AttackingPass.h
+++ b/include/roboteam_ai/stp/new_plays/AttackingPass.h
@@ -12,106 +12,106 @@
 namespace rtt::ai::stp::play {
 
 class AttackingPass : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  AttackingPass();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    AttackingPass();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Calculates n defensive positions for the roles to defend
-   * @param numberOfDefenders
-   * @param world
-   * @param enemyRobots
-   * @return A vector of defend positions
-   */
-  std::vector<Vector2> calculateDefensivePositions(int numberOfDefenders, world_new::World* world, std::vector<world_new::view::RobotView> enemyRobots);
+    /**
+     * Calculates n defensive positions for the roles to defend
+     * @param numberOfDefenders
+     * @param world
+     * @param enemyRobots
+     * @return A vector of defend positions
+     */
+    std::vector<Vector2> calculateDefensivePositions(int numberOfDefenders, world_new::World* world, std::vector<world_new::view::RobotView> enemyRobots);
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
-  /**
-   * Checks if this is a valid play to keep
-   * @param world
-   * @return true if we can keep this play, false if we cannot
-   */
-  [[nodiscard]] bool isValidPlayToKeep(world_new::World* world) noexcept override;
+    /**
+     * Checks if this is a valid play to keep
+     * @param world
+     * @return true if we can keep this play, false if we cannot
+     */
+    [[nodiscard]] bool isValidPlayToKeep(world_new::World* world) noexcept override;
 
- protected:
-  /**
-   * Checks whether this role should skip the end tactic in its state machine
-   * @return whether to skip the end tactic
-   */
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    /**
+     * Checks whether this role should skip the end tactic in its state machine
+     * @return whether to skip the end tactic
+     */
+    bool shouldRoleSkipEndTactic() override;
 
-  /**
-   * Calculates the pass location
-   * @return a pair of the pass location and the score of that location
-   * The score is used to decide to which pass location to pass when there are more receivers
-   */
-  std::pair<Vector2, double> calculatePassLocation(Grid searchGrid) noexcept;
+    /**
+     * Calculates the pass location
+     * @return a pair of the pass location and the score of that location
+     * The score is used to decide to which pass location to pass when there are more receivers
+     */
+    std::pair<Vector2, double> calculatePassLocation(Grid searchGrid) noexcept;
 
- private:
-  /**
-   * Checks if the pass is finished so the play knows whether it should
-   * keep this play or move to another play
-   * @return true: when ONE of the receivers is closer than 0.08m to the ball
-   *         false: when NONE of the receivers is closer than 0.08m to the ball
-   */
-  [[nodiscard]] bool passFinished() noexcept;
+   private:
+    /**
+     * Checks if the pass is finished so the play knows whether it should
+     * keep this play or move to another play
+     * @return true: when ONE of the receivers is closer than 0.08m to the ball
+     *         false: when NONE of the receivers is closer than 0.08m to the ball
+     */
+    [[nodiscard]] bool passFinished() noexcept;
 
-  /**
-   * Called every time the .initialize() is called on a play,
-   * runs exactly once at the start of this play when this play is picked to be executed
-   */
-  void onInitialize() noexcept override;
+    /**
+     * Called every time the .initialize() is called on a play,
+     * runs exactly once at the start of this play when this play is picked to be executed
+     */
+    void onInitialize() noexcept override;
 
-  /**
-   * Position that the passer will pass to
-   */
-  Vector2 passingPosition;
+    /**
+     * Position that the passer will pass to
+     */
+    Vector2 passingPosition;
 
-  /**
-   * Did the passer shoot or not
-   */
-  bool passerShot{false};
+    /**
+     * Did the passer shoot or not
+     */
+    bool passerShot{false};
 
-  /**
-   * Two receive locations with their scores.
-   * The passer will shoot to the highest scoring position
-   */
-  std::pair<Vector2, double> receiverPositionLeft{};
-  std::pair<Vector2, double> receiverPositionRight{};
+    /**
+     * Two receive locations with their scores.
+     * The passer will shoot to the highest scoring position
+     */
+    std::pair<Vector2, double> receiverPositionLeft{};
+    std::pair<Vector2, double> receiverPositionRight{};
 
-  /**
-   * The two grids that are used to calculate pass locations within it.
-   * In this case the grids are on their side, one on the left and one on the right
-   */
-  Grid gridLeft = Grid(0.15 * field.getFieldWidth(), 0, 3, 2.5, 5, 5);
-  Grid gridRight = Grid(0.15 * field.getFieldWidth(), -2.5, 3, 2.5, 5, 5);
+    /**
+     * The two grids that are used to calculate pass locations within it.
+     * In this case the grids are on their side, one on the left and one on the right
+     */
+    Grid gridLeft = Grid(0.15 * field.getFieldWidth(), 0, 3, 2.5, 5, 5);
+    Grid gridRight = Grid(0.15 * field.getFieldWidth(), -2.5, 3, 2.5, 5, 5);
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/AttackingPass.h
+++ b/include/roboteam_ai/stp/new_plays/AttackingPass.h
@@ -7,106 +7,111 @@
 
 #include <roboteam_utils/Grid.h>
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class AttackingPass : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    AttackingPass();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  AttackingPass();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Calculates n defensive positions for the roles to defend
-     * @param numberOfDefenders
-     * @param world
-     * @param enemyRobots
-     * @return A vector of defend positions
-     */
-    std::vector<Vector2> calculateDefensivePositions(int numberOfDefenders, world_new::World* world, std::vector<world_new::view::RobotView> enemyRobots);
+  /**
+   * Calculates n defensive positions for the roles to defend
+   * @param numberOfDefenders
+   * @param world
+   * @param enemyRobots
+   * @return A vector of defend positions
+   */
+  std::vector<Vector2> calculateDefensivePositions(int numberOfDefenders, world_new::World* world, std::vector<world_new::view::RobotView> enemyRobots);
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-    [[nodiscard]] bool isValidPlayToKeep(world_new::World* world) noexcept override;
+  /**
+   * Checks if this is a valid play to keep
+   * @param world
+   * @return true if we can keep this play, false if we cannot
+   */
+  [[nodiscard]] bool isValidPlayToKeep(world_new::World* world) noexcept override;
 
-   protected:
-    /**
-     * Checks whether this role should skip the end tactic in its state machine
-     * @return whether to skip the end tactic
-     */
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  /**
+   * Checks whether this role should skip the end tactic in its state machine
+   * @return whether to skip the end tactic
+   */
+  bool shouldRoleSkipEndTactic() override;
 
-    /**
-     * Calculates the pass location
-     * @return a pair of the pass location and the score of that location
-     * The score is used to decide to which pass location to pass when there are more receivers
-     */
-    std::pair<Vector2, double> calculatePassLocation(Grid searchGrid) noexcept;
+  /**
+   * Calculates the pass location
+   * @return a pair of the pass location and the score of that location
+   * The score is used to decide to which pass location to pass when there are more receivers
+   */
+  std::pair<Vector2, double> calculatePassLocation(Grid searchGrid) noexcept;
 
-   private:
-    /**
-     * Checks if the pass is finished so the play knows whether it should
-     * keep this play or move to another play
-     * @return true: when ONE of the receivers is closer than 0.08m to the ball
-     *         false: when NONE of the receivers is closer than 0.08m to the ball
-     */
-    [[nodiscard]] bool passFinished() noexcept;
+ private:
+  /**
+   * Checks if the pass is finished so the play knows whether it should
+   * keep this play or move to another play
+   * @return true: when ONE of the receivers is closer than 0.08m to the ball
+   *         false: when NONE of the receivers is closer than 0.08m to the ball
+   */
+  [[nodiscard]] bool passFinished() noexcept;
 
-    /**
-     * Called every time the .initialize() is called on a play,
-     * runs exactly once at the start of this play when this play is picked to be executed
-     */
-    void onInitialize() noexcept override;
+  /**
+   * Called every time the .initialize() is called on a play,
+   * runs exactly once at the start of this play when this play is picked to be executed
+   */
+  void onInitialize() noexcept override;
 
-    /**
-     * Position that the passer will pass to
-     */
-    Vector2 passingPosition;
+  /**
+   * Position that the passer will pass to
+   */
+  Vector2 passingPosition;
 
-    /**
-     * Did the passer shoot or not
-     */
-    bool passerShot{false};
+  /**
+   * Did the passer shoot or not
+   */
+  bool passerShot{false};
 
-    /**
-     * Two receive locations with their scores.
-     * The passer will shoot to the highest scoring position
-     */
-    std::pair<Vector2, double> receiverPositionLeft{};
-    std::pair<Vector2, double> receiverPositionRight{};
+  /**
+   * Two receive locations with their scores.
+   * The passer will shoot to the highest scoring position
+   */
+  std::pair<Vector2, double> receiverPositionLeft{};
+  std::pair<Vector2, double> receiverPositionRight{};
 
-    /**
-     * The two grids that are used to calculate pass locations within it.
-     * In this case the grids are on their side, one on the left and one on the right
-     */
-    Grid gridLeft = Grid(0.15 * field.getFieldWidth(), 0, 3, 2.5, 5, 5);
-    Grid gridRight = Grid(0.15 * field.getFieldWidth(), -2.5, 3, 2.5, 5, 5);
+  /**
+   * The two grids that are used to calculate pass locations within it.
+   * In this case the grids are on their side, one on the left and one on the right
+   */
+  Grid gridLeft = Grid(0.15 * field.getFieldWidth(), 0, 3, 2.5, 5, 5);
+  Grid gridRight = Grid(0.15 * field.getFieldWidth(), -2.5, 3, 2.5, 5, 5);
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/BallPlacementThem.h
+++ b/include/roboteam_ai/stp/new_plays/BallPlacementThem.h
@@ -6,40 +6,40 @@
 namespace rtt::ai::stp::play {
 
 class BallPlacementThem : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  BallPlacementThem();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    BallPlacementThem();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/BallPlacementThem.h
+++ b/include/roboteam_ai/stp/new_plays/BallPlacementThem.h
@@ -5,42 +5,42 @@
 
 namespace rtt::ai::stp::play {
 
-    class BallPlacementThem : public Play {
-    public:
-        /**
-         * Constructor that initializes roles with roles that are necessary for this play
-         */
-        BallPlacementThem();
+class BallPlacementThem : public Play {
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  BallPlacementThem();
 
-        /**
-         * Gets the score for the current play
-         *
-         * On the contrary to isValidPlay() this checks how good the play actually is
-         * return in range of 0 - 100
-         *
-         * @param world World to get the score for (world_new::World::instance())
-         * @return The score, 0 - 100
-         */
-        uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-        /**
-         * Assigns robots to roles of this play
-         */
-        Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-        /**
-         * Calculates info for the roles
-         */
-        void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-        /**
-         * Gets the play name
-         */
-        const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-    protected:
-        bool shouldRoleSkipEndTactic() override;
-    };
+ protected:
+  bool shouldRoleSkipEndTactic() override;
+};
 }  // namespace rtt::ai::stp::play
 
-#endif // RTT_BALLPLACEMENTTHEM_H
+#endif  // RTT_BALLPLACEMENTTHEM_H

--- a/include/roboteam_ai/stp/new_plays/BallPlacementUs.h
+++ b/include/roboteam_ai/stp/new_plays/BallPlacementUs.h
@@ -6,40 +6,40 @@
 namespace rtt::ai::stp::play {
 
 class BallPlacementUs : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  BallPlacementUs();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    BallPlacementUs();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/BallPlacementUs.h
+++ b/include/roboteam_ai/stp/new_plays/BallPlacementUs.h
@@ -5,42 +5,42 @@
 
 namespace rtt::ai::stp::play {
 
-    class BallPlacementUs : public Play {
-    public:
-        /**
-         * Constructor that initializes roles with roles that are necessary for this play
-         */
-        BallPlacementUs();
+class BallPlacementUs : public Play {
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  BallPlacementUs();
 
-        /**
-         * Gets the score for the current play
-         *
-         * On the contrary to isValidPlay() this checks how good the play actually is
-         * return in range of 0 - 100
-         *
-         * @param world World to get the score for (world_new::World::instance())
-         * @return The score, 0 - 100
-         */
-        uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-        /**
-         * Assigns robots to roles of this play
-         */
-        Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-        /**
-         * Calculates info for the roles
-         */
-        void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-        /**
-         * Gets the play name
-         */
-        const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-    protected:
-        bool shouldRoleSkipEndTactic() override;
-    };
+ protected:
+  bool shouldRoleSkipEndTactic() override;
+};
 }  // namespace rtt::ai::stp::play
 
-#endif // RTT_BALLPLACEMENTUS_H
+#endif  // RTT_BALLPLACEMENTUS_H

--- a/include/roboteam_ai/stp/new_plays/DefendPass.h
+++ b/include/roboteam_ai/stp/new_plays/DefendPass.h
@@ -15,65 +15,65 @@ namespace rtt::ai::stp::play {
  * be passed to.
  */
 class DefendPass : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  DefendPass();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    DefendPass();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 
-  /**
-   * Calculates info for the defenders
-   */
-  void calculateInfoForDefenders() noexcept;
+    /**
+     * Calculates info for the defenders
+     */
+    void calculateInfoForDefenders() noexcept;
 
-  /**
-   * Calculates info for the blockers
-   */
-  void calculateInfoForBlockers() noexcept;
+    /**
+     * Calculates info for the blockers
+     */
+    void calculateInfoForBlockers() noexcept;
 
-  /**
-   * Calculates info for the keeper
-   */
-  void calculateInfoForKeeper() noexcept;
+    /**
+     * Calculates info for the keeper
+     */
+    void calculateInfoForKeeper() noexcept;
 
-  /**
-   * Calculates info for the harassers
-   */
-  void calculateInfoForHarassers() noexcept;
+    /**
+     * Calculates info for the harassers
+     */
+    void calculateInfoForHarassers() noexcept;
 
-  /**
-   * Calculates info for the offenders
-   */
-  void calculateInfoForOffenders() noexcept;
+    /**
+     * Calculates info for the offenders
+     */
+    void calculateInfoForOffenders() noexcept;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/DefendPass.h
+++ b/include/roboteam_ai/stp/new_plays/DefendPass.h
@@ -5,7 +5,7 @@
 #ifndef RTT_DEFENDPASS_H
 #define RTT_DEFENDPASS_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
@@ -15,67 +15,66 @@ namespace rtt::ai::stp::play {
  * be passed to.
  */
 class DefendPass : public Play {
-public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    DefendPass();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  DefendPass();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 
-    /**
-     * Calculates info for the defenders
-     */
-    void calculateInfoForDefenders() noexcept;
+  /**
+   * Calculates info for the defenders
+   */
+  void calculateInfoForDefenders() noexcept;
 
-    /**
-     * Calculates info for the blockers
-     */
-    void calculateInfoForBlockers() noexcept;
+  /**
+   * Calculates info for the blockers
+   */
+  void calculateInfoForBlockers() noexcept;
 
-    /**
-     * Calculates info for the keeper
-     */
-    void calculateInfoForKeeper() noexcept;
+  /**
+   * Calculates info for the keeper
+   */
+  void calculateInfoForKeeper() noexcept;
 
-    /**
-     * Calculates info for the harassers
-     */
-    void calculateInfoForHarassers() noexcept;
+  /**
+   * Calculates info for the harassers
+   */
+  void calculateInfoForHarassers() noexcept;
 
-    /**
-     * Calculates info for the offenders
-     */
-    void calculateInfoForOffenders() noexcept;
+  /**
+   * Calculates info for the offenders
+   */
+  void calculateInfoForOffenders() noexcept;
 };
+}  // namespace rtt::ai::stp::play
 
-} // namespace rtt::ai::stp::play
-
-#endif // RTT_DEFENDPASS_H
+#endif  // RTT_DEFENDPASS_H

--- a/include/roboteam_ai/stp/new_plays/DefendShot.h
+++ b/include/roboteam_ai/stp/new_plays/DefendShot.h
@@ -5,7 +5,7 @@
 #ifndef RTT_DEFENDSHOT_H
 #define RTT_DEFENDSHOT_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
@@ -15,67 +15,66 @@ namespace rtt::ai::stp::play {
  * robots and the goal. Other defenders block other enemy robots to avoid passes to them.
  */
 class DefendShot : public Play {
-public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    DefendShot();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  DefendShot();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 
-    /**
-     * Calculates info for the defenders
-     */
-    void calculateInfoForDefenders() noexcept;
+  /**
+   * Calculates info for the defenders
+   */
+  void calculateInfoForDefenders() noexcept;
 
-    /**
-     * Calculates info for the harassers
-     */
-    void calculateInfoForHarassers() noexcept;
+  /**
+   * Calculates info for the harassers
+   */
+  void calculateInfoForHarassers() noexcept;
 
-    /**
-     * Calculates info for the keeper
-     */
-    void calculateInfoForKeeper() noexcept;
+  /**
+   * Calculates info for the keeper
+   */
+  void calculateInfoForKeeper() noexcept;
 
-    /**
-     * Calculates info for the midfielders
-     */
-    void calculateInfoForMidfielders() noexcept;
+  /**
+   * Calculates info for the midfielders
+   */
+  void calculateInfoForMidfielders() noexcept;
 
-    /**
-     * Calculates info for the offenders
-     */
-    void calculateInfoForOffenders() noexcept;
+  /**
+   * Calculates info for the offenders
+   */
+  void calculateInfoForOffenders() noexcept;
 };
+}  // namespace rtt::ai::stp::play
 
-} // namespace rtt::ai::stp::play
-
-#endif // RTT_DEFENDSHOT_H
+#endif  // RTT_DEFENDSHOT_H

--- a/include/roboteam_ai/stp/new_plays/DefendShot.h
+++ b/include/roboteam_ai/stp/new_plays/DefendShot.h
@@ -15,65 +15,65 @@ namespace rtt::ai::stp::play {
  * robots and the goal. Other defenders block other enemy robots to avoid passes to them.
  */
 class DefendShot : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  DefendShot();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    DefendShot();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 
-  /**
-   * Calculates info for the defenders
-   */
-  void calculateInfoForDefenders() noexcept;
+    /**
+     * Calculates info for the defenders
+     */
+    void calculateInfoForDefenders() noexcept;
 
-  /**
-   * Calculates info for the harassers
-   */
-  void calculateInfoForHarassers() noexcept;
+    /**
+     * Calculates info for the harassers
+     */
+    void calculateInfoForHarassers() noexcept;
 
-  /**
-   * Calculates info for the keeper
-   */
-  void calculateInfoForKeeper() noexcept;
+    /**
+     * Calculates info for the keeper
+     */
+    void calculateInfoForKeeper() noexcept;
 
-  /**
-   * Calculates info for the midfielders
-   */
-  void calculateInfoForMidfielders() noexcept;
+    /**
+     * Calculates info for the midfielders
+     */
+    void calculateInfoForMidfielders() noexcept;
 
-  /**
-   * Calculates info for the offenders
-   */
-  void calculateInfoForOffenders() noexcept;
+    /**
+     * Calculates info for the offenders
+     */
+    void calculateInfoForOffenders() noexcept;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/DefensiveFormation.h
+++ b/include/roboteam_ai/stp/new_plays/DefensiveFormation.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class DefensiveFormation : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  DefensiveFormation();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    DefensiveFormation();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/DefensiveFormation.h
+++ b/include/roboteam_ai/stp/new_plays/DefensiveFormation.h
@@ -5,45 +5,45 @@
 #ifndef RTT_DEFENSIVEFORMATION_H
 #define RTT_DEFENSIVEFORMATION_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class DefensiveFormation : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    DefensiveFormation();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  DefensiveFormation();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-   protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/FreeKickThem.h
+++ b/include/roboteam_ai/stp/new_plays/FreeKickThem.h
@@ -10,61 +10,61 @@
 namespace rtt::ai::stp::play {
 
 class FreeKickThem : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  FreeKickThem();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    FreeKickThem();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 
- private:
-  /**
-   * Calculates info for the keeper
-   */
-  void calculateInfoForKeeper() noexcept;
+   private:
+    /**
+     * Calculates info for the keeper
+     */
+    void calculateInfoForKeeper() noexcept;
 
-  /**
-   * Calculates info the the blockers, which block off enemy robots
-   */
-  void calculateInfoForBlockers() noexcept;
+    /**
+     * Calculates info the the blockers, which block off enemy robots
+     */
+    void calculateInfoForBlockers() noexcept;
 
-  /**
-   * Calculates info for the defenders, which defend the goal
-   */
-  void calculateInfoForDefenders() noexcept;
+    /**
+     * Calculates info for the defenders, which defend the goal
+     */
+    void calculateInfoForDefenders() noexcept;
 
-  /**
-   * Calculates info for the offenders
-   */
-  void calculateInfoForOffenders() noexcept;
+    /**
+     * Calculates info for the offenders
+     */
+    void calculateInfoForOffenders() noexcept;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/FreeKickThem.h
+++ b/include/roboteam_ai/stp/new_plays/FreeKickThem.h
@@ -5,68 +5,67 @@
 #ifndef RTT_FREEKICKTHEM_H
 #define RTT_FREEKICKTHEM_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class FreeKickThem : public Play {
-public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    FreeKickThem();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  FreeKickThem();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 
-private:
-    /**
-     * Calculates info for the keeper
-     */
-    void calculateInfoForKeeper() noexcept;
+ private:
+  /**
+   * Calculates info for the keeper
+   */
+  void calculateInfoForKeeper() noexcept;
 
-    /**
-     * Calculates info the the blockers, which block off enemy robots
-     */
-    void calculateInfoForBlockers() noexcept;
+  /**
+   * Calculates info the the blockers, which block off enemy robots
+   */
+  void calculateInfoForBlockers() noexcept;
 
-    /**
-     * Calculates info for the defenders, which defend the goal
-     */
-    void calculateInfoForDefenders() noexcept;
+  /**
+   * Calculates info for the defenders, which defend the goal
+   */
+  void calculateInfoForDefenders() noexcept;
 
-    /**
-     * Calculates info for the offenders
-     */
-    void calculateInfoForOffenders() noexcept;
+  /**
+   * Calculates info for the offenders
+   */
+  void calculateInfoForOffenders() noexcept;
 };
-
 }  // namespace rtt::ai::stp::play
 
-#endif //RTT_FREEKICKTHEM_H
+#endif  // RTT_FREEKICKTHEM_H

--- a/include/roboteam_ai/stp/new_plays/GenericPass.h
+++ b/include/roboteam_ai/stp/new_plays/GenericPass.h
@@ -12,92 +12,92 @@
 namespace rtt::ai::stp::play {
 
 class GenericPass : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  GenericPass();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    GenericPass();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
-  [[nodiscard]] bool isValidPlayToKeep(world_new::World* world) noexcept override;
+    [[nodiscard]] bool isValidPlayToKeep(world_new::World* world) noexcept override;
 
- protected:
-  /**
-   * Checks whether this role should skip the end tactic in its state machine
-   * @return whether to skip the end tactic
-   */
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    /**
+     * Checks whether this role should skip the end tactic in its state machine
+     * @return whether to skip the end tactic
+     */
+    bool shouldRoleSkipEndTactic() override;
 
-  /**
-   * Calculates the pass location
-   * @return a pair of the pass location and the score of that location
-   * The score is used to decide to which pass location to pass when there are more receivers
-   */
-  std::pair<Vector2, double> calculatePassLocation(Grid searchGrid) noexcept;
+    /**
+     * Calculates the pass location
+     * @return a pair of the pass location and the score of that location
+     * The score is used to decide to which pass location to pass when there are more receivers
+     */
+    std::pair<Vector2, double> calculatePassLocation(Grid searchGrid) noexcept;
 
- private:
-  /**
-   * Checks if the pass is finished so the play knows whether it should
-   * keep this play or move to another play
-   * @return true: when ONE of the receivers is closer than 0.08m to the ball
-   *         false: when NONE of the receivers is closer than 0.08m to the ball
-   */
-  [[nodiscard]] bool passFinished() noexcept;
+   private:
+    /**
+     * Checks if the pass is finished so the play knows whether it should
+     * keep this play or move to another play
+     * @return true: when ONE of the receivers is closer than 0.08m to the ball
+     *         false: when NONE of the receivers is closer than 0.08m to the ball
+     */
+    [[nodiscard]] bool passFinished() noexcept;
 
-  /**
-   * Called every time the .initialize() is called on a play,
-   * runs exactly once at the start of this play when this play is picked to be executed
-   */
-  void onInitialize() noexcept override;
+    /**
+     * Called every time the .initialize() is called on a play,
+     * runs exactly once at the start of this play when this play is picked to be executed
+     */
+    void onInitialize() noexcept override;
 
-  /**
-   * Position that the passer will pass to
-   */
-  Vector2 passingPosition;
+    /**
+     * Position that the passer will pass to
+     */
+    Vector2 passingPosition;
 
-  /**
-   * Did the passer shoot or not
-   */
-  bool passerShot{false};
+    /**
+     * Did the passer shoot or not
+     */
+    bool passerShot{false};
 
-  /**
-   * Two receive locations with their scores.
-   * The passer will shoot to the highest scoring position
-   */
-  std::pair<Vector2, double> receiverPositionLeft{};
-  std::pair<Vector2, double> receiverPositionRight{};
+    /**
+     * Two receive locations with their scores.
+     * The passer will shoot to the highest scoring position
+     */
+    std::pair<Vector2, double> receiverPositionLeft{};
+    std::pair<Vector2, double> receiverPositionRight{};
 
-  /**
-   * The two grids that are used to calculate pass locations within it.
-   * In this case the grids are on their side, one on the left and one on the right
-   */
-  Grid gridLeft = Grid(0, 0, 3, 2.5, 5, 5);
-  Grid gridRight = Grid(0, -2.5, 3, 2.5, 5, 5);
+    /**
+     * The two grids that are used to calculate pass locations within it.
+     * In this case the grids are on their side, one on the left and one on the right
+     */
+    Grid gridLeft = Grid(0, 0, 3, 2.5, 5, 5);
+    Grid gridRight = Grid(0, -2.5, 3, 2.5, 5, 5);
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/GenericPass.h
+++ b/include/roboteam_ai/stp/new_plays/GenericPass.h
@@ -7,106 +7,97 @@
 
 #include <roboteam_utils/Grid.h>
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class GenericPass : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    GenericPass();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  GenericPass();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Calculates n defensive positions for the roles to defend
-     * @param numberOfDefenders
-     * @param world
-     * @param enemyRobots
-     * @return A vector of defend positions
-     */
-    std::vector<Vector2> calculateDefensivePositions(int numberOfDefenders, world_new::World* world, std::vector<world_new::view::RobotView> enemyRobots);
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  [[nodiscard]] bool isValidPlayToKeep(world_new::World* world) noexcept override;
 
-    [[nodiscard]] bool isValidPlayToKeep(world_new::World* world) noexcept override;
+ protected:
+  /**
+   * Checks whether this role should skip the end tactic in its state machine
+   * @return whether to skip the end tactic
+   */
+  bool shouldRoleSkipEndTactic() override;
 
-   protected:
-    /**
-     * Checks whether this role should skip the end tactic in its state machine
-     * @return whether to skip the end tactic
-     */
-    bool shouldRoleSkipEndTactic() override;
+  /**
+   * Calculates the pass location
+   * @return a pair of the pass location and the score of that location
+   * The score is used to decide to which pass location to pass when there are more receivers
+   */
+  std::pair<Vector2, double> calculatePassLocation(Grid searchGrid) noexcept;
 
-    /**
-     * Calculates the pass location
-     * @return a pair of the pass location and the score of that location
-     * The score is used to decide to which pass location to pass when there are more receivers
-     */
-    std::pair<Vector2, double> calculatePassLocation(Grid searchGrid) noexcept;
+ private:
+  /**
+   * Checks if the pass is finished so the play knows whether it should
+   * keep this play or move to another play
+   * @return true: when ONE of the receivers is closer than 0.08m to the ball
+   *         false: when NONE of the receivers is closer than 0.08m to the ball
+   */
+  [[nodiscard]] bool passFinished() noexcept;
 
-   private:
-   /**
-    * Checks if the pass is finished so the play knows whether it should
-    * keep this play or move to another play
-    * @return true: when ONE of the receivers is closer than 0.08m to the ball
-    *         false: when NONE of the receivers is closer than 0.08m to the ball
-    */
-    [[nodiscard]] bool passFinished() noexcept;
+  /**
+   * Called every time the .initialize() is called on a play,
+   * runs exactly once at the start of this play when this play is picked to be executed
+   */
+  void onInitialize() noexcept override;
 
-    /**
-     * Called every time the .initialize() is called on a play,
-     * runs exactly once at the start of this play when this play is picked to be executed
-     */
-    void onInitialize() noexcept override;
+  /**
+   * Position that the passer will pass to
+   */
+  Vector2 passingPosition;
 
-    /**
-     * Position that the passer will pass to
-     */
-    Vector2 passingPosition;
+  /**
+   * Did the passer shoot or not
+   */
+  bool passerShot{false};
 
-    /**
-     * Did the passer shoot or not
-     */
-    bool passerShot{false};
+  /**
+   * Two receive locations with their scores.
+   * The passer will shoot to the highest scoring position
+   */
+  std::pair<Vector2, double> receiverPositionLeft{};
+  std::pair<Vector2, double> receiverPositionRight{};
 
-    /**
-     * Two receive locations with their scores.
-     * The passer will shoot to the highest scoring position
-     */
-    std::pair<Vector2, double> receiverPositionLeft{};
-    std::pair<Vector2, double> receiverPositionRight{};
-
-    /**
-     * The two grids that are used to calculate pass locations within it.
-     * In this case the grids are on their side, one on the left and one on the right
-     */
-    Grid gridLeft = Grid(0, 0, 3, 2.5, 5, 5);
-    Grid gridRight = Grid(0, -2.5, 3, 2.5, 5, 5);
+  /**
+   * The two grids that are used to calculate pass locations within it.
+   * In this case the grids are on their side, one on the left and one on the right
+   */
+  Grid gridLeft = Grid(0, 0, 3, 2.5, 5, 5);
+  Grid gridRight = Grid(0, -2.5, 3, 2.5, 5, 5);
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/GetBallPossession.h
+++ b/include/roboteam_ai/stp/new_plays/GetBallPossession.h
@@ -5,47 +5,46 @@
 #ifndef RTT_GETBALLPOSSESSION_H
 #define RTT_GETBALLPOSSESSION_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class GetBallPossession : public Play {
-public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    GetBallPossession();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  GetBallPossession();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
-
 }  // namespace rtt::ai::stp::play
 
-#endif //RTT_GETBALLPOSSESSION_H
+#endif  // RTT_GETBALLPOSSESSION_H

--- a/include/roboteam_ai/stp/new_plays/GetBallPossession.h
+++ b/include/roboteam_ai/stp/new_plays/GetBallPossession.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class GetBallPossession : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  GetBallPossession();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    GetBallPossession();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/GetBallRisky.h
+++ b/include/roboteam_ai/stp/new_plays/GetBallRisky.h
@@ -5,45 +5,46 @@
 #ifndef RTT_GETBALLRISKY_H
 #define RTT_GETBALLRISKY_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class GetBallRisky : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    GetBallRisky();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  GetBallRisky();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-   protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
+
 #endif  // RTT_GETBALLRISKY_H

--- a/include/roboteam_ai/stp/new_plays/GetBallRisky.h
+++ b/include/roboteam_ai/stp/new_plays/GetBallRisky.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class GetBallRisky : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  GetBallRisky();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    GetBallRisky();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/Halt.h
+++ b/include/roboteam_ai/stp/new_plays/Halt.h
@@ -5,45 +5,45 @@
 #ifndef RTT_HALT_PLAY_H
 #define RTT_HALT_PLAY_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class Halt : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    Halt();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  Halt();
 
-        /**
-         * Gets the score for the current play
-         *
-         * On the contrary to isValidPlay() this checks how good the play actually is
-         * return in range of 0 - 100
-         *
-         * @param world World to get the score for (world_new::World::instance())
-         * @return The score, 0 - 100
-         */
-        uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-   protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/Halt.h
+++ b/include/roboteam_ai/stp/new_plays/Halt.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class Halt : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  Halt();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    Halt();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/KickOffThem.h
+++ b/include/roboteam_ai/stp/new_plays/KickOffThem.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class KickOffThem : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  KickOffThem();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    KickOffThem();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/KickOffThem.h
+++ b/include/roboteam_ai/stp/new_plays/KickOffThem.h
@@ -5,45 +5,45 @@
 #ifndef RTT_KICKOFFTHEM_H
 #define RTT_KICKOFFTHEM_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class KickOffThem : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    KickOffThem();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  KickOffThem();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-   protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/KickOffThemPrepare.h
+++ b/include/roboteam_ai/stp/new_plays/KickOffThemPrepare.h
@@ -5,47 +5,46 @@
 #ifndef RTT_KICKOFFTHEMPREPARE_H
 #define RTT_KICKOFFTHEMPREPARE_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class KickOffThemPrepare : public Play {
-public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    KickOffThemPrepare();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  KickOffThemPrepare();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
-
 }  // namespace rtt::ai::stp::play
 
-#endif //RTT_KICKOFFTHEMPREPARE_H
+#endif  // RTT_KICKOFFTHEMPREPARE_H

--- a/include/roboteam_ai/stp/new_plays/KickOffThemPrepare.h
+++ b/include/roboteam_ai/stp/new_plays/KickOffThemPrepare.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class KickOffThemPrepare : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  KickOffThemPrepare();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    KickOffThemPrepare();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/KickOffUs.h
+++ b/include/roboteam_ai/stp/new_plays/KickOffUs.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class KickOffUs : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  KickOffUs();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    KickOffUs();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/KickOffUs.h
+++ b/include/roboteam_ai/stp/new_plays/KickOffUs.h
@@ -5,45 +5,45 @@
 #ifndef RTT_KICKOFFUS_H
 #define RTT_KICKOFFUS_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class KickOffUs : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    KickOffUs();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  KickOffUs();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-   protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/KickOffUsPrepare.h
+++ b/include/roboteam_ai/stp/new_plays/KickOffUsPrepare.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class KickOffUsPrepare : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  KickOffUsPrepare();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    KickOffUsPrepare();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/KickOffUsPrepare.h
+++ b/include/roboteam_ai/stp/new_plays/KickOffUsPrepare.h
@@ -5,47 +5,46 @@
 #ifndef RTT_KICKOFFUSPREPARE_H
 #define RTT_KICKOFFUSPREPARE_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class KickOffUsPrepare : public Play {
-public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    KickOffUsPrepare();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  KickOffUsPrepare();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
-
 }  // namespace rtt::ai::stp::play
 
-#endif //RTT_KICKOFFUSPREPARE_H
+#endif  // RTT_KICKOFFUSPREPARE_H

--- a/include/roboteam_ai/stp/new_plays/PenaltyThem.h
+++ b/include/roboteam_ai/stp/new_plays/PenaltyThem.h
@@ -5,41 +5,44 @@
 #ifndef RTT_PENALTYTHEM_H
 #define RTT_PENALTYTHEM_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class PenaltyThem : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with test roles
-     */
-    PenaltyThem();
+ public:
+  /**
+   * Constructor that initializes roles with test roles
+   */
+  PenaltyThem();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    bool shouldRoleSkipEndTactic() override;
+  bool shouldRoleSkipEndTactic() override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/PenaltyThem.h
+++ b/include/roboteam_ai/stp/new_plays/PenaltyThem.h
@@ -10,39 +10,39 @@
 namespace rtt::ai::stp::play {
 
 class PenaltyThem : public Play {
- public:
-  /**
-   * Constructor that initializes roles with test roles
-   */
-  PenaltyThem();
+   public:
+    /**
+     * Constructor that initializes roles with test roles
+     */
+    PenaltyThem();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  bool shouldRoleSkipEndTactic() override;
+    bool shouldRoleSkipEndTactic() override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/PenaltyThemPrepare.h
+++ b/include/roboteam_ai/stp/new_plays/PenaltyThemPrepare.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class PenaltyThemPrepare : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  PenaltyThemPrepare();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    PenaltyThemPrepare();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/PenaltyThemPrepare.h
+++ b/include/roboteam_ai/stp/new_plays/PenaltyThemPrepare.h
@@ -5,45 +5,45 @@
 #ifndef RTT_PENALTYTHEMPREPARE_H
 #define RTT_PENALTYTHEMPREPARE_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class PenaltyThemPrepare : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    PenaltyThemPrepare();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  PenaltyThemPrepare();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-   protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/PenaltyUs.h
+++ b/include/roboteam_ai/stp/new_plays/PenaltyUs.h
@@ -5,41 +5,41 @@
 #ifndef RTT_PENALTYUS_H
 #define RTT_PENALTYUS_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class PenaltyUs : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with test roles
-     */
-    PenaltyUs();
+ public:
+  /**
+   * Constructor that initializes roles with test roles
+   */
+  PenaltyUs();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    void calculateInfoForRoles() noexcept override;
+  void calculateInfoForRoles() noexcept override;
 
-    bool shouldRoleSkipEndTactic() override;
+  bool shouldRoleSkipEndTactic() override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/PenaltyUs.h
+++ b/include/roboteam_ai/stp/new_plays/PenaltyUs.h
@@ -10,36 +10,36 @@
 namespace rtt::ai::stp::play {
 
 class PenaltyUs : public Play {
- public:
-  /**
-   * Constructor that initializes roles with test roles
-   */
-  PenaltyUs();
+   public:
+    /**
+     * Constructor that initializes roles with test roles
+     */
+    PenaltyUs();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  void calculateInfoForRoles() noexcept override;
+    void calculateInfoForRoles() noexcept override;
 
-  bool shouldRoleSkipEndTactic() override;
+    bool shouldRoleSkipEndTactic() override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/PenaltyUsPrepare.h
+++ b/include/roboteam_ai/stp/new_plays/PenaltyUsPrepare.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class PenaltyUsPrepare : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  PenaltyUsPrepare();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    PenaltyUsPrepare();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/PenaltyUsPrepare.h
+++ b/include/roboteam_ai/stp/new_plays/PenaltyUsPrepare.h
@@ -5,45 +5,45 @@
 #ifndef RTT_PENALTYUSPREPARE_H
 #define RTT_PENALTYUSPREPARE_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class PenaltyUsPrepare : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    PenaltyUsPrepare();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  PenaltyUsPrepare();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-   protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/ReflectKick.h
+++ b/include/roboteam_ai/stp/new_plays/ReflectKick.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class ReflectKick : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  ReflectKick();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    ReflectKick();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/ReflectKick.h
+++ b/include/roboteam_ai/stp/new_plays/ReflectKick.h
@@ -10,42 +10,41 @@
 namespace rtt::ai::stp::play {
 
 class ReflectKick : public Play {
-public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    ReflectKick();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  ReflectKick();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
+}  // namespace rtt::ai::stp::play
 
-} // namespace rtt::ai::stp::play
-
-#endif // RTT_REFLECTKICK_H
+#endif  // RTT_REFLECTKICK_H

--- a/include/roboteam_ai/stp/new_plays/TestPlay.h
+++ b/include/roboteam_ai/stp/new_plays/TestPlay.h
@@ -10,39 +10,39 @@
 namespace rtt::ai::stp {
 
 class TestPlay : public Play {
- public:
-  /**
-   * Constructor that initializes roles with test roles
-   */
-  TestPlay();
+   public:
+    /**
+     * Constructor that initializes roles with test roles
+     */
+    TestPlay();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  bool shouldRoleSkipEndTactic() override;
+    bool shouldRoleSkipEndTactic() override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/new_plays/TestPlay.h
+++ b/include/roboteam_ai/stp/new_plays/TestPlay.h
@@ -5,41 +5,44 @@
 #ifndef RTT_TESTPLAY_H
 #define RTT_TESTPLAY_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp {
 
 class TestPlay : public Play {
-   public:
-    /**
-     * Constructor that initializes roles with test roles
-     */
-    TestPlay();
+ public:
+  /**
+   * Constructor that initializes roles with test roles
+   */
+  TestPlay();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World *world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    bool shouldRoleSkipEndTactic() override;
+  bool shouldRoleSkipEndTactic() override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/new_plays/TimeOut.h
+++ b/include/roboteam_ai/stp/new_plays/TimeOut.h
@@ -10,40 +10,40 @@
 namespace rtt::ai::stp::play {
 
 class TimeOut : public Play {
- public:
-  /**
-   * Constructor that initializes roles with roles that are necessary for this play
-   */
-  TimeOut();
+   public:
+    /**
+     * Constructor that initializes roles with roles that are necessary for this play
+     */
+    TimeOut();
 
-  /**
-   * Gets the score for the current play
-   *
-   * On the contrary to isValidPlay() this checks how good the play actually is
-   * return in range of 0 - 100
-   *
-   * @param world World to get the score for (world_new::World::instance())
-   * @return The score, 0 - 100
-   */
-  uint8_t score(world_new::World* world) noexcept override;
+    /**
+     * Gets the score for the current play
+     *
+     * On the contrary to isValidPlay() this checks how good the play actually is
+     * return in range of 0 - 100
+     *
+     * @param world World to get the score for (world_new::World::instance())
+     * @return The score, 0 - 100
+     */
+    uint8_t score(world_new::World* world) noexcept override;
 
-  /**
-   * Assigns robots to roles of this play
-   */
-  Dealer::FlagMap decideRoleFlags() const noexcept override;
+    /**
+     * Assigns robots to roles of this play
+     */
+    Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-  /**
-   * Calculates info for the roles
-   */
-  void calculateInfoForRoles() noexcept override;
+    /**
+     * Calculates info for the roles
+     */
+    void calculateInfoForRoles() noexcept override;
 
-  /**
-   * Gets the play name
-   */
-  const char* getName() override;
+    /**
+     * Gets the play name
+     */
+    const char* getName() override;
 
- protected:
-  bool shouldRoleSkipEndTactic() override;
+   protected:
+    bool shouldRoleSkipEndTactic() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/new_plays/TimeOut.h
+++ b/include/roboteam_ai/stp/new_plays/TimeOut.h
@@ -5,49 +5,46 @@
 #ifndef RTT_TIMEOUT_H
 #define RTT_TIMEOUT_H
 
-#include <stp/Play.hpp>
+#include "stp/Play.hpp"
 
 namespace rtt::ai::stp::play {
 
 class TimeOut : public Play {
-public:
-    /**
-     * Constructor that initializes roles with roles that are necessary for this play
-     */
-    TimeOut();
+ public:
+  /**
+   * Constructor that initializes roles with roles that are necessary for this play
+   */
+  TimeOut();
 
-    /**
-     * Gets the score for the current play
-     *
-     * On the contrary to isValidPlay() this checks how good the play actually is
-     * return in range of 0 - 100
-     *
-     * @param world World to get the score for (world_new::World::instance())
-     * @return The score, 0 - 100
-     */
-    uint8_t score(world_new::World* world) noexcept override;
+  /**
+   * Gets the score for the current play
+   *
+   * On the contrary to isValidPlay() this checks how good the play actually is
+   * return in range of 0 - 100
+   *
+   * @param world World to get the score for (world_new::World::instance())
+   * @return The score, 0 - 100
+   */
+  uint8_t score(world_new::World* world) noexcept override;
 
-    /**
-     * Assigns robots to roles of this play
-     */
-    Dealer::FlagMap decideRoleFlags() const noexcept override;
+  /**
+   * Assigns robots to roles of this play
+   */
+  Dealer::FlagMap decideRoleFlags() const noexcept override;
 
-    /**
-     * Calculates info for the roles
-     */
-    void calculateInfoForRoles() noexcept override;
+  /**
+   * Calculates info for the roles
+   */
+  void calculateInfoForRoles() noexcept override;
 
-    /**
-     * Gets the play name
-     */
-    const char* getName() override;
+  /**
+   * Gets the play name
+   */
+  const char* getName() override;
 
-protected:
-    bool shouldRoleSkipEndTactic() override;
+ protected:
+  bool shouldRoleSkipEndTactic() override;
 };
-
 }  // namespace rtt::ai::stp::play
 
-
-
-#endif //RTT_TIMEOUT_H
+#endif  // RTT_TIMEOUT_H

--- a/include/roboteam_ai/stp/new_roles/Attacker.h
+++ b/include/roboteam_ai/stp/new_roles/Attacker.h
@@ -10,14 +10,13 @@
 namespace rtt::ai::stp::role {
 
 class Attacker : public Role {
-public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
-    Attacker(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  Attacker(std::string name);
 };
+}  // namespace rtt::ai::stp::role
 
-} // namespace rtt::ai::stp::role
-
-#endif //RTT_ATTACKER_H
+#endif  // RTT_ATTACKER_H

--- a/include/roboteam_ai/stp/new_roles/Attacker.h
+++ b/include/roboteam_ai/stp/new_roles/Attacker.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class Attacker : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  Attacker(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    Attacker(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/BallAvoider.h
+++ b/include/roboteam_ai/stp/new_roles/BallAvoider.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class BallAvoider : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  BallAvoider(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    BallAvoider(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/BallAvoider.h
+++ b/include/roboteam_ai/stp/new_roles/BallAvoider.h
@@ -9,16 +9,14 @@
 
 namespace rtt::ai::stp::role {
 
-    class BallAvoider : public Role {
-    public:
-        /**
-         * Ctor that sets the name of the role and creates a statemachine of tactics
-         * @param name name of the role
-         */
-        BallAvoider(std::string name);
-    };
+class BallAvoider : public Role {
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  BallAvoider(std::string name);
+};
+}  // namespace rtt::ai::stp::role
 
-} // namespace rtt::ai::stp::role
-
-
-#endif //RTT_BALLAVOIDER_H
+#endif  // RTT_BALLAVOIDER_H

--- a/include/roboteam_ai/stp/new_roles/BallGetter.h
+++ b/include/roboteam_ai/stp/new_roles/BallGetter.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class BallGetter : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  BallGetter(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    BallGetter(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/BallGetter.h
+++ b/include/roboteam_ai/stp/new_roles/BallGetter.h
@@ -10,14 +10,13 @@
 namespace rtt::ai::stp::role {
 
 class BallGetter : public Role {
-public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
-    BallGetter(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  BallGetter(std::string name);
 };
+}  // namespace rtt::ai::stp::role
 
-} // namespace rtt::ai::stp::role
-
-#endif //RTT_BALLGETTER_H
+#endif  // RTT_BALLGETTER_H

--- a/include/roboteam_ai/stp/new_roles/BallPlacer.h
+++ b/include/roboteam_ai/stp/new_roles/BallPlacer.h
@@ -9,15 +9,14 @@
 
 namespace rtt::ai::stp::role {
 
-    class BallPlacer : public Role {
-    public:
-        /**
-         * Ctor that sets the name of the role and creates a statemachine of tactics
-         * @param name name of the role
-         */
-        BallPlacer(std::string name);
-    };
+class BallPlacer : public Role {
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  BallPlacer(std::string name);
+};
+}  // namespace rtt::ai::stp::role
 
-} // namespace rtt::ai::stp::role
-
-#endif //RTT_ATTACKER_H
+#endif  // RTT_ATTACKER_H

--- a/include/roboteam_ai/stp/new_roles/BallPlacer.h
+++ b/include/roboteam_ai/stp/new_roles/BallPlacer.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class BallPlacer : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  BallPlacer(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    BallPlacer(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/BallReflector.h
+++ b/include/roboteam_ai/stp/new_roles/BallReflector.h
@@ -10,14 +10,13 @@
 namespace rtt::ai::stp::role {
 
 class BallReflector : public Role {
-public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
- BallReflector(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  BallReflector(std::string name);
 };
-
-} // namespace rtt::ai::stp::role
+}  // namespace rtt::ai::stp::role
 
 #endif  // RTT_BALLREFLECTOR_H

--- a/include/roboteam_ai/stp/new_roles/BallReflector.h
+++ b/include/roboteam_ai/stp/new_roles/BallReflector.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class BallReflector : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  BallReflector(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    BallReflector(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/Defender.h
+++ b/include/roboteam_ai/stp/new_roles/Defender.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class Defender : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  Defender(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    Defender(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/Defender.h
+++ b/include/roboteam_ai/stp/new_roles/Defender.h
@@ -5,19 +5,18 @@
 #ifndef RTT_DEFENDER_H
 #define RTT_DEFENDER_H
 
-#include <stp/Role.hpp>
+#include "stp/Role.hpp"
 
 namespace rtt::ai::stp::role {
 
 class Defender : public Role {
-public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
-    Defender(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  Defender(std::string name);
 };
+}  // namespace rtt::ai::stp::role
 
-} // namespace rtt::ai::stp::role
-
-#endif // RTT_DEFENDER_H
+#endif  // RTT_DEFENDER_H

--- a/include/roboteam_ai/stp/new_roles/Formation.h
+++ b/include/roboteam_ai/stp/new_roles/Formation.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class Formation : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  Formation(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    Formation(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/Formation.h
+++ b/include/roboteam_ai/stp/new_roles/Formation.h
@@ -5,17 +5,17 @@
 #ifndef RTT_FORMATION_H
 #define RTT_FORMATION_H
 
-#include <stp/Role.hpp>
+#include "stp/Role.hpp"
 
 namespace rtt::ai::stp::role {
 
 class Formation : public Role {
-   public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
-    Formation(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  Formation(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/Halt.h
+++ b/include/roboteam_ai/stp/new_roles/Halt.h
@@ -5,18 +5,18 @@
 #ifndef RTT_HALT_H
 #define RTT_HALT_H
 
-#include <stp/Role.hpp>
+#include "stp/Role.hpp"
 
 namespace rtt::ai::stp::role {
 
-    class Halt : public Role {
-    public:
-        /**
-         * Ctor that sets the name of the role and creates a statemachine of tactics
-         * @param name name of the role
-         */
-        Halt(std::string name);
-    };
+class Halt : public Role {
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  Halt(std::string name);
+};
 }  // namespace rtt::ai::stp::role
 
-#endif //RTT_HALT_H
+#endif  // RTT_HALT_H

--- a/include/roboteam_ai/stp/new_roles/Halt.h
+++ b/include/roboteam_ai/stp/new_roles/Halt.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class Halt : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  Halt(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    Halt(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/Harasser.h
+++ b/include/roboteam_ai/stp/new_roles/Harasser.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class Harasser : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  Harasser(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    Harasser(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/Harasser.h
+++ b/include/roboteam_ai/stp/new_roles/Harasser.h
@@ -5,17 +5,17 @@
 #ifndef RTT_HARASSER_H
 #define RTT_HARASSER_H
 
-#include <stp/Role.hpp>
+#include "stp/Role.hpp"
 
 namespace rtt::ai::stp::role {
 
 class Harasser : public Role {
-   public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
-    Harasser(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  Harasser(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/Keeper.h
+++ b/include/roboteam_ai/stp/new_roles/Keeper.h
@@ -11,36 +11,36 @@
 namespace rtt::ai::stp::role {
 
 class Keeper : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  explicit Keeper(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    explicit Keeper(std::string name);
 
-  /**
-   * Besides the default update from base class Role, it also switches between tactics depending on the ball position and velocity
-   * @param info TacticInfo to be passed to update()
-   * @return The status that the current tactic returns
-   */
-  [[nodiscard]] Status update(StpInfo const& info) noexcept override;
+    /**
+     * Besides the default update from base class Role, it also switches between tactics depending on the ball position and velocity
+     * @param info TacticInfo to be passed to update()
+     * @return The status that the current tactic returns
+     */
+    [[nodiscard]] Status update(StpInfo const& info) noexcept override;
 
- private:
-  /**
-   * Checks if ball is in our defense area and still
-   * @param field Field
-   * @param ballPos Ball position
-   * @param ballVel Ball velocity
-   * @return True if ball is in our defense area and still
-   */
-  [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
+   private:
+    /**
+     * Checks if ball is in our defense area and still
+     * @param field Field
+     * @param ballPos Ball position
+     * @param ballVel Ball velocity
+     * @return True if ball is in our defense area and still
+     */
+    [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
 
-  /**
-   * Resets state machine when ball is in our defense area and still and current tactic is not KeeperBlockBall
-   * @param isBallInOurDefenseAreaAndStill True if ball is in our defense area and still
-   * @return True if isBallInOurDefenseAreaAndStill and current tactic is not KeeperBlockBall
-   */
-  [[nodiscard]] bool shouldRoleReset(bool isBallInOurDefenseAreaAndStill) noexcept;
+    /**
+     * Resets state machine when ball is in our defense area and still and current tactic is not KeeperBlockBall
+     * @param isBallInOurDefenseAreaAndStill True if ball is in our defense area and still
+     * @return True if isBallInOurDefenseAreaAndStill and current tactic is not KeeperBlockBall
+     */
+    [[nodiscard]] bool shouldRoleReset(bool isBallInOurDefenseAreaAndStill) noexcept;
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/Keeper.h
+++ b/include/roboteam_ai/stp/new_roles/Keeper.h
@@ -11,38 +11,37 @@
 namespace rtt::ai::stp::role {
 
 class Keeper : public Role {
-public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
-    explicit Keeper(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  explicit Keeper(std::string name);
 
-    /**
-     * Besides the default update from base class Role, it also switches between tactics depending on the ball position and velocity
-     * @param info TacticInfo to be passed to update()
-     * @return The status that the current tactic returns
-     */
-    [[nodiscard]] Status update(StpInfo const &info) noexcept override;
+  /**
+   * Besides the default update from base class Role, it also switches between tactics depending on the ball position and velocity
+   * @param info TacticInfo to be passed to update()
+   * @return The status that the current tactic returns
+   */
+  [[nodiscard]] Status update(StpInfo const& info) noexcept override;
 
-private:
-    /**
-     * Checks if ball is in our defense area and still
-     * @param field Field
-     * @param ballPos Ball position
-     * @param ballVel Ball velocity
-     * @return True if ball is in our defense area and still
-     */
-    [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
+ private:
+  /**
+   * Checks if ball is in our defense area and still
+   * @param field Field
+   * @param ballPos Ball position
+   * @param ballVel Ball velocity
+   * @return True if ball is in our defense area and still
+   */
+  [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
 
-    /**
-     * Resets state machine when ball is in our defense area and still and current tactic is not KeeperBlockBall
-     * @param isBallInOurDefenseAreaAndStill True if ball is in our defense area and still
-     * @return True if isBallInOurDefenseAreaAndStill and current tactic is not KeeperBlockBall
-     */
-    [[nodiscard]] bool shouldRoleReset(bool isBallInOurDefenseAreaAndStill) noexcept;
+  /**
+   * Resets state machine when ball is in our defense area and still and current tactic is not KeeperBlockBall
+   * @param isBallInOurDefenseAreaAndStill True if ball is in our defense area and still
+   * @return True if isBallInOurDefenseAreaAndStill and current tactic is not KeeperBlockBall
+   */
+  [[nodiscard]] bool shouldRoleReset(bool isBallInOurDefenseAreaAndStill) noexcept;
 };
+}  // namespace rtt::ai::stp::role
 
-} // namespace rtt::ai::stp::role
-
-#endif //RTT_KEEPER_H
+#endif  // RTT_KEEPER_H

--- a/include/roboteam_ai/stp/new_roles/PassReceiver.h
+++ b/include/roboteam_ai/stp/new_roles/PassReceiver.h
@@ -5,17 +5,17 @@
 #ifndef RTT_PASSRECEIVER_H
 #define RTT_PASSRECEIVER_H
 
-#include <stp/Role.hpp>
+#include "stp/Role.hpp"
 
 namespace rtt::ai::stp::role {
 
 class PassReceiver : public Role {
-   public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
-    PassReceiver(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  PassReceiver(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/PassReceiver.h
+++ b/include/roboteam_ai/stp/new_roles/PassReceiver.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class PassReceiver : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  PassReceiver(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    PassReceiver(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/Passer.h
+++ b/include/roboteam_ai/stp/new_roles/Passer.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp::role {
 
 class Passer : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  Passer(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    Passer(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/Passer.h
+++ b/include/roboteam_ai/stp/new_roles/Passer.h
@@ -5,17 +5,17 @@
 #ifndef RTT_PASSER_H
 #define RTT_PASSER_H
 
-#include <stp/Role.hpp>
+#include "stp/Role.hpp"
 
 namespace rtt::ai::stp::role {
 
 class Passer : public Role {
-   public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
-    Passer(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  Passer(std::string name);
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/PenaltyKeeper.h
+++ b/include/roboteam_ai/stp/new_roles/PenaltyKeeper.h
@@ -12,19 +12,19 @@
 namespace rtt::ai::stp::role {
 
 class PenaltyKeeper : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a state machine of tactics
-   * @param name name of the role
-   */
-  explicit PenaltyKeeper(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a state machine of tactics
+     * @param name name of the role
+     */
+    explicit PenaltyKeeper(std::string name);
 
-  /**
-   * Besides the default update from base class Role, it also switches between tactics depending on the ball position and velocity
-   * @param info TacticInfo to be passed to update()
-   * @return The status that the current tactic returns
-   */
-  [[nodiscard]] Status update(StpInfo const& info) noexcept override;
+    /**
+     * Besides the default update from base class Role, it also switches between tactics depending on the ball position and velocity
+     * @param info TacticInfo to be passed to update()
+     * @return The status that the current tactic returns
+     */
+    [[nodiscard]] Status update(StpInfo const& info) noexcept override;
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/new_roles/PenaltyKeeper.h
+++ b/include/roboteam_ai/stp/new_roles/PenaltyKeeper.h
@@ -12,21 +12,20 @@
 namespace rtt::ai::stp::role {
 
 class PenaltyKeeper : public Role {
-   public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
-    explicit PenaltyKeeper(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a state machine of tactics
+   * @param name name of the role
+   */
+  explicit PenaltyKeeper(std::string name);
 
-    /**
-     * Besides the default update from base class Role, it also switches between tactics depending on the ball position and velocity
-     * @param info TacticInfo to be passed to update()
-     * @return The status that the current tactic returns
-     */
-    [[nodiscard]] Status update(StpInfo const& info) noexcept override;
+  /**
+   * Besides the default update from base class Role, it also switches between tactics depending on the ball position and velocity
+   * @param info TacticInfo to be passed to update()
+   * @return The status that the current tactic returns
+   */
+  [[nodiscard]] Status update(StpInfo const& info) noexcept override;
 };
-
 }  // namespace rtt::ai::stp::role
 
 #endif  // RTT_PENALTYKEEPER_H

--- a/include/roboteam_ai/stp/new_roles/TestRole.h
+++ b/include/roboteam_ai/stp/new_roles/TestRole.h
@@ -10,12 +10,12 @@
 namespace rtt::ai::stp {
 
 class TestRole : public Role {
- public:
-  /**
-   * Ctor that sets the name of the role and creates a statemachine of tactics
-   * @param name name of the role
-   */
-  TestRole(std::string name);
+   public:
+    /**
+     * Ctor that sets the name of the role and creates a statemachine of tactics
+     * @param name name of the role
+     */
+    TestRole(std::string name);
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/new_roles/TestRole.h
+++ b/include/roboteam_ai/stp/new_roles/TestRole.h
@@ -5,17 +5,17 @@
 #ifndef RTT_TESTROLE_H
 #define RTT_TESTROLE_H
 
-#include <stp/Role.hpp>
+#include "stp/Role.hpp"
 
 namespace rtt::ai::stp {
 
 class TestRole : public Role {
-   public:
-    /**
-     * Ctor that sets the name of the role and creates a statemachine of tactics
-     * @param name name of the role
-     */
-    TestRole(std::string name);
+ public:
+  /**
+   * Ctor that sets the name of the role and creates a statemachine of tactics
+   * @param name name of the role
+   */
+  TestRole(std::string name);
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/new_skills/Chip.h
+++ b/include/roboteam_ai/stp/new_skills/Chip.h
@@ -10,33 +10,25 @@
 namespace rtt::ai::stp::skill {
 
 class Chip : public Skill {
-    /**
-     * On initialize of this tactic
-     */
-    void onInitialize() noexcept override;
+  /**
+   * On update of this tactic
+   * @param info StpInfo struct with all relevant info for this robot and this skill
+   * @return A Status, either Running or Success
+   */
+  Status onUpdate(StpInfo const& info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    Status onUpdate(StpInfo const& info) noexcept override;
+  /**
+   * Gets the skill name
+   * @return The name of this skill
+   */
+  const char* getName() override;
 
-    /**
-     * On terminate of this tactic
-     */
-    void onTerminate() noexcept override;
-
-    /**
-     * Gets the skill name
-     */
-    const char* getName() override;
-
-   private:
-    /**
-     * Keeps track of how many ticks we tried to chip
-     */
-    int chipAttempts = 0;
+ private:
+  /**
+   * Keeps track of how many ticks we tried to chip
+   */
+  int chipAttempts = 0;
 };
-
 }  // namespace rtt::ai::stp::skill
 
 #endif  // RTT_CHIP_H

--- a/include/roboteam_ai/stp/new_skills/Chip.h
+++ b/include/roboteam_ai/stp/new_skills/Chip.h
@@ -10,24 +10,24 @@
 namespace rtt::ai::stp::skill {
 
 class Chip : public Skill {
-  /**
-   * On update of this tactic
-   * @param info StpInfo struct with all relevant info for this robot and this skill
-   * @return A Status, either Running or Success
-   */
-  Status onUpdate(StpInfo const& info) noexcept override;
+    /**
+     * On update of this tactic
+     * @param info StpInfo struct with all relevant info for this robot and this skill
+     * @return A Status, either Running or Success
+     */
+    Status onUpdate(StpInfo const& info) noexcept override;
 
-  /**
-   * Gets the skill name
-   * @return The name of this skill
-   */
-  const char* getName() override;
+    /**
+     * Gets the skill name
+     * @return The name of this skill
+     */
+    const char* getName() override;
 
- private:
-  /**
-   * Keeps track of how many ticks we tried to chip
-   */
-  int chipAttempts = 0;
+   private:
+    /**
+     * Keeps track of how many ticks we tried to chip
+     */
+    int chipAttempts = 0;
 };
 }  // namespace rtt::ai::stp::skill
 

--- a/include/roboteam_ai/stp/new_skills/GoToPos.h
+++ b/include/roboteam_ai/stp/new_skills/GoToPos.h
@@ -10,27 +10,19 @@
 namespace rtt::ai::stp::skill {
 
 class GoToPos : public Skill {
-    /**
-     * On initialize of this tactic
-     */
-    void onInitialize() noexcept override;
+  /**
+   * On update of this tactic
+   * @param info StpInfo struct with all relevant info for this robot and this skill
+   * @return A Status, either Running or Success
+   */
+  Status onUpdate(StpInfo const& info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    Status onUpdate(StpInfo const& info) noexcept override;
-
-    /**
-     * On terminate of this tactic
-     */
-    void onTerminate() noexcept override;
-
-    /**
-     * Gets the skill name
-     */
-    const char *getName() override;
+  /**
+   * Gets the skill name
+   * @return The name of this skill
+   */
+  const char* getName() override;
 };
-
 }  // namespace rtt::ai::stp::skill
 
 #endif  // RTT_GOTOPOS_H

--- a/include/roboteam_ai/stp/new_skills/GoToPos.h
+++ b/include/roboteam_ai/stp/new_skills/GoToPos.h
@@ -10,18 +10,18 @@
 namespace rtt::ai::stp::skill {
 
 class GoToPos : public Skill {
-  /**
-   * On update of this tactic
-   * @param info StpInfo struct with all relevant info for this robot and this skill
-   * @return A Status, either Running or Success
-   */
-  Status onUpdate(StpInfo const& info) noexcept override;
+    /**
+     * On update of this tactic
+     * @param info StpInfo struct with all relevant info for this robot and this skill
+     * @return A Status, either Running or Success
+     */
+    Status onUpdate(StpInfo const& info) noexcept override;
 
-  /**
-   * Gets the skill name
-   * @return The name of this skill
-   */
-  const char* getName() override;
+    /**
+     * Gets the skill name
+     * @return The name of this skill
+     */
+    const char* getName() override;
 };
 }  // namespace rtt::ai::stp::skill
 

--- a/include/roboteam_ai/stp/new_skills/Kick.h
+++ b/include/roboteam_ai/stp/new_skills/Kick.h
@@ -10,33 +10,25 @@
 namespace rtt::ai::stp::skill {
 
 class Kick : public Skill {
-    /**
-     * On initialize of this tactic
-     */
-    void onInitialize() noexcept override;
+  /**
+   * On update of this tactic
+   * @param info StpInfo struct with all relevant info for this robot and this skill
+   * @return A Status, either Running or Success
+   */
+  Status onUpdate(StpInfo const& info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    Status onUpdate(StpInfo const& info) noexcept override;
+  /**
+   * Gets the skill name
+   * @return The name of this skill
+   */
+  const char* getName() override;
 
-    /**
-     * On terminate of this tactic
-     */
-    void onTerminate() noexcept override;
-
-    /**
-     * Gets the skill name
-     */
-    const char* getName() override;
-
-   private:
-    /**
-     * Keeps track of how many ticks we tried to kick
-     */
-    int kickAttempts = 0;
+ private:
+  /**
+   * Keeps track of how many ticks we tried to kick
+   */
+  int kickAttempts = 0;
 };
-
 }  // namespace rtt::ai::stp::skill
 
 #endif  // RTT_KICK_H

--- a/include/roboteam_ai/stp/new_skills/Kick.h
+++ b/include/roboteam_ai/stp/new_skills/Kick.h
@@ -10,24 +10,24 @@
 namespace rtt::ai::stp::skill {
 
 class Kick : public Skill {
-  /**
-   * On update of this tactic
-   * @param info StpInfo struct with all relevant info for this robot and this skill
-   * @return A Status, either Running or Success
-   */
-  Status onUpdate(StpInfo const& info) noexcept override;
+    /**
+     * On update of this tactic
+     * @param info StpInfo struct with all relevant info for this robot and this skill
+     * @return A Status, either Running or Success
+     */
+    Status onUpdate(StpInfo const& info) noexcept override;
 
-  /**
-   * Gets the skill name
-   * @return The name of this skill
-   */
-  const char* getName() override;
+    /**
+     * Gets the skill name
+     * @return The name of this skill
+     */
+    const char* getName() override;
 
- private:
-  /**
-   * Keeps track of how many ticks we tried to kick
-   */
-  int kickAttempts = 0;
+   private:
+    /**
+     * Keeps track of how many ticks we tried to kick
+     */
+    int kickAttempts = 0;
 };
 }  // namespace rtt::ai::stp::skill
 

--- a/include/roboteam_ai/stp/new_skills/Rotate.h
+++ b/include/roboteam_ai/stp/new_skills/Rotate.h
@@ -10,18 +10,18 @@
 namespace rtt::ai::stp::skill {
 
 class Rotate : public Skill {
-  /**
-   * On update of this tactic
-   * @param info StpInfo struct with all relevant info for this robot and this skill
-   * @return A Status, either Running or Success
-   */
-  Status onUpdate(StpInfo const& info) noexcept override;
+    /**
+     * On update of this tactic
+     * @param info StpInfo struct with all relevant info for this robot and this skill
+     * @return A Status, either Running or Success
+     */
+    Status onUpdate(StpInfo const& info) noexcept override;
 
-  /**
-   * Gets the skill name
-   * @return The name of this skill
-   */
-  const char* getName() override;
+    /**
+     * Gets the skill name
+     * @return The name of this skill
+     */
+    const char* getName() override;
 };
 }  // namespace rtt::ai::stp::skill
 

--- a/include/roboteam_ai/stp/new_skills/Rotate.h
+++ b/include/roboteam_ai/stp/new_skills/Rotate.h
@@ -10,27 +10,19 @@
 namespace rtt::ai::stp::skill {
 
 class Rotate : public Skill {
-    /**
-     * On initialize of this tactic
-     */
-    void onInitialize() noexcept override;
+  /**
+   * On update of this tactic
+   * @param info StpInfo struct with all relevant info for this robot and this skill
+   * @return A Status, either Running or Success
+   */
+  Status onUpdate(StpInfo const& info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    Status onUpdate(StpInfo const& info) noexcept override;
-
-    /**
-     * On terminate of this tactic
-     */
-    void onTerminate() noexcept override;
-
-    /**
-     * Gets the skill name
-     */
-    const char *getName() override;
+  /**
+   * Gets the skill name
+   * @return The name of this skill
+   */
+  const char* getName() override;
 };
-
 }  // namespace rtt::ai::stp::skill
 
 #endif  // RTT_ROTATE_H

--- a/include/roboteam_ai/stp/new_skills/Shoot.h
+++ b/include/roboteam_ai/stp/new_skills/Shoot.h
@@ -10,48 +10,40 @@
 namespace rtt::ai::stp::skill {
 
 class Shoot : public Skill {
-    /**
-     * On initialize of this tactic
-     */
-    void onInitialize() noexcept override;
+  /**
+   * On update of this tactic
+   * Here we check if we should kick or chip and call the corresponding function
+   * @param info StpInfo struct with all relevant info for this robot and this skill
+   * @return A Status, either Running or Success
+   */
+  Status onUpdate(StpInfo const& info) noexcept override;
 
-    /**
-     * On update of this tactic
-     * Here we check if we should kick or chip and call the corresponding function
-     */
-    Status onUpdate(StpInfo const& info) noexcept override;
+  /**
+   * This function handles chipping
+   * @param info StpInfo struct with all relevant info for this robot and this skill
+   * @return A Status, either Running or Success
+   */
+  Status onUpdateChip(StpInfo const& info) noexcept;
 
-    /**
-     * This function handles chipping
-     * @param info
-     * @return Status
-     */
-    Status onUpdateChip(StpInfo const& info) noexcept;
+  /**
+   * This function handles kicking
+   * @param info StpInfo struct with all relevant info for this robot and this skill
+   * @return A Status, either Running or Success
+   */
+  Status onUpdateKick(StpInfo const& info) noexcept;
 
-    /**
-     * This function handles kicking
-     * @param info
-     * @return Status
-     */
-    Status onUpdateKick(StpInfo const& info) noexcept;
+  /**
+   * Gets the skill name
+   * @return The name of this skill
+   */
+  const char* getName() override;
 
-    /**
-     * On terminate of this tactic
-     */
-    void onTerminate() noexcept override;
-
-    /**
-     * Gets the skill name
-     */
-    const char* getName() override;
-
-   private:
-    /**
-     * Keeps track of how many ticks we tried to shoot
-     */
-    int shootAttempts = 0;
+ private:
+  /**
+   * Keeps track of how many ticks we tried to shoot
+   */
+  int shootAttempts = 0;
 };
-
 }  // namespace rtt::ai::stp::skill
 
 #endif  // RTT_SHOOT_H

--- a/include/roboteam_ai/stp/new_skills/Shoot.h
+++ b/include/roboteam_ai/stp/new_skills/Shoot.h
@@ -10,39 +10,39 @@
 namespace rtt::ai::stp::skill {
 
 class Shoot : public Skill {
-  /**
-   * On update of this tactic
-   * Here we check if we should kick or chip and call the corresponding function
-   * @param info StpInfo struct with all relevant info for this robot and this skill
-   * @return A Status, either Running or Success
-   */
-  Status onUpdate(StpInfo const& info) noexcept override;
+    /**
+     * On update of this tactic
+     * Here we check if we should kick or chip and call the corresponding function
+     * @param info StpInfo struct with all relevant info for this robot and this skill
+     * @return A Status, either Running or Success
+     */
+    Status onUpdate(StpInfo const& info) noexcept override;
 
-  /**
-   * This function handles chipping
-   * @param info StpInfo struct with all relevant info for this robot and this skill
-   * @return A Status, either Running or Success
-   */
-  Status onUpdateChip(StpInfo const& info) noexcept;
+    /**
+     * This function handles chipping
+     * @param info StpInfo struct with all relevant info for this robot and this skill
+     * @return A Status, either Running or Success
+     */
+    Status onUpdateChip(StpInfo const& info) noexcept;
 
-  /**
-   * This function handles kicking
-   * @param info StpInfo struct with all relevant info for this robot and this skill
-   * @return A Status, either Running or Success
-   */
-  Status onUpdateKick(StpInfo const& info) noexcept;
+    /**
+     * This function handles kicking
+     * @param info StpInfo struct with all relevant info for this robot and this skill
+     * @return A Status, either Running or Success
+     */
+    Status onUpdateKick(StpInfo const& info) noexcept;
 
-  /**
-   * Gets the skill name
-   * @return The name of this skill
-   */
-  const char* getName() override;
+    /**
+     * Gets the skill name
+     * @return The name of this skill
+     */
+    const char* getName() override;
 
- private:
-  /**
-   * Keeps track of how many ticks we tried to shoot
-   */
-  int shootAttempts = 0;
+   private:
+    /**
+     * Keeps track of how many ticks we tried to shoot
+     */
+    int shootAttempts = 0;
 };
 }  // namespace rtt::ai::stp::skill
 

--- a/include/roboteam_ai/stp/new_tactics/AvoidBall.h
+++ b/include/roboteam_ai/stp/new_tactics/AvoidBall.h
@@ -9,45 +9,49 @@
 
 namespace rtt::ai::stp::tactic {
 
-    class AvoidBall : public Tactic {
-    public:
-        AvoidBall();
+class AvoidBall : public Tactic {
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  AvoidBall();
 
-    private:
-        /**
-         * On initialization of this tactic, initialize the state machine with skills
-         */
-        void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-        /**
-         * On update of this tactic
-         */
-        void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * This tactic can never fail, so always returns false
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-        /**
-         * On terminate of this tactic, call terminate on all underlying skills
-         */
-        void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Returns true when the robot is further away from the target position than some error margin
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-        /**
-         * Calculate the SkillInfo from the TacticInfo
-         * @param info info is the TacticInfo passed by the role
-         * @return std::optional<SkillInfo> based on the TacticInfo
-         */
-        std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return true, since it is an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-        bool isTacticFailing(const StpInfo &info) noexcept override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
+};
+}  // namespace rtt::ai::stp::tactic
 
-        bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-        bool isEndTactic() noexcept override;
-
-        /**
-         * Gets the tactic name
-         */
-        const char *getName() override;
-    };
-
-} // namespace rtt::ai::stp::tactic
-
-#endif //RTT_AVOIDBALL_H
+#endif  // RTT_AVOIDBALL_H

--- a/include/roboteam_ai/stp/new_tactics/AvoidBall.h
+++ b/include/roboteam_ai/stp/new_tactics/AvoidBall.h
@@ -10,47 +10,47 @@
 namespace rtt::ai::stp::tactic {
 
 class AvoidBall : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  AvoidBall();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    AvoidBall();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * This tactic can never fail, so always returns false
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * This tactic can never fail, so always returns false
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Returns true when the robot is further away from the target position than some error margin
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Returns true when the robot is further away from the target position than some error margin
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return true, since it is an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return true, since it is an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/BlockBall.h
+++ b/include/roboteam_ai/stp/new_tactics/BlockBall.h
@@ -10,53 +10,57 @@
 namespace rtt::ai::stp::tactic {
 
 class BlockBall : public Tactic {
-   public:
-    BlockBall();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  BlockBall();
 
-   private:
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * This tactic can never fail, so always returns false
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Returns true when the robot is further away from the target position than some error margin
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate the SkillInfo from the TacticInfo
-     * @param info info is the TacticInfo passed by the role
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return true, since it is an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    bool isTacticFailing(const StpInfo &info) noexcept override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    bool isEndTactic() noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
-
-    /**
-     * Calculates the position for the blocker
-     * @param ball Ball
-     * @param field Field
-     * @param enemyRobot Enemy robot closest to ball
-     * @return Target position for the blocker
-     */
-    static Vector2 calculateTargetPosition(const world_new::view::BallView &ball, const world::Field &field, const world_new::view::RobotView &enemyRobot) noexcept;
+  /**
+   * Calculates the position for the blocker
+   * @param ball Ball
+   * @param field Field
+   * @param enemyRobot Enemy robot closest to ball
+   * @return Target position for the blocker
+   */
+  static Vector2 calculateTargetPosition(const world_new::view::BallView &ball, const world::Field &field, const world_new::view::RobotView &enemyRobot) noexcept;
 };
-
 }  // namespace rtt::ai::stp::tactic
 
 #endif  // RTT_BLOCKBALL_H

--- a/include/roboteam_ai/stp/new_tactics/BlockBall.h
+++ b/include/roboteam_ai/stp/new_tactics/BlockBall.h
@@ -10,56 +10,56 @@
 namespace rtt::ai::stp::tactic {
 
 class BlockBall : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  BlockBall();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    BlockBall();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * This tactic can never fail, so always returns false
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * This tactic can never fail, so always returns false
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Returns true when the robot is further away from the target position than some error margin
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Returns true when the robot is further away from the target position than some error margin
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return true, since it is an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return true, since it is an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 
-  /**
-   * Calculates the position for the blocker
-   * @param ball Ball
-   * @param field Field
-   * @param enemyRobot Enemy robot closest to ball
-   * @return Target position for the blocker
-   */
-  static Vector2 calculateTargetPosition(const world_new::view::BallView &ball, const world::Field &field, const world_new::view::RobotView &enemyRobot) noexcept;
+    /**
+     * Calculates the position for the blocker
+     * @param ball Ball
+     * @param field Field
+     * @param enemyRobot Enemy robot closest to ball
+     * @return Target position for the blocker
+     */
+    static Vector2 calculateTargetPosition(const world_new::view::BallView &ball, const world::Field &field, const world_new::view::RobotView &enemyRobot) noexcept;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/BlockRobot.h
+++ b/include/roboteam_ai/stp/new_tactics/BlockRobot.h
@@ -10,66 +10,66 @@
 namespace rtt::ai::stp::tactic {
 
 class BlockRobot : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  BlockRobot();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    BlockRobot();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * This tactic can never fail, so always returns false
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * This tactic can never fail, so always returns false
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Returns true when the robot is further away from the target position than some error margin
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Returns true when the robot is further away from the target position than some error margin
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return true, since it is an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return true, since it is an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 
-  /**
-   * Find the desired angle for the robot to block the target
-   * @param enemy the robot that is being blocked
-   * @param targetLocation the location that you want to block off from the robot. For example, the ball position,
-   * or our goal
-   * @return desired angle for robot to block target
-   */
-  double calculateAngle(const world_new::view::RobotView enemy, const Vector2 &targetLocation);
+    /**
+     * Find the desired angle for the robot to block the target
+     * @param enemy the robot that is being blocked
+     * @param targetLocation the location that you want to block off from the robot. For example, the ball position,
+     * or our goal
+     * @return desired angle for robot to block target
+     */
+    double calculateAngle(const world_new::view::RobotView enemy, const Vector2 &targetLocation);
 
-  /**
-   * Find location for robot to move to to block the target
-   * @param blockDistance how close the robot should be to the enemy robot.
-   * @param enemy the enemy robot to be blocked
-   * @param targetLocation the location that you want to block off from the robot. For example, the ball position,
-   * or our goal
-   * @return the desired position to block the target.
-   */
-  Vector2 calculateDesiredRobotPosition(BlockDistance blockDistance, const world_new::view::RobotView enemy, const Vector2 &targetLocation);
+    /**
+     * Find location for robot to move to to block the target
+     * @param blockDistance how close the robot should be to the enemy robot.
+     * @param enemy the enemy robot to be blocked
+     * @param targetLocation the location that you want to block off from the robot. For example, the ball position,
+     * or our goal
+     * @return the desired position to block the target.
+     */
+    Vector2 calculateDesiredRobotPosition(BlockDistance blockDistance, const world_new::view::RobotView enemy, const Vector2 &targetLocation);
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/BlockRobot.h
+++ b/include/roboteam_ai/stp/new_tactics/BlockRobot.h
@@ -5,68 +5,71 @@
 #ifndef RTT_BLOCKROBOT_H
 #define RTT_BLOCKROBOT_H
 
-#include <include/roboteam_ai/stp/Tactic.h>
-#include <include/roboteam_ai/utilities/Constants.h>
+#include "stp/Tactic.h"
 
 namespace rtt::ai::stp::tactic {
 
 class BlockRobot : public Tactic {
-   public:
-    BlockRobot();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  BlockRobot();
 
-   private:
-    // TODO: TUNE make this a sensible margin
-    const double errorMargin = 1 * Constants::ROBOT_RADIUS();
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * This tactic can never fail, so always returns false
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Returns true when the robot is further away from the target position than some error margin
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate the SkillInfo from the TacticInfo
-     * @param info info is the TacticInfo passed by the role
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return true, since it is an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    /**
-     * Find the desired angle for the robot to block the target
-     * @param enemy the robot that is being blocked
-     * @param targetLocation the location that you want to block off from the robot. For example, the ball position,
-     * or our goal
-     * @return desired angle for robot to block target
-     */
-    double calculateAngle(const world_new::view::RobotView enemy, const Vector2& targetLocation);
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 
-    /**
-     * Find location for robot to move to to block the target
-     * @param blockDistance how close the robot should be to the enemy robot.
-     * @param enemy the enemy robot to be blocked
-     * @param targetLocation the location that you want to block off from the robot. For example, the ball position,
-     * or our goal
-     * @return the desired position to block the target.
-     */
-    Vector2 calculateDesiredRobotPosition(BlockDistance blockDistance, const world_new::view::RobotView enemy, const Vector2& targetLocation);
+  /**
+   * Find the desired angle for the robot to block the target
+   * @param enemy the robot that is being blocked
+   * @param targetLocation the location that you want to block off from the robot. For example, the ball position,
+   * or our goal
+   * @return desired angle for robot to block target
+   */
+  double calculateAngle(const world_new::view::RobotView enemy, const Vector2 &targetLocation);
 
-    bool isTacticFailing(const StpInfo &info) noexcept override;
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    bool isEndTactic() noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Find location for robot to move to to block the target
+   * @param blockDistance how close the robot should be to the enemy robot.
+   * @param enemy the enemy robot to be blocked
+   * @param targetLocation the location that you want to block off from the robot. For example, the ball position,
+   * or our goal
+   * @return the desired position to block the target.
+   */
+  Vector2 calculateDesiredRobotPosition(BlockDistance blockDistance, const world_new::view::RobotView enemy, const Vector2 &targetLocation);
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/ChipAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/ChipAtPos.h
@@ -10,47 +10,47 @@
 namespace rtt::ai::stp::tactic {
 
 class ChipAtPos : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  ChipAtPos();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    ChipAtPos();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * Returns true when robot doesn't have the ball or if there is no shootTarget
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * Returns true when robot doesn't have the ball or if there is no shootTarget
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Returns true when the robot angle is not within its error margin
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Returns true when the robot angle is not within its error margin
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return false, since it is NOT an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return false, since it is NOT an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/ChipAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/ChipAtPos.h
@@ -5,47 +5,52 @@
 #ifndef RTT_CHIPATPOS_H
 #define RTT_CHIPATPOS_H
 
-#include "include/roboteam_ai/stp/Tactic.h"
+#include "stp/Tactic.h"
 
 namespace rtt::ai::stp::tactic {
 
 class ChipAtPos : public Tactic {
-   public:
-    ChipAtPos();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  ChipAtPos();
 
-   private:
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * Returns true when robot doesn't have the ball or if there is no shootTarget
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Returns true when the robot angle is not within its error margin
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate the SkillInfo from the TacticInfo
-     * @param info info is the TacticInfo passed by the role
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return false, since it is NOT an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    bool isEndTactic() noexcept override;
-
-    bool isTacticFailing(const StpInfo &info) noexcept override;
-
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/DriveWithBall.h
+++ b/include/roboteam_ai/stp/new_tactics/DriveWithBall.h
@@ -9,42 +9,47 @@
 
 namespace rtt::ai::stp::tactic {
 class DriveWithBall : public Tactic {
-   public:
-    DriveWithBall();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  DriveWithBall();
 
-   private:
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * Fails if we don't have the ball or there is no movement position
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Should reset if the angle the robot is at is no longer correct
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate the SkillInfo from the TacticInfo
-     * @param info info is the TacticInfo passed by the role
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return false, since it is NOT an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    bool isEndTactic() noexcept override;
-
-    bool isTacticFailing(const StpInfo &info) noexcept override;
-
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/DriveWithBall.h
+++ b/include/roboteam_ai/stp/new_tactics/DriveWithBall.h
@@ -9,47 +9,47 @@
 
 namespace rtt::ai::stp::tactic {
 class DriveWithBall : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  DriveWithBall();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    DriveWithBall();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * Fails if we don't have the ball or there is no movement position
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * Fails if we don't have the ball or there is no movement position
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Should reset if the angle the robot is at is no longer correct
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Should reset if the angle the robot is at is no longer correct
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return false, since it is NOT an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return false, since it is NOT an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/Formation.h
+++ b/include/roboteam_ai/stp/new_tactics/Formation.h
@@ -10,47 +10,47 @@
 namespace rtt::ai::stp::tactic {
 
 class Formation : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  Formation();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    Formation();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * Fails if there is no position to move to
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * Fails if there is no position to move to
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Resets when robot position is not close enough to the target position
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Resets when robot position is not close enough to the target position
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return true, since it is an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return true, since it is an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/Formation.h
+++ b/include/roboteam_ai/stp/new_tactics/Formation.h
@@ -10,54 +10,48 @@
 namespace rtt::ai::stp::tactic {
 
 class Formation : public Tactic {
-   public:
-    Formation();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  Formation();
 
-   private:
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * Fails if there is no position to move to
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Resets when robot position is not close enough to the target position
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate info for the skills
-     * @param info Info passed by the role
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return true, since it is an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    /**
-     * Tactic fails if target type is not a move target
-     * @param info Info
-     * @return True if target type is not a move target
-     */
-    bool isTacticFailing(const StpInfo &info) noexcept override;
-
-    /**
-     * Reset tactic when robot position is not close enough to the target position
-     * @param info Info
-     * @return True if robot position is not close enough to the target position
-     */
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    bool isEndTactic() noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 };
-
 }  // namespace rtt::ai::stp::tactic
 
 #endif  // RTT_FORMATION_TACTIC_H

--- a/include/roboteam_ai/stp/new_tactics/GetBall.h
+++ b/include/roboteam_ai/stp/new_tactics/GetBall.h
@@ -14,54 +14,55 @@ namespace rtt::ai::stp::tactic {
  * end tactic, therefore it can succeed.
  */
 class GetBall : public Tactic {
-   public:
-    GetBall();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  GetBall();
 
-   protected:
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * This tactic can never fail, so always returns false
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Returns true when the robot does not have the ball
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * See base class' implementation for details. <br><br>
-     * Extra information for this skill is the target position (which will be a point
-     * close to the ball between it and the robot, the rotation angle (the robot will
-     * face the ball after getting close) and dribbler.
-     * @param info tactic info passed from play
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return false, since it is NOT an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    /**
-     * Check base class for usages. The current tactic cannot fail, only reset.
-     * @param info
-     * @return always false
-     */
-    bool isTacticFailing(const StpInfo &info) noexcept override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 
-    /**
-     * This tactic will be reset when the robot looses the ball
-     * @param info
-     * @return true if the robot lost the ball
-     */
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    bool isEndTactic() noexcept override;
-
-    /**
-     * Checks if this tactic should be forced success
-     * It is forced success whenever the corresponding robot has the ball
-     * @param info
-     * @return whether the tactic is forced success
-     */
-    bool forceTacticSuccess(const StpInfo &info) noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Checks if this tactic should be forced success
+   * It is forced success whenever the corresponding robot has the ball
+   * @param info
+   * @return whether the tactic is forced success
+   */
+  bool forceTacticSuccess(const StpInfo &info) noexcept override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/GetBall.h
+++ b/include/roboteam_ai/stp/new_tactics/GetBall.h
@@ -14,55 +14,55 @@ namespace rtt::ai::stp::tactic {
  * end tactic, therefore it can succeed.
  */
 class GetBall : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  GetBall();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    GetBall();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * This tactic can never fail, so always returns false
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * This tactic can never fail, so always returns false
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Returns true when the robot does not have the ball
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Returns true when the robot does not have the ball
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return false, since it is NOT an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return false, since it is NOT an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 
-  /**
-   * Checks if this tactic should be forced success
-   * It is forced success whenever the corresponding robot has the ball
-   * @param info
-   * @return whether the tactic is forced success
-   */
-  bool forceTacticSuccess(const StpInfo &info) noexcept override;
+    /**
+     * Checks if this tactic should be forced success
+     * It is forced success whenever the corresponding robot has the ball
+     * @param info
+     * @return whether the tactic is forced success
+     */
+    bool forceTacticSuccess(const StpInfo &info) noexcept override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/GetBallInDirection.h
+++ b/include/roboteam_ai/stp/new_tactics/GetBallInDirection.h
@@ -14,47 +14,47 @@ namespace rtt::ai::stp::tactic {
  * It's not an end tactic, therefore it can succeed.
  */
 class GetBallInDirection : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  GetBallInDirection();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    GetBallInDirection();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * Fails when there is no target to shoot at
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * Fails when there is no target to shoot at
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * This tactic never resets, so false
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * This tactic never resets, so false
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return false, since it is NOT an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return false, since it is NOT an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/GetBallInDirection.h
+++ b/include/roboteam_ai/stp/new_tactics/GetBallInDirection.h
@@ -13,50 +13,49 @@ namespace rtt::ai::stp::tactic {
  * It fails when there is no target to point towards and does not reset.
  * It's not an end tactic, therefore it can succeed.
  */
-    class GetBallInDirection : public Tactic {
-    public:
-        GetBallInDirection();
+class GetBallInDirection : public Tactic {
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  GetBallInDirection();
 
-    protected:
-        void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-        void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * Fails when there is no target to shoot at
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-        void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * This tactic never resets, so false
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-        /**
-         * See base class' implementation for details. <br><br>
-         * Extra information for this skill is the position behind the ball, rotation angle and dribbler speed.
-         * @param info tactic info passed from play
-         * @return std::optional<SkillInfo> based on the TacticInfo
-         */
-        std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return false, since it is NOT an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-        /**
-         * Check base class for usages. The current tactic fails if there is no target position to aim
-         * @param info
-         * @return True when there is no positionToShootAt
-         */
-        bool isTacticFailing(const StpInfo &info) noexcept override;
-
-        /**
-         * This tactic does not reset
-         * @param info
-         * @return Always false
-         */
-        bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-        /**
-         * This tactic is not an end tactic
-         * @return Always false
-         */
-        bool isEndTactic() noexcept override;
-
-        /**
-         * Gets the tactic name
-         */
-        const char *getName() override;
-    };
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
+};
 }  // namespace rtt::ai::stp::tactic
 
-#endif //RTT_GETBALLINDIRECTION_H
+#endif  // RTT_GETBALLINDIRECTION_H

--- a/include/roboteam_ai/stp/new_tactics/Halt.h
+++ b/include/roboteam_ai/stp/new_tactics/Halt.h
@@ -14,47 +14,47 @@ namespace rtt::ai::stp::tactic {
  * end tactic, therefore it can succeed.
  */
 class Halt : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  Halt();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    Halt();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * This tactic can never fail, so always returns false
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * This tactic can never fail, so always returns false
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * This tactic can never reset, so always returns false
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * This tactic can never reset, so always returns false
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return true, since it is an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return true, since it is an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/Halt.h
+++ b/include/roboteam_ai/stp/new_tactics/Halt.h
@@ -14,50 +14,48 @@ namespace rtt::ai::stp::tactic {
  * end tactic, therefore it can succeed.
  */
 class Halt : public Tactic {
-public:
-    Halt();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  Halt();
 
-protected:
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * This tactic can never fail, so always returns false
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * This tactic can never reset, so always returns false
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * See base class' implementation for details. <br><br>
-     * Extra information for this skill is the target position and rotation angle
-     * @param info tactic info passed from play
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return true, since it is an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    /**
-     * Check base class for usages. The current tactic cannot fail
-     * @param info
-     * @return always false
-     */
-    bool isTacticFailing(const StpInfo &info) noexcept override;
-
-    /**
-     * This tactic cannot be reset
-     * @param info
-     * @return always false
-     */
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    /**
-     * This tactic is an end tactic
-     * @return true
-     */
-    bool isEndTactic() noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 
-
-#endif //RTT_HALT_TACTIC_H
+#endif  // RTT_HALT_TACTIC_H

--- a/include/roboteam_ai/stp/new_tactics/Intercept.h
+++ b/include/roboteam_ai/stp/new_tactics/Intercept.h
@@ -9,63 +9,63 @@
 
 namespace rtt::ai::stp::tactic {
 class Intercept : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  Intercept();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    Intercept();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * This tactic fails if the ball does not move
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * This tactic fails if the ball does not move
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Returns true when the robot does not have the ball
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Returns true when the robot does not have the ball
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return true, since it is an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return true, since it is an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 
-  /**
-   * Calculate the angle between the robot and the ball
-   * @param robot Robot
-   * @param ball Ball
-   * @return Angle between robot and ball
-   */
-  double calculateAngle(const world_new::view::RobotView &robot, const world_new::view::BallView &ball);
+    /**
+     * Calculate the angle between the robot and the ball
+     * @param robot Robot
+     * @param ball Ball
+     * @return Angle between robot and ball
+     */
+    double calculateAngle(const world_new::view::RobotView &robot, const world_new::view::BallView &ball);
 
-  /**
-   * Determine the dribbler speed
-   * Turn dribbler at full speed when ball is close to robot, otherwise do not dribble
-   * @param robot Robot
-   * @return Dribbler speed in %
-   */
-  int determineDribblerSpeed(const world_new::view::RobotView &robot);
+    /**
+     * Determine the dribbler speed
+     * Turn dribbler at full speed when ball is close to robot, otherwise do not dribble
+     * @param robot Robot
+     * @return Dribbler speed in %
+     */
+    int determineDribblerSpeed(const world_new::view::RobotView &robot);
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/Intercept.h
+++ b/include/roboteam_ai/stp/new_tactics/Intercept.h
@@ -9,68 +9,63 @@
 
 namespace rtt::ai::stp::tactic {
 class Intercept : public Tactic {
-   public:
-    Intercept();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  Intercept();
 
-   private:
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * This tactic fails if the ball does not move
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Returns true when the robot does not have the ball
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate info for the skills
-     * @param info Info passed by the role
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return true, since it is an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    /**
-     * Tactic fails if targetType is not a receiveTarget
-     * @param info Info
-     * @return True if targetType is not a receiveTarget
-     */
-    bool isTacticFailing(const StpInfo &info) noexcept override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 
-    /**
-     * Reset tactic when robot position is not close enough to the target position for receiving
-     * @param info Info
-     * @return True if robot position is not close enough to the target position
-     */
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
+  /**
+   * Calculate the angle between the robot and the ball
+   * @param robot Robot
+   * @param ball Ball
+   * @return Angle between robot and ball
+   */
+  double calculateAngle(const world_new::view::RobotView &robot, const world_new::view::BallView &ball);
 
-    bool isEndTactic() noexcept override;
-
-    /**
-     * Calculate the angle between the robot and the ball
-     * @param robot Robot
-     * @param ball Ball
-     * @return Angle between robot and ball
-     */
-    double calculateAngle(const world_new::view::RobotView &robot, const world_new::view::BallView &ball);
-
-    /**
-     * Determine the dribbler speed
-     * Turn dribbler at full speed when ball is close to robot, otherwise do not dribble
-     * @param robot Robot
-     * @return Dribbler speed in %
-     */
-    int determineDribblerSpeed(const world_new::view::RobotView &robot);
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Determine the dribbler speed
+   * Turn dribbler at full speed when ball is close to robot, otherwise do not dribble
+   * @param robot Robot
+   * @return Dribbler speed in %
+   */
+  int determineDribblerSpeed(const world_new::view::RobotView &robot);
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/KeeperBlockBall.h
+++ b/include/roboteam_ai/stp/new_tactics/KeeperBlockBall.h
@@ -10,55 +10,59 @@
 namespace rtt::ai::stp::tactic {
 
 class KeeperBlockBall : public Tactic {
-   public:
-    KeeperBlockBall();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  KeeperBlockBall();
 
-   private:
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * This tactic can never fail, so always returns false
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Returns true when the robot is further away from the target position than some error margin
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate the SkillInfo from the TacticInfo
-     * @param info info is the TacticInfo passed by the role
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return true, since it is an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    bool isTacticFailing(const StpInfo &info) noexcept override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    bool isEndTactic() noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
-
-    /**
-     * Calculates the position for the keeper
-     * @param ball Ball
-     * @param field Field
-     * @param enemyRobot Enemy robot closest to ball
-     * @return Target position for the keeper and the corresponding PID type
-     * PID type is different for intercepting and kicking (coarse and fast or fine and slower control)
-     */
-    static std::pair<Vector2, stp::PIDType> calculateTargetPosition(const world_new::view::BallView &ball, const world::Field &field,
-                                                                    const world_new::view::RobotView &enemyRobot) noexcept;
+  /**
+   * Calculates the position for the keeper
+   * @param ball Ball
+   * @param field Field
+   * @param enemyRobot Enemy robot closest to ball
+   * @return Target position for the keeper and the corresponding PID type
+   * PID type is different for intercepting and kicking (coarse and fast or fine and slower control)
+   */
+  static std::pair<Vector2, stp::PIDType> calculateTargetPosition(const world_new::view::BallView &ball, const world::Field &field,
+                                                                  const world_new::view::RobotView &enemyRobot) noexcept;
 };
-
 }  // namespace rtt::ai::stp::tactic
 
 #endif  // RTT_KEEPERBLOCKBALL_H

--- a/include/roboteam_ai/stp/new_tactics/KeeperBlockBall.h
+++ b/include/roboteam_ai/stp/new_tactics/KeeperBlockBall.h
@@ -10,58 +10,58 @@
 namespace rtt::ai::stp::tactic {
 
 class KeeperBlockBall : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  KeeperBlockBall();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    KeeperBlockBall();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * This tactic can never fail, so always returns false
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * This tactic can never fail, so always returns false
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Returns true when the robot is further away from the target position than some error margin
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Returns true when the robot is further away from the target position than some error margin
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return true, since it is an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return true, since it is an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 
-  /**
-   * Calculates the position for the keeper
-   * @param ball Ball
-   * @param field Field
-   * @param enemyRobot Enemy robot closest to ball
-   * @return Target position for the keeper and the corresponding PID type
-   * PID type is different for intercepting and kicking (coarse and fast or fine and slower control)
-   */
-  static std::pair<Vector2, stp::PIDType> calculateTargetPosition(const world_new::view::BallView &ball, const world::Field &field,
-                                                                  const world_new::view::RobotView &enemyRobot) noexcept;
+    /**
+     * Calculates the position for the keeper
+     * @param ball Ball
+     * @param field Field
+     * @param enemyRobot Enemy robot closest to ball
+     * @return Target position for the keeper and the corresponding PID type
+     * PID type is different for intercepting and kicking (coarse and fast or fine and slower control)
+     */
+    static std::pair<Vector2, stp::PIDType> calculateTargetPosition(const world_new::view::BallView &ball, const world::Field &field,
+                                                                    const world_new::view::RobotView &enemyRobot) noexcept;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/KickAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/KickAtPos.h
@@ -10,47 +10,47 @@
 namespace rtt::ai::stp::tactic {
 
 class KickAtPos : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  KickAtPos();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    KickAtPos();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * Fails is robot doesn't have the ball or if there is no shootTarget
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * Fails is robot doesn't have the ball or if there is no shootTarget
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Returns true when the robot angle is outside some error margin
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Returns true when the robot angle is outside some error margin
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return false, since it is NOT an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return false, since it is NOT an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/KickAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/KickAtPos.h
@@ -5,47 +5,52 @@
 #ifndef RTT_KICKATPOS_H
 #define RTT_KICKATPOS_H
 
-#include "include/roboteam_ai/stp/Tactic.h"
+#include "stp/Tactic.h"
 
 namespace rtt::ai::stp::tactic {
 
 class KickAtPos : public Tactic {
-   public:
-    KickAtPos();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  KickAtPos();
 
-   private:
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * Fails is robot doesn't have the ball or if there is no shootTarget
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Returns true when the robot angle is outside some error margin
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate the SkillInfo from the TacticInfo
-     * @param info info is the TacticInfo passed by the role
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return false, since it is NOT an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    bool isEndTactic() noexcept override;
-
-    bool isTacticFailing(const StpInfo &info) noexcept override;
-
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/PositionAndAim.h
+++ b/include/roboteam_ai/stp/new_tactics/PositionAndAim.h
@@ -10,47 +10,47 @@
 namespace rtt::ai::stp::tactic {
 
 class PositionAndAim : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  PositionAndAim();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    PositionAndAim();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * This tactic fails if there is no position to move to or no shotTarget
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * This tactic fails if there is no position to move to or no shotTarget
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Returns true when the robot is further away from the target position than some error margin
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Returns true when the robot is further away from the target position than some error margin
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return true, since it is an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return true, since it is an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/PositionAndAim.h
+++ b/include/roboteam_ai/stp/new_tactics/PositionAndAim.h
@@ -10,54 +10,48 @@
 namespace rtt::ai::stp::tactic {
 
 class PositionAndAim : public Tactic {
-public:
-    PositionAndAim();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  PositionAndAim();
 
-private:
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * This tactic fails if there is no position to move to or no shotTarget
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Returns true when the robot is further away from the target position than some error margin
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate info for the skills
-     * @param info Info passed by the role
-     * @return Info for the skills
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return true, since it is an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    /**
-     * Tactic fails if target type is not a move target
-     * @param info Info
-     * @return True if target type is not a move target
-     */
-    bool isTacticFailing(const StpInfo &info) noexcept override;
-
-    /**
-     * Reset tactic when robot position is not close enough to the target position
-     * @param info Info
-     * @return True if robot position is not close enough to the target position
-     */
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    bool isEndTactic() noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 };
-
 }  // namespace rtt::ai::stp::tactic
 
-#endif // RTT_POSITIONANDAIM_H
+#endif  // RTT_POSITIONANDAIM_H

--- a/include/roboteam_ai/stp/new_tactics/Receive.h
+++ b/include/roboteam_ai/stp/new_tactics/Receive.h
@@ -10,55 +10,55 @@
 namespace rtt::ai::stp::tactic {
 
 class Receive : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  Receive();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    Receive();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * This tactic fails if there is no move to position
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * This tactic fails if there is no move to position
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Returns true when the robot is further away from the target position than some error margin
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Returns true when the robot is further away from the target position than some error margin
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return true, since it is an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return true, since it is an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 
-  /**
-   * Calculates the angle the robot needs to have using the ball position
-   * @param robot
-   * @param ball
-   * @return Angle the robot should take
-   */
-  double calculateAngle(const world_new::view::RobotView &robot, const world_new::view::BallView &ball);
+    /**
+     * Calculates the angle the robot needs to have using the ball position
+     * @param robot
+     * @param ball
+     * @return Angle the robot should take
+     */
+    double calculateAngle(const world_new::view::RobotView &robot, const world_new::view::BallView &ball);
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/Receive.h
+++ b/include/roboteam_ai/stp/new_tactics/Receive.h
@@ -5,75 +5,61 @@
 #ifndef RTT_RECEIVE_H
 #define RTT_RECEIVE_H
 
-#include "include/roboteam_ai/stp/Tactic.h"
+#include "stp/Tactic.h"
 
 namespace rtt::ai::stp::tactic {
 
 class Receive : public Tactic {
-   public:
-    Receive();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  Receive();
 
-   private:
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * This tactic fails if there is no move to position
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Returns true when the robot is further away from the target position than some error margin
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate info for the skills
-     * @param info Info passed by the role
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return true, since it is an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    /**
-     * Tactic fails if targetType is not a receiveTarget
-     * @param info Info
-     * @return True if targetType is not a receiveTarget
-     */
-    bool isTacticFailing(const StpInfo &info) noexcept override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 
-    /**
-     * Reset tactic when robot position is not close enough to the target position for receiving
-     * @param info Info
-     * @return True if robot position is not close enough to the target position
-     */
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    /**
-     * Calculate the angle between the robot and the ball
-     * @param robot Robot
-     * @param ball Ball
-     * @return Angle between robot and ball
-     */
-    double calculateAngle(const world_new::view::RobotView &robot, const world_new::view::BallView &ball);
-
-    /**
-     * Determine the dribbler speed
-     * Turn dribbler at full speed when ball is close to robot, otherwise do not dribble
-     * @param robot Robot
-     * @return Dribbler speed in %
-     */
-    int determineDribblerSpeed(const world_new::view::RobotView &robot);
-
-    bool isEndTactic() noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Calculates the angle the robot needs to have using the ball position
+   * @param robot
+   * @param ball
+   * @return Angle the robot should take
+   */
+  double calculateAngle(const world_new::view::RobotView &robot, const world_new::view::BallView &ball);
 };
-
 }  // namespace rtt::ai::stp::tactic
 
 #endif  // RTT_RECEIVE_H

--- a/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
@@ -10,61 +10,61 @@
 namespace rtt::ai::stp::tactic {
 
 class ShootAtPos : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  ShootAtPos();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    ShootAtPos();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * Fails if robot doesn't have the ball or if there is no shootTarget
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * Fails if robot doesn't have the ball or if there is no shootTarget
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * Reset if ball is moving or if the angle of the robot to the ball is greater than some error margin
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Reset if ball is moving or if the angle of the robot to the ball is greater than some error margin
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return false, since it is NOT an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return false, since it is NOT an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 
-  /**
-   * Calculate the info if the role/play wants to execute a kick
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForKick(const StpInfo &info) noexcept;
+    /**
+     * Calculate the info if the role/play wants to execute a kick
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForKick(const StpInfo &info) noexcept;
 
-  /**
-   * Calculate the info if the role/play wants to execute a chip
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForChip(const StpInfo &info) noexcept;
+    /**
+     * Calculate the info if the role/play wants to execute a chip
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForChip(const StpInfo &info) noexcept;
 };
 }  // namespace rtt::ai::stp::tactic
 

--- a/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
+++ b/include/roboteam_ai/stp/new_tactics/ShootAtPos.h
@@ -9,55 +9,63 @@
 
 namespace rtt::ai::stp::tactic {
 
-    class ShootAtPos : public Tactic {
-    public:
-        ShootAtPos();
+class ShootAtPos : public Tactic {
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  ShootAtPos();
 
-    private:
-        /**
-         * On initialization of this tactic, initialize the state machine with skills
-         */
-        void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-        /**
-         * On update of this tactic
-         */
-        void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * Fails if robot doesn't have the ball or if there is no shootTarget
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-        /**
-         * On terminate of this tactic, call terminate on all underlying skills
-         */
-        void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * Reset if ball is moving or if the angle of the robot to the ball is greater than some error margin
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-        /**
-         * Calculate the SkillInfo from the TacticInfo
-         * @param info info is the TacticInfo passed by the role
-         * @return std::optional<SkillInfo> based on the TacticInfo
-         */
-        std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return false, since it is NOT an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-        /**
-         * Calculate the info if the role/play wants to execute a kick
-         */
-        std::optional<StpInfo> calculateInfoForKick(const StpInfo &info) noexcept;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 
-        /**
-         * Calculate the info if the role/play wants to execute a chip
-         */
-        std::optional<StpInfo> calculateInfoForChip(const StpInfo &info) noexcept;
+  /**
+   * Calculate the info if the role/play wants to execute a kick
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForKick(const StpInfo &info) noexcept;
 
-        bool isEndTactic() noexcept override;
-
-        bool isTacticFailing(const StpInfo &info) noexcept override;
-
-        bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-        /**
-         * Gets the tactic name
-         */
-        const char *getName() override;
-    };
+  /**
+   * Calculate the info if the role/play wants to execute a chip
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForChip(const StpInfo &info) noexcept;
+};
 }  // namespace rtt::ai::stp::tactic
 
-
-#endif //RTT_SHOOTATPOS_H
+#endif  // RTT_SHOOTATPOS_H

--- a/include/roboteam_ai/stp/new_tactics/TestTactic.h
+++ b/include/roboteam_ai/stp/new_tactics/TestTactic.h
@@ -10,47 +10,47 @@
 namespace rtt::ai::stp {
 
 class TestTactic : public Tactic {
- public:
-  /**
-   * Constructor for the tactic, it constructs the state machine of skills
-   */
-  TestTactic();
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    TestTactic();
 
- private:
-  /**
-   * Calculate the info for skills from the StpInfo struct parameter
-   * @param info info is the StpInfo passed by the role
-   * @return std::optional<SkillInfo> based on the StpInfo parameter
-   */
-  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-  /**
-   * Is this tactic failing during execution (go back to the previous tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
-   * This tactic can never fail, so always returns false
-   */
-  bool isTacticFailing(const StpInfo &info) noexcept override;
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * This tactic can never fail, so always returns false
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
 
-  /**
-   * Should this tactic be reset (go back to the first skill of this tactic)
-   * @param info StpInfo can be used to check some data
-   * @return true if tactic  should reset, false if execution should continue
-   * This tactic never resets, always false
-   */
-  bool shouldTacticReset(const StpInfo &info) noexcept override;
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * This tactic never resets, always false
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-  /**
-   * Is this tactic an end tactic?
-   * @return This will always return false, since it is NOT an endTactic
-   */
-  bool isEndTactic() noexcept override;
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return false, since it is NOT an endTactic
+     */
+    bool isEndTactic() noexcept override;
 
-  /**
-   * Gets the tactic name
-   * @return The name of this tactic
-   */
-  const char *getName() override;
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/new_tactics/TestTactic.h
+++ b/include/roboteam_ai/stp/new_tactics/TestTactic.h
@@ -5,49 +5,53 @@
 #ifndef RTT_TESTTACTIC_H
 #define RTT_TESTTACTIC_H
 
-#include "include/roboteam_ai/stp/Tactic.h"
+#include "stp/Tactic.h"
 
 namespace rtt::ai::stp {
 
 class TestTactic : public Tactic {
-   public:
-    TestTactic();
+ public:
+  /**
+   * Constructor for the tactic, it constructs the state machine of skills
+   */
+  TestTactic();
 
-   private:
-    /**
-     * On initialization of this tactic, initialize the state machine with skills
-     */
-    void onInitialize() noexcept override;
+ private:
+  /**
+   * Calculate the info for skills from the StpInfo struct parameter
+   * @param info info is the StpInfo passed by the role
+   * @return std::optional<SkillInfo> based on the StpInfo parameter
+   */
+  std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
 
-    /**
-     * On update of this tactic
-     */
-    void onUpdate(Status const &status) noexcept override;
+  /**
+   * Is this tactic failing during execution (go back to the previous tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+   * This tactic can never fail, so always returns false
+   */
+  bool isTacticFailing(const StpInfo &info) noexcept override;
 
-    /**
-     * On terminate of this tactic, call terminate on all underlying skills
-     */
-    void onTerminate() noexcept override;
+  /**
+   * Should this tactic be reset (go back to the first skill of this tactic)
+   * @param info StpInfo can be used to check some data
+   * @return true if tactic  should reset, false if execution should continue
+   * This tactic never resets, always false
+   */
+  bool shouldTacticReset(const StpInfo &info) noexcept override;
 
-    /**
-     * Calculate the SkillInfo from the TacticInfo
-     * @param info info is the TacticInfo passed by the role
-     * @return std::optional<SkillInfo> based on the TacticInfo
-     */
-    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+  /**
+   * Is this tactic an end tactic?
+   * @return This will always return false, since it is NOT an endTactic
+   */
+  bool isEndTactic() noexcept override;
 
-    bool isTacticFailing(const StpInfo &info) noexcept override;
-
-    bool shouldTacticReset(const StpInfo &info) noexcept override;
-
-    bool isEndTactic() noexcept override;
-
-    /**
-     * Gets the tactic name
-     */
-    const char *getName() override;
+  /**
+   * Gets the tactic name
+   * @return The name of this tactic
+   */
+  const char *getName() override;
 };
-
 }  // namespace rtt::ai::stp
 
 #endif  // RTT_TESTTACTIC_H

--- a/src/control/ControlUtils.cpp
+++ b/src/control/ControlUtils.cpp
@@ -101,18 +101,18 @@ Vector2 ControlUtils::projectPositionToOutsideDefenseArea(const world::Field &fi
 }
 
 /// Calculates the chip force
-double ControlUtils::determineChipForce(const double distance, stp::KickChipType desiredBallSpeedType) noexcept {
+double ControlUtils::determineChipForce(const double distance, stp::ShotType shotType) noexcept {
     // TODO: Needs further tuning
     constexpr double TARGET_FACTOR{0.5};
     constexpr double PASS_FACTOR{0.745};
 
-    if (desiredBallSpeedType == stp::MAX) return stp::control_constants::MAX_KICK_POWER;
+    if (shotType == stp::ShotType::MAX) return stp::control_constants::MAX_KICK_POWER;
 
     double limitingFactor{};
     // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
-    if (desiredBallSpeedType == stp::PASS) {
+    if (shotType == stp::ShotType::PASS) {
         limitingFactor = PASS_FACTOR;
-    } else if (desiredBallSpeedType == stp::TARGET) {
+    } else if (shotType == stp::ShotType::TARGET) {
         limitingFactor = TARGET_FACTOR;
     } else {
         RTT_ERROR("No valid ballSpeedType, kick velocity set to 0")
@@ -127,18 +127,18 @@ double ControlUtils::determineChipForce(const double distance, stp::KickChipType
 }
 
 /// Calculate the kick force
-double ControlUtils::determineKickForce(const double distance, stp::KickChipType desiredBallSpeedType) noexcept {
+double ControlUtils::determineKickForce(const double distance, stp::ShotType shotType) noexcept {
     // TODO: Needs further tuning
     constexpr double TARGET_FACTOR{0.5};
     constexpr double PASS_FACTOR{0.745};
 
-    if (desiredBallSpeedType == stp::MAX) return stp::control_constants::MAX_KICK_POWER;
+    if (shotType == stp::ShotType::MAX) return stp::control_constants::MAX_KICK_POWER;
 
     double limitingFactor{};
     // Pick the right limiting factor based on ballSpeedType and whether we use GRSIM or not
-    if (desiredBallSpeedType == stp::PASS) {
+    if (shotType == stp::ShotType::PASS) {
         limitingFactor = PASS_FACTOR;
-    } else if (desiredBallSpeedType == stp::TARGET) {
+    } else if (shotType == stp::ShotType::TARGET) {
         limitingFactor = TARGET_FACTOR;
     } else {
         RTT_ERROR("No valid ballSpeedType, kick velocity set to 0")

--- a/src/control/positionControl/pathTracking/PidTracking.cpp
+++ b/src/control/positionControl/pathTracking/PidTracking.cpp
@@ -35,22 +35,22 @@ void PidTracking::updatePIDValues(stp::PIDType pidType, int robotID) {
     std::tuple<double, double, double> newPID;
 
     switch (pidType) {
-        case stp::DEFAULT: {
+      case stp::PIDType::DEFAULT: {
             newPID = interface::Output::getNumTreePid();
             break;
         }
-        case stp::RECEIVE: {
+        case stp::PIDType::RECEIVE: {
             newPID = interface::Output::getReceivePid();
             break;
         }
-        case stp::INTERCEPT: {
+        case stp::PIDType::INTERCEPT: {
             newPID = interface::Output::getInterceptPid();
         }
-        case stp::KEEPER: {
+        case stp::PIDType::KEEPER: {
             newPID = interface::Output::getKeeperPid();
             break;
         }
-        case stp::KEEPER_INTERCEPT: {
+        case stp::PIDType::KEEPER_INTERCEPT: {
             newPID = interface::Output::getKeeperInterceptPid();
             break;
         }

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -2,141 +2,134 @@
 // Created by john on 3/9/20.
 //
 
-#include "include/roboteam_ai/stp/Play.hpp"
+#include "stp/Play.hpp"
+
 #include "interface/widgets/MainControlsWidget.h"
 
 namespace rtt::ai::stp {
 
 void Play::initialize() noexcept {
-    calculateInfoForRoles();
-    distributeRoles();
-    previousRobotNum = world->getWorld()->getRobotsNonOwning().size();
-    onInitialize();
+  calculateInfoForRoles();
+  distributeRoles();
+  previousRobotNum = world->getWorld()->getRobotsNonOwning().size();
+  onInitialize();
 }
 
 void Play::updateWorld(world_new::World* world) noexcept {
-    this->world = world;
-    this->field = world->getField().value();
+  this->world = world;
+  this->field = world->getField().value();
 }
 
 void Play::update() noexcept {
-    // clear roleStatuses so it only contains the current tick's statuses
-    roleStatuses.clear();
-    RTT_INFO("Play executing: ", getName())
+  // clear roleStatuses so it only contains the current tick's statuses
+  roleStatuses.clear();
+  RTT_INFO("Play executing: ", getName())
 
-    auto currentRobotNum{world->getWorld()->getRobotsNonOwning().size()};
+  auto currentRobotNum{world->getWorld()->getRobotsNonOwning().size()};
 
-    if (currentRobotNum != previousRobotNum) {
-        RTT_WARNING("Reassigning bots")
+  if (currentRobotNum != previousRobotNum) {
+    RTT_INFO("Reassigning bots")
 
-        // Make sure we don't re assign with too many robots
-        if (world->getWorld()->getUs().size() > stp::control_constants::MAX_ROBOT_COUNT) {
-            RTT_ERROR("More robots than ROBOT_COUNT(), aborting update on Play")
-            // Make sure the stpInfos is cleared to trigger a reassign whenever
-            // the robots don't exceed ROBOT_COUNT anymore
-            stpInfos = std::unordered_map<std::string, StpInfo>{};
-            return;
-        }
-        calculateInfoForRoles();
-        distributeRoles();
-        previousRobotNum = currentRobotNum;
+    // Make sure we don't re assign with too many robots
+    if (world->getWorld()->getUs().size() > stp::control_constants::MAX_ROBOT_COUNT) {
+      RTT_ERROR("More robots than ROBOT_COUNT(), aborting update on Play")
+      // Make sure the stpInfos is cleared to trigger a reassign whenever
+      // the robots don't exceed ROBOT_COUNT anymore
+      stpInfos = std::unordered_map<std::string, StpInfo>{};
+      return;
     }
-
-    // Refresh the RobotViews, BallViews and fields
-    refreshData();
-
-    // derived class method call
     calculateInfoForRoles();
+    distributeRoles();
+    previousRobotNum = currentRobotNum;
+  }
 
-    for (auto& role : roles) {
-        // Update the roles
-        if (stpInfos.find(role->getName()) != stpInfos.end()) {
-            auto roleStatus = role->update(stpInfos[role->getName()]);
-            roleStatuses[role.get()] = roleStatus;
+  // Refresh the RobotViews, BallViews and fields
+  refreshData();
 
-            if (roleStatus == Status::Waiting) {
-                // Should role skip end tactic?
-                if (shouldRoleSkipEndTactic()) {
-                    // TODO: force role to go to next tactic
-                    // role.forceNextTactic(); (not implemented yet)
-                }
-            }
-        } else {
-            RTT_DEBUG("Trying to update role [", role->getName(), "] which is not in STPInfos!")
+  // derived class method call
+  calculateInfoForRoles();
+
+  // Loop through roles and update them if they exist in stpInfos
+  for (auto& role : roles) {
+    if (stpInfos.find(role->getName()) != stpInfos.end()) {
+      // Update and store the returned status
+      auto roleStatus = role->update(stpInfos[role->getName()]);
+      roleStatuses[role.get()] = roleStatus;
+
+      if (roleStatus == Status::Waiting) {
+        // Should role skip end tactic?
+        if (shouldRoleSkipEndTactic()) {
+          role->forceNextTactic();
         }
+      }
+    } else {
+      RTT_DEBUG("Trying to update role [", role->getName(), "] which is not in STPInfos!")
     }
-}
-
-bool Play::arePlayRolesFinished() {
-    return !roleStatuses.empty() && std::all_of(roleStatuses.begin(), roleStatuses.end(), [](auto& s) { return s.second == Status::Success; });
+  }
 }
 
 void Play::refreshData() noexcept {
-    // Get a new BallView and field from world
-    auto newBallView = world->getWorld()->getBall();
-    auto newField = world->getField();
+  // Get a new BallView and field from world
+  auto newBallView = world->getWorld()->getBall();
 
-    for (auto& role : roles) {
-        auto stpInfo = stpInfos.find(role->getName());
-        if (stpInfo != stpInfos.end() && stpInfo->second.getRobot().has_value()) {
-            // Get a new RobotView from world using the old robot id
-            stpInfo->second.setRobot(world->getWorld()->getRobotForId(stpInfo->second.getRobot()->get()->getId()));
+  // Loop through all roles, if an stpInfo exists and has an assigned robot, refresh the data
+  for (auto& role : roles) {
+    auto stpInfo = stpInfos.find(role->getName());
+    if (stpInfo != stpInfos.end() && stpInfo->second.getRobot().has_value()) {
+      // Get a new RobotView from world using the old robot id
+      stpInfo->second.setRobot(world->getWorld()->getRobotForId(stpInfo->second.getRobot()->get()->getId()));
 
-            // Assign the new BallView and field
-            stpInfo->second.setBall(newBallView);
-            stpInfo->second.setField(newField);
+      // Assign the new BallView and field
+      stpInfo->second.setBall(newBallView);
+      stpInfo->second.setField(field);
 
-            if (stpInfo->second.getEnemyRobot().has_value()) {
-                stpInfo->second.setEnemyRobot(world->getWorld()->getRobotForId(stpInfo->second.getEnemyRobot()->get()->getId(), false));
-            }
-        }
+      if (stpInfo->second.getEnemyRobot().has_value()) {
+        stpInfo->second.setEnemyRobot(world->getWorld()->getRobotForId(stpInfo->second.getEnemyRobot()->get()->getId(), false));
+      }
     }
+  }
 }
 
 void Play::distributeRoles() noexcept {
-    Dealer dealer{world->getWorld().value(), &field};
+  Dealer dealer{world->getWorld().value(), &field};
 
-    auto flagMap = decideRoleFlags();
+  auto flagMap = decideRoleFlags();
 
-    auto distribution = dealer.distribute(world->getWorld()->getUs(), flagMap, stpInfos);
+  auto distribution = dealer.distribute(world->getWorld()->getUs(), flagMap, stpInfos);
 
-    stpInfos = std::unordered_map<std::string, StpInfo>{};
-    for (auto& role : roles) {
-        role->reset();
-        auto roleName{role->getName()};
-        if (distribution.find(roleName) != distribution.end()) {
-            auto robot = distribution.find(role->getName())->second;
+  // Clear the stpInfos for the new role assignment
+  stpInfos = std::unordered_map<std::string, StpInfo>{};
+  for (auto& role : roles) {
+    role->reset();
+    auto roleName{role->getName()};
+    if (distribution.find(roleName) != distribution.end()) {
+      auto robot = distribution.find(role->getName())->second;
 
-            stpInfos.emplace(roleName, StpInfo{});
-            stpInfos[roleName].setRobot(robot);
-        }
+      stpInfos.emplace(roleName, StpInfo{});
+      stpInfos[roleName].setRobot(robot);
     }
+  }
 
-    std::for_each(stpInfos.begin(), stpInfos.end(), [this](auto& each) { each.second.setCurrentWorld(world); });
+  std::for_each(stpInfos.begin(), stpInfos.end(), [this](auto& each) { each.second.setCurrentWorld(world); });
 }
 
-std::unordered_map<Role*, Status> const&Play::getRoleStatuses() const {
-    return roleStatuses;
+std::unordered_map<Role*, Status> const& Play::getRoleStatuses() const { return roleStatuses; }
+
+bool Play::isValidPlayToKeep(world_new::World* world) noexcept {
+  if (!interface::MainControlsWidget::ignoreInvariants) {
+    world::Field field = world->getField().value();
+    return std::all_of(keepPlayInvariants.begin(), keepPlayInvariants.end(), [world, field](auto& x) { return x->checkInvariant(world->getWorld().value(), &field); });
+  } else {
+    return true;
+  }
 }
 
-bool Play::isValidPlayToKeep(world_new::World *world) noexcept {
-    if (!interface::MainControlsWidget::ignoreInvariants) {
-        world::Field field = world->getField().value();
-        return std::all_of(keepPlayInvariants.begin(), keepPlayInvariants.end(),
-                           [world, field](auto &x) { return x->checkInvariant(world->getWorld().value(), &field); });
-    } else {
-        return true;
-    }
+bool Play::isValidPlayToStart(world_new::World* world) const noexcept {
+  if (!interface::MainControlsWidget::ignoreInvariants) {
+    world::Field field = world->getField().value();
+    return std::all_of(startPlayInvariants.begin(), startPlayInvariants.end(), [world, field](auto& x) { return x->checkInvariant(world->getWorld().value(), &field); });
+  } else {
+    return true;
+  }
 }
-
-bool Play::isValidPlayToStart(world_new::World *world) const noexcept {
-    if (!interface::MainControlsWidget::ignoreInvariants) {
-        world::Field field = world->getField().value();
-        return std::all_of(startPlayInvariants.begin(), startPlayInvariants.end(),
-                           [world, field](auto &x) { return x->checkInvariant(world->getWorld().value(), &field); });
-    } else {
-        return true;
-    }
-}
-
 }  // namespace rtt::ai::stp

--- a/src/stp/PlayChecker.cpp
+++ b/src/stp/PlayChecker.cpp
@@ -2,19 +2,20 @@
 // Created by john on 3/9/20.
 //
 
-#include "include/roboteam_ai/stp/PlayChecker.hpp"
+#include "stp/PlayChecker.hpp"
 
 namespace rtt::ai::stp {
 std::vector<Play*> PlayChecker::getValidPlays() noexcept {
-    std::vector<Play*> validPlays;
+  std::vector<Play*> validPlays;
 
-    for (auto& each : *allPlays) {
-        if (each->isValidPlayToStart(world)) {
-            validPlays.push_back(each.get());
-        }
+  // Only add plays that are valid
+  for (auto& each : *allPlays) {
+    if (each->isValidPlayToStart(world)) {
+      validPlays.push_back(each.get());
     }
+  }
 
-    return validPlays;
+  return validPlays;
 }
 
 void PlayChecker::update(world_new::World* world) noexcept { this->world = world; }
@@ -22,10 +23,11 @@ void PlayChecker::update(world_new::World* world) noexcept { this->world = world
 void PlayChecker::setPlays(std::vector<std::unique_ptr<Play>>& plays) noexcept { this->allPlays = &plays; }
 
 Play* PlayChecker::getPlayForName(const std::string& playName) const noexcept {
-    auto found = std::find_if(allPlays->begin(), allPlays->end(), [&](auto& play) { return play->getName() == playName; });
-    if (found == allPlays->end()) {
-        return nullptr;
-    } else
-        return found->get();
+  // Find play for playName param
+  auto found = std::find_if(allPlays->begin(), allPlays->end(), [&](auto& play) { return play->getName() == playName; });
+  if (found == allPlays->end()) {
+    return nullptr;
+  } else
+    return found->get();
 }
 }  // namespace rtt::ai::stp

--- a/src/stp/PlayDecider.cpp
+++ b/src/stp/PlayDecider.cpp
@@ -2,19 +2,15 @@
 // Created by john on 3/9/20.
 //
 
-#include "include/roboteam_ai/stp/PlayDecider.hpp"
+#include "stp/PlayDecider.hpp"
 
 namespace rtt::ai::stp {
-    Play *PlayDecider::decideBestPlay(world_new::World *pWorld, std::vector<Play *> plays) noexcept {
-        if (lockedPlay) {
-            return lockedPlay;
-        }
-        return *std::max_element(plays.begin(), plays.end(), [&](auto &largest, auto &play) {
-            return largest->score(pWorld) < play->score(pWorld);
-        });
-    }
+Play *PlayDecider::decideBestPlay(world_new::World *pWorld, std::vector<Play *> plays) noexcept {
+  if (lockedPlay) {
+    return lockedPlay;
+  }
+  return *std::max_element(plays.begin(), plays.end(), [&](auto &largest, auto &play) { return largest->score(pWorld) < play->score(pWorld); });
+}
 
-    void PlayDecider::lockPlay(Play *play) {
-        lockedPlay = play;
-    }
+void PlayDecider::lockPlay(Play *play) { lockedPlay = play; }
 }  // namespace rtt::ai::stp

--- a/src/stp/Role.cpp
+++ b/src/stp/Role.cpp
@@ -2,73 +2,69 @@
 // Created by john on 3/9/20.
 //
 
-#include "include/roboteam_ai/stp/Role.hpp"
+#include "stp/Role.hpp"
+
+#include <roboteam_utils/Print.h>
 
 namespace rtt::ai::stp {
 Status Role::update(StpInfo const& info) noexcept {
-    // Failure if the required data is not present
-    if (!info.getBall() || !info.getRobot() || !info.getField()) {
-        RTT_WARNING("Required information missing in the tactic info")
-        return Status::Failure;
+  // Failure if the required data is not present
+  if (!info.getBall() || !info.getRobot() || !info.getField()) {
+    RTT_WARNING("Required information missing in the tactic info")
+    return Status::Failure;
+  }
+
+  currentRobot = info.getRobot();
+  // Update the current tactic with the new tacticInfo
+  auto status = robotTactics.update(info);
+
+  // Success if the tactic returned success and if all tactics are done
+  if (status == Status::Success && robotTactics.finished()) {
+    RTT_INFO("ROLE SUCCESSFUL for ", info.getRobot()->get()->getId())
+    return Status::Success;
+  }
+
+  // Reset the tactic state machine if a tactic failed and the state machine is not yet finished
+  if (status == Status::Failure && !robotTactics.finished()) {
+    RTT_INFO("State Machine reset for current role for ID = ", info.getRobot()->get()->getId())
+    // Reset all the Skills state machines
+    for (auto& tactic : robotTactics) {
+      tactic->reset();
     }
+    // Reset Tactics state machine
+    robotTactics.reset();
+  }
 
-    currentRobot = info.getRobot();
-    // Update the current tactic with the new tacticInfo
-    auto status = robotTactics.update(info);
-
-    // Success if the tactic returned success and if all tactics are done
-    if (status == Status::Success && robotTactics.finished()) {
-        RTT_INFO("ROLE SUCCESSFUL for ", info.getRobot()->get()->getId())
-        return Status::Success;
+  // Success if waiting and tactics are finished
+  // Waiting if waiting but not finished
+  if (status == Status::Waiting) {
+    if (robotTactics.finished()) {
+      return Status::Success;
     }
+    return Status::Waiting;
+  }
 
-    // Reset the tactic state machine if a tactic failed and the state machine is not yet finished
-    if (status == Status::Failure && !robotTactics.finished()) {
-        RTT_INFO("State Machine reset for current role for ID = ", info.getRobot()->get()->getId())
-        // Reset all the Skills state machines
-        for (auto& tactic : robotTactics) {
-            tactic->reset();
-        }
-        // Reset Tactics state machine
-        robotTactics.reset();
-    }
-
-    // Success if waiting and tactics are finished
-    // Waiting if waiting but not finished
-    if (status == Status::Waiting) {
-        if (robotTactics.finished()) {
-            return Status::Success;
-        }
-        return Status::Waiting;
-    }
-
-    // Return running by default
-    return Status::Running;
+  // Return running by default
+  return Status::Running;
 }
 
 bool Role::finished() const noexcept { return robotTactics.finished(); }
 
-void Role::forceNextTactic() noexcept {
-    robotTactics.skip_n(1);
-}
+void Role::forceNextTactic() noexcept { robotTactics.skip_n(1); }
 
-std::optional<world_new::view::RobotView> const&Role::getCurrentRobot() const {
-    return currentRobot;
-}
+std::optional<world_new::view::RobotView> const& Role::getCurrentRobot() const { return currentRobot; }
 
-Tactic * Role::getCurrentTactic() {
-    return robotTactics.get_current();
-}
+Tactic* Role::getCurrentTactic() { return robotTactics.get_current(); }
 
 void Role::reset() noexcept {
-    currentRobot.reset();
+  currentRobot.reset();
 
-    // Reset all tactics
-    for (auto& tactic : robotTactics) {
-        tactic->reset();
-    }
-    // Reset Tactics state machine
-    robotTactics.reset();
+  // Reset all tactics
+  for (auto& tactic : robotTactics) {
+    tactic->reset();
+  }
+  // Reset Tactics state machine
+  robotTactics.reset();
 }
 
 }  // namespace rtt::ai::stp

--- a/src/stp/Skill.cpp
+++ b/src/stp/Skill.cpp
@@ -2,7 +2,7 @@
 // Created by john on 3/2/20.
 //
 
-#include "include/roboteam_ai/stp/Skill.h"
+#include "stp/Skill.h"
 
 #include <roboteam_utils/Print.h>
 
@@ -14,102 +14,95 @@
 namespace rtt::ai::stp {
 
 void Skill::rotateRobotCommand() noexcept {
-    command.mutable_vel()->set_x(-command.vel().x());
-    command.mutable_vel()->set_y(-command.vel().y());
-    command.set_w(static_cast<float>(Angle(command.w() + M_PI)));
+  command.mutable_vel()->set_x(-command.vel().x());
+  command.mutable_vel()->set_y(-command.vel().y());
+  command.set_w(static_cast<float>(Angle(command.w() + M_PI)));
 }
 
 void Skill::publishRobotCommand(world_new::World const* data) noexcept {
-    limitRobotCommand();
+  limitRobotCommand();
 
-    if (!SETTINGS.isLeft()) {
-        rotateRobotCommand();
+  if (!SETTINGS.isLeft()) {
+    rotateRobotCommand();
+  }
+
+  if (std::isnan(command.vel().x()) || std::isnan(command.vel().y())) {
+    RTT_ERROR("x or y vel in command is NaN in skill" + std::string{getName()} + "!\nRobot: " + std::to_string(robot.value()->getId()))
+  }
+
+  if (command.id() == -1) {
+    if (robot && robot.value()->getId() != -1) {
+      command.set_id(robot.value()->getId());
+      io::io.publishRobotCommand(command, data);
     }
+  } else {
+    io::io.publishRobotCommand(command, data);
+  }
 
-    if (std::isnan(command.vel().x()) || std::isnan(command.vel().y())) {
-        RTT_ERROR("x or y vel in command is NaN in skill" + std::string{getName()} + "!\nRobot: " + std::to_string(robot.value()->getId()))
-    }
-
-    if (command.id() == -1) {
-        if (robot && robot.value()->getId() != -1) {
-            command.set_id(robot.value()->getId());
-            io::io.publishRobotCommand(command, data);  // We default to our robots being on the left if parameter is not set
-        }
-    } else {
-        io::io.publishRobotCommand(command, data);  // We default to our robots being on the left if parameter is not set
-    }
-
-    // refresh the robot command after it has been sent
-    refreshRobotCommand();
+  // refresh the robot command after it has been sent
+  refreshRobotCommand();
 }
 
 void Skill::refreshRobotCommand() noexcept {
-    proto::RobotCommand emptyCmd;
-    emptyCmd.set_use_angle(true);
-    emptyCmd.set_id(robot ? robot.value()->getId() : -1);
-    emptyCmd.set_geneva_state(0);
-    command = emptyCmd;
+  proto::RobotCommand emptyCmd;
+  emptyCmd.set_use_angle(true);
+  emptyCmd.set_id(robot ? robot.value()->getId() : -1);
+  emptyCmd.set_geneva_state(0);
+  command = emptyCmd;
 }
 
 void Skill::limitRobotCommand() noexcept {
-    limitVel();
-    limitAngularVel();
+  limitVel();
+  limitAngularVel();
 }
 
 void Skill::limitVel() noexcept {
-    auto limitedVel = Vector2(command.vel().x(), command.vel().y());
+  auto limitedVel = Vector2(command.vel().x(), command.vel().y());
 
-    limitedVel = control::ControlUtils::velocityLimiter(limitedVel);
+  limitedVel = control::ControlUtils::velocityLimiter(limitedVel);
 
-    if (std::isnan(limitedVel.x) || std::isnan(limitedVel.y)) {
-        RTT_ERROR("Robot will have NAN: " + std::string{getName()} + "!\nrobot: " + std::to_string(robot.value()->getId()))
-    }
+  if (std::isnan(limitedVel.x) || std::isnan(limitedVel.y)) {
+    RTT_ERROR("Robot will have NAN: " + std::string{getName()} + "!\nrobot: " + std::to_string(robot.value()->getId()))
+  }
 
-    /* Limit the velocity when the robot has the ball
-     * TODO: Test if it is necessary to limit the velocity when the robot has the ball
-     * Might not be necessary because the robot is only allowed to move a small distance with the ball
-     */
-    double maxVel = 3.0; // Maximum velocity of the robot with ball TODO: TUNE
+  // Limit robot velocity when the robot has the ball
+  if (robot->hasBall() && limitedVel.length() > control_constants::MAX_VEL_WHEN_HAS_BALL) {
+    // Clamp velocity
+    limitedVel = control::ControlUtils::velocityLimiter(limitedVel, control_constants::MAX_VEL_WHEN_HAS_BALL, 0.0, false);
+  }
 
-    if (robot->hasBall() && limitedVel.length() > maxVel) {
-        // Clamp velocity
-        limitedVel = control::ControlUtils::velocityLimiter(limitedVel, maxVel, 0.0, false);
-    }
-
-    command.mutable_vel()->set_x(limitedVel.x);
-    command.mutable_vel()->set_y(limitedVel.y);
+  command.mutable_vel()->set_x(limitedVel.x);
+  command.mutable_vel()->set_y(limitedVel.y);
 }
 
 void Skill::limitAngularVel() noexcept {
-    // Limit the angular velocity when the robot has the ball by setting the target angle in small steps
-    // TODO: Might want to limit on the robot itself
-    if (robot->hasBall() && command.use_angle()) {
-        auto targetAngle = command.w();
-        auto robotAngle = robot.value()->getAngle();
+  // Limit the angular velocity when the robot has the ball by setting the target angle in small steps
+  // TODO: Might want to limit on the robot itself
+  if (robot->hasBall() && command.use_angle()) {
+    auto targetAngle = command.w();
+    auto robotAngle = robot.value()->getAngle();
 
-        // If the angle error is larger than the desired angle rate, the angle command is adjusted
-        if (robotAngle.shortestAngleDiff(targetAngle) > control_constants::ANGLE_RATE) {
-            // Direction of rotation is the shortest distance
-            int direction = Angle(robotAngle).rotateDirection(targetAngle) ? 1 : -1;
-            // Set the angle command to the current robot angle + the angle rate
-            command.set_w(robotAngle + Angle(direction * control_constants::ANGLE_RATE));
-        }
+    // If the angle error is larger than the desired angle rate, the angle command is adjusted
+    if (robotAngle.shortestAngleDiff(targetAngle) > control_constants::ANGLE_RATE) {
+      // Direction of rotation is the shortest distance
+      int direction = Angle(robotAngle).rotateDirection(targetAngle) ? 1 : -1;
+      // Set the angle command to the current robot angle + the angle rate
+      command.set_w(robotAngle + Angle(direction * control_constants::ANGLE_RATE));
     }
+  }
 }
 
 void Skill::terminate() noexcept { onTerminate(); }
 
 Status Skill::update(StpInfo const& info) noexcept {
-    robot = info.getRobot();
-    auto result = onUpdate(info);
-    currentStatus = result;
-    return result;
+  robot = info.getRobot();
+  auto result = onUpdate(info);
+  currentStatus = result;
+  return result;
 }
 
 void Skill::initialize() noexcept { onInitialize(); }
 
-[[nodiscard]] Status Skill::getStatus() const {
-    return currentStatus;
-}
+[[nodiscard]] Status Skill::getStatus() const { return currentStatus; }
 
 }  // namespace rtt::ai::stp

--- a/src/stp/Skill.cpp
+++ b/src/stp/Skill.cpp
@@ -92,7 +92,7 @@ void Skill::limitAngularVel() noexcept {
   }
 }
 
-void Skill::terminate() noexcept { onTerminate(); }
+void Skill::terminate() noexcept { }
 
 Status Skill::update(StpInfo const& info) noexcept {
   robot = info.getRobot();
@@ -101,7 +101,7 @@ Status Skill::update(StpInfo const& info) noexcept {
   return result;
 }
 
-void Skill::initialize() noexcept { onInitialize(); }
+void Skill::initialize() noexcept { }
 
 [[nodiscard]] Status Skill::getStatus() const { return currentStatus; }
 

--- a/src/stp/Tactic.cpp
+++ b/src/stp/Tactic.cpp
@@ -8,7 +8,11 @@
 
 namespace rtt::ai::stp {
 
-void Tactic::initialize() noexcept { onInitialize(); }
+void Tactic::initialize() noexcept {
+  for (auto &x : skills) {
+    x->initialize();
+  }
+}
 
 Status Tactic::update(StpInfo const &info) noexcept {
   if (!info.getBall() || !info.getRobot() || !info.getField()) {
@@ -24,8 +28,7 @@ Status Tactic::update(StpInfo const &info) noexcept {
     // Update the current skill with the new SkillInfo
     auto status = skills.update(skill_info.value());
 
-    // Call onUpdate on a skill for specific behaviour
-    onUpdate(status);
+    (void)status;
   } else {
     RTT_ERROR("Not all data was present, bad update!")
   }
@@ -57,7 +60,11 @@ Status Tactic::update(StpInfo const &info) noexcept {
   return Status::Running;
 }
 
-void Tactic::terminate() noexcept { onTerminate(); }
+void Tactic::terminate() noexcept {
+  for (auto &x : skills) {
+    x->terminate();
+  }
+}
 
 void Tactic::reset() noexcept { skills.reset(); }
 

--- a/src/stp/Tactic.cpp
+++ b/src/stp/Tactic.cpp
@@ -4,55 +4,57 @@
 
 #include "stp/Tactic.h"
 
+#include <roboteam_utils/Print.h>
+
 namespace rtt::ai::stp {
 
 void Tactic::initialize() noexcept { onInitialize(); }
 
 Status Tactic::update(StpInfo const &info) noexcept {
-    if (!info.getBall() || !info.getRobot() || !info.getField()) {
-        RTT_WARNING("Required information missing in the tactic info")
-        currentStatus = Status::Failure;
-        return Status::Failure;
+  if (!info.getBall() || !info.getRobot() || !info.getField()) {
+    RTT_WARNING("Required information missing in the tactic info")
+    currentStatus = Status::Failure;
+    return Status::Failure;
+  }
+
+  // Update skill info
+  auto skill_info = calculateInfoForSkill(info);
+
+  if (skill_info) {
+    // Update the current skill with the new SkillInfo
+    auto status = skills.update(skill_info.value());
+
+    // Call onUpdate on a skill for specific behaviour
+    onUpdate(status);
+  } else {
+    RTT_ERROR("Not all data was present, bad update!")
+  }
+
+  // the tactic will not be reset if it's the first skill
+  if (skills.current_num() != 0 && shouldTacticReset(skill_info.value())) {
+    reset();
+  }
+
+  // Check if the skills are all finished
+  if (skills.finished() || forceTacticSuccess(skill_info.value())) {
+    if (!isEndTactic()) {
+      currentStatus = Status::Success;
+      return Status::Success;
     }
+    // Make sure we keep executing the last tactic since it is an end tactic
+    skills.reset();
+    currentStatus = Status::Waiting;
+    return Status::Waiting;
+  }
 
-    // Update skill info
-    auto skill_info = calculateInfoForSkill(info);
+  // if the failing condition is true, the current tactic will fail
+  if (skill_info && isTacticFailing(skill_info.value())) {
+    currentStatus = Status::Failure;
+    return Status::Failure;
+  }
 
-    if (skill_info) {
-        // Update the current skill with the new SkillInfo
-        auto status = skills.update(skill_info.value());
-
-        // Call onUpdate on a skill for specific behaviour
-        onUpdate(status);
-    } else {
-        RTT_ERROR("Not all data was present, bad update!")
-    }
-
-    // the tactic will not be reset if it's the first skill
-    if (skills.current_num() != 0 && shouldTacticReset(skill_info.value())) {
-        reset();
-    }
-
-    // Check if the skills are all finished
-    if (skills.finished() || forceTacticSuccess(skill_info.value())) {
-        if (!isEndTactic()) {
-            currentStatus = Status::Success;
-            return Status::Success;
-        }
-        // Make sure we keep executing the last tactic since it is an end tactic
-        skills.reset();
-        currentStatus = Status::Waiting;
-        return Status::Waiting;
-    }
-
-    // if the failing condition is true, the current tactic will fail
-    if (skill_info && isTacticFailing(skill_info.value())) {
-        currentStatus = Status::Failure;
-        return Status::Failure;
-    }
-
-    currentStatus = Status::Running;
-    return Status::Running;
+  currentStatus = Status::Running;
+  return Status::Running;
 }
 
 void Tactic::terminate() noexcept { onTerminate(); }

--- a/src/stp/Tactic.cpp
+++ b/src/stp/Tactic.cpp
@@ -28,7 +28,7 @@ Status Tactic::update(StpInfo const &info) noexcept {
     // Update the current skill with the new SkillInfo
     auto status = skills.update(skill_info.value());
 
-    (void)status;
+    (void)status; // return of update is never used, but it is marked [[no-discard]] in the state machine. This cast to void uses up the return to suppress the compile warning.
   } else {
     RTT_ERROR("Not all data was present, bad update!")
   }

--- a/src/stp/new_constants/ControlConstants.cpp
+++ b/src/stp/new_constants/ControlConstants.cpp
@@ -48,7 +48,9 @@ constexpr double MAX_VEL_WHEN_HAS_BALL = 3.0;
 // Angle margin robot to ball. Within this margin, the robot has the ball
 constexpr double HAS_BALL_ANGLE_ERROR_MARGIN = 0.10;
 // Distance margin robot to ball. Within this margin, the robot has the ball
-constexpr double HAS_BALL_DISTANCE_ERROR_MARGIN = 0.10;
+/// WHEN IN GRSIM, CHANGE HAS_BALL_DISTANCE_ERROR_MARGIN TO 0.12
+/// WHEN IRL, CHANGE HAS_BALL_DISTANCE_ERROR_MARGIN TO 0.10
+constexpr double HAS_BALL_DISTANCE_ERROR_MARGIN = 0.12;
 
 /// GTP Constants
 // Distance margin for 'goToPos'. If the robot is within this margin, goToPos is successful

--- a/src/stp/new_constants/ControlConstants.cpp
+++ b/src/stp/new_constants/ControlConstants.cpp
@@ -42,6 +42,7 @@ constexpr double MAX_VEL_CMD = 1.891;
 constexpr double MAX_DRIBBLER_CMD = 31;
 // Angle increment per tick
 constexpr double ANGLE_RATE = 0.1 * M_PI;
+constexpr double MAX_VEL_WHEN_HAS_BALL = 3.0;
 
 /// HasBall margins
 // Angle margin robot to ball. Within this margin, the robot has the ball

--- a/src/stp/new_plays/Attack.cpp
+++ b/src/stp/new_plays/Attack.cpp
@@ -75,12 +75,10 @@ void Attack::calculateInfoForRoles() noexcept {
     // Attacker
     auto goalTarget = calculateGoalTarget();
     stpInfos["attacker"].setPositionToShootAt(goalTarget);
-    stpInfos["attacker"].setKickChipType(MAX);
+    stpInfos["attacker"].setShotType(ShotType::MAX);
 
     // Offenders
-
     stpInfos["offender_1"].setPositionToMoveTo(Vector2(field.getFieldLength() / 4, field.getFieldWidth() / 4));
-
     stpInfos["offender_2"].setPositionToMoveTo(Vector2(field.getFieldLength() / 4, -field.getFieldWidth() / 4));
 
     // Midfielders

--- a/src/stp/new_plays/AttackingPass.cpp
+++ b/src/stp/new_plays/AttackingPass.cpp
@@ -136,13 +136,13 @@ void AttackingPass::calculateInfoForRoles() noexcept {
             }
             return passLine.contains(bot->getPos());
         })) {
-        stpInfos["passer"].setShootType(CHIP);
+        stpInfos["passer"].setKickOrChip(KickOrChip::CHIP);
     } else {
-        stpInfos["passer"].setShootType(KICK);
+        stpInfos["passer"].setKickOrChip(KickOrChip::KICK);
     }
     // Passer
     stpInfos["passer"].setPositionToShootAt(passingPosition);
-    stpInfos["passer"].setKickChipType(TARGET);
+    stpInfos["passer"].setShotType(ShotType::TARGET);
 
     // Defenders
     for (int defenderIndex = 0; defenderIndex < numberOfDefenders; defenderIndex++) {

--- a/src/stp/new_plays/DefendPass.cpp
+++ b/src/stp/new_plays/DefendPass.cpp
@@ -72,11 +72,11 @@ void DefendPass::calculateInfoForDefenders() noexcept {
 
     stpInfos["defender_1"].setPositionToDefend(field.getOurTopGoalSide());
     stpInfos["defender_1"].setEnemyRobot(enemyClosestToBall);
-    stpInfos["defender_1"].setBlockDistance(HALFWAY);
+    stpInfos["defender_1"].setBlockDistance(BlockDistance::HALFWAY);
 
     stpInfos["defender_2"].setPositionToDefend(field.getOurBottomGoalSide());
     stpInfos["defender_2"].setEnemyRobot(enemyClosestToBall);
-    stpInfos["defender_2"].setBlockDistance(HALFWAY);
+    stpInfos["defender_2"].setBlockDistance(BlockDistance::HALFWAY);
 
     // When the ball moves, one defender tries to intercept the ball
     auto closestBotUs = world->getWorld()->getRobotClosestToBall(world_new::us);
@@ -127,12 +127,12 @@ void DefendPass::calculateInfoForBlockers() noexcept {
                 }
 
                 stpInfos[roleName].setEnemyRobot(enemyPasser);
-                stpInfos[roleName].setBlockDistance(FAR);
+                stpInfos[roleName].setBlockDistance(BlockDistance::FAR);
             } else {
                 // TODO: Improve default behaviour when there are no enemy robots to block
                 stpInfos[roleName].setPositionToDefend(field.getOurGoalCenter());
                 stpInfos[roleName].setEnemyRobot(world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), world_new::them));
-                stpInfos[roleName].setBlockDistance(HALFWAY);
+                stpInfos[roleName].setBlockDistance(BlockDistance::HALFWAY);
             }
         }
     }

--- a/src/stp/new_plays/DefendShot.cpp
+++ b/src/stp/new_plays/DefendShot.cpp
@@ -88,29 +88,29 @@ void DefendShot::calculateInfoForDefenders() noexcept {
 
     stpInfos["defender_1"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["defender_1"].setEnemyRobot(enemyAttacker);
-    stpInfos["defender_1"].setBlockDistance(HALFWAY);
+    stpInfos["defender_1"].setBlockDistance(BlockDistance::HALFWAY);
 
     stpInfos["defender_2"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["defender_2"].setEnemyRobot(enemyClosestToGoal);
-    stpInfos["defender_2"].setBlockDistance(HALFWAY);
+    stpInfos["defender_2"].setBlockDistance(BlockDistance::HALFWAY);
 
     if (enemyClosestToGoal)
         stpInfos["defender_3"].setPositionToDefend(enemyClosestToGoal.value()->getPos());
     else
         stpInfos["defender_3"].setPositionToDefend(std::nullopt);
     stpInfos["defender_3"].setEnemyRobot(enemyAttacker);
-    stpInfos["defender_3"].setBlockDistance(HALFWAY);
+    stpInfos["defender_3"].setBlockDistance(BlockDistance::HALFWAY);
 
     stpInfos["defender_4"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["defender_4"].setEnemyRobot(secondEnemyClosestToGoal);
-    stpInfos["defender_4"].setBlockDistance(HALFWAY);
+    stpInfos["defender_4"].setBlockDistance(BlockDistance::HALFWAY);
 
     if (enemyClosestToGoal)
         stpInfos["defender_5"].setPositionToDefend(secondEnemyClosestToGoal.value()->getPos());
     else
         stpInfos["defender_5"].setPositionToDefend(std::nullopt);
     stpInfos["defender_5"].setEnemyRobot(enemyAttacker);
-    stpInfos["defender_5"].setBlockDistance(HALFWAY);
+    stpInfos["defender_5"].setBlockDistance(BlockDistance::HALFWAY);
 
     // When the ball moves, one defender tries to intercept the ball
     auto closestBotUs = world->getWorld()->getRobotClosestToBall(world_new::us);

--- a/src/stp/new_plays/FreeKickThem.cpp
+++ b/src/stp/new_plays/FreeKickThem.cpp
@@ -74,12 +74,12 @@ void FreeKickThem::calculateInfoForBlockers() noexcept {
                 else
                     stpInfos[roleName].setPositionToDefend(std::nullopt);
                 stpInfos[roleName].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world_new::them));
-                stpInfos[roleName].setBlockDistance(FAR);
+                stpInfos[roleName].setBlockDistance(BlockDistance::FAR);
             } else {
                 // TODO: Improve default behaviour when there are no enemy robots to block
                 stpInfos[roleName].setPositionToDefend(field.getOurGoalCenter());
                 stpInfos[roleName].setEnemyRobot(world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), world_new::them));
-                stpInfos[roleName].setBlockDistance(HALFWAY);
+                stpInfos[roleName].setBlockDistance(BlockDistance::HALFWAY);
             }
         }
     }
@@ -88,15 +88,15 @@ void FreeKickThem::calculateInfoForBlockers() noexcept {
 void FreeKickThem::calculateInfoForDefenders() noexcept {
     stpInfos["defender_0"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["defender_0"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world_new::them));
-    stpInfos["defender_0"].setBlockDistance(HALFWAY);
+    stpInfos["defender_0"].setBlockDistance(BlockDistance::HALFWAY);
 
     stpInfos["defender_1"].setPositionToDefend(field.getOurTopGoalSide());
     stpInfos["defender_1"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world_new::them));
-    stpInfos["defender_1"].setBlockDistance(HALFWAY);
+    stpInfos["defender_1"].setBlockDistance(BlockDistance::HALFWAY);
 
     stpInfos["defender_2"].setPositionToDefend(field.getOurBottomGoalSide());
     stpInfos["defender_2"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world_new::them));
-    stpInfos["defender_2"].setBlockDistance(HALFWAY);
+    stpInfos["defender_2"].setBlockDistance(BlockDistance::HALFWAY);
 }
 
 void FreeKickThem::calculateInfoForOffenders() noexcept { stpInfos["offender"].setPositionToMoveTo(Vector2(field.getFieldLength() / 4, 0.0)); }

--- a/src/stp/new_plays/GenericPass.cpp
+++ b/src/stp/new_plays/GenericPass.cpp
@@ -144,12 +144,12 @@ Dealer::FlagMap GenericPass::decideRoleFlags() const noexcept {
     flagMap.insert({"receiver_left", {receiverFlag}});
     flagMap.insert({"receiver_right", {not_important}});
     flagMap.insert({"midfielder_1", {not_important}});
-    flagMap.insert({"midfielder_2", {not_important}});
+    flagMap.insert({"defender_1", {not_important}});
     flagMap.insert({"halt_3", {not_important}});
     flagMap.insert({"halt_4", {not_important}});
     flagMap.insert({"halt_5", {not_important}});
     flagMap.insert({"halt_6", {not_important}});
-    flagMap.insert({"hal0_7", {not_important}});
+    flagMap.insert({"halt_7", {not_important}});
 
     return flagMap;
 }

--- a/src/stp/new_plays/GenericPass.cpp
+++ b/src/stp/new_plays/GenericPass.cpp
@@ -107,19 +107,19 @@ void GenericPass::calculateInfoForRoles() noexcept {
             }
             return passLine.contains(bot->getPos());
         })) {
-        stpInfos["passer"].setShootType(CHIP);
+        stpInfos["passer"].setKickOrChip(KickOrChip::CHIP);
     } else {
-        stpInfos["passer"].setShootType(KICK);
+        stpInfos["passer"].setKickOrChip(KickOrChip::KICK);
     }
     // Passer
     stpInfos["passer"].setPositionToShootAt(passingPosition);
-    stpInfos["passer"].setKickChipType(PASS);
+    stpInfos["passer"].setShotType(ShotType::PASS);
 
     // Defender
     auto enemyAttacker = world->getWorld()->getRobotClosestToBall(world_new::them);
     stpInfos["defender_1"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["defender_1"].setEnemyRobot(enemyAttacker);
-    stpInfos["defender_1"].setBlockDistance(HALFWAY);
+    stpInfos["defender_1"].setBlockDistance(BlockDistance::HALFWAY);
 
     // Midfielder
     if (stpInfos["midfielder_1"].getRobot()) {
@@ -192,9 +192,9 @@ std::pair<Vector2, double> GenericPass::calculatePassLocation(Grid searchGrid) n
     auto passLine = Tube(w->getBall()->get()->getPos(), bestPosition, control_constants::ROBOT_CLOSE_TO_POINT / 2);
     auto enemyBots = w.getThem();
     if (std::any_of(enemyBots.begin(), enemyBots.end(), [&](const auto& bot) { return passLine.contains(bot->getPos()); })) {
-        stpInfos["passer"].setShootType(CHIP);
+        stpInfos["passer"].setKickOrChip(KickOrChip::CHIP);
     } else {
-        stpInfos["passer"].setShootType(KICK);
+        stpInfos["passer"].setKickOrChip(KickOrChip::KICK);
     }
     return std::make_pair(bestPosition, bestScore);
 }

--- a/src/stp/new_plays/GetBallPossession.cpp
+++ b/src/stp/new_plays/GetBallPossession.cpp
@@ -48,15 +48,15 @@ void GetBallPossession::calculateInfoForRoles() noexcept {
 
     stpInfos["defender_0"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["defender_0"].setEnemyRobot(world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), world_new::them));
-    stpInfos["defender_0"].setBlockDistance(HALFWAY);
+    stpInfos["defender_0"].setBlockDistance(BlockDistance::HALFWAY);
 
     stpInfos["defender_1"].setPositionToDefend(field.getOurBottomGoalSide());
     stpInfos["defender_1"].setEnemyRobot(world->getWorld()->getRobotClosestToPoint(field.getOurBottomGoalSide(), world_new::them));
-    stpInfos["defender_1"].setBlockDistance(HALFWAY);
+    stpInfos["defender_1"].setBlockDistance(BlockDistance::HALFWAY);
 
     stpInfos["defender_2"].setPositionToDefend(field.getOurTopGoalSide());
     stpInfos["defender_2"].setEnemyRobot(world->getWorld()->getRobotClosestToPoint(field.getOurTopGoalSide(), world_new::them));
-    stpInfos["defender_2"].setBlockDistance(HALFWAY);
+    stpInfos["defender_2"].setBlockDistance(BlockDistance::HALFWAY);
 
     auto length = field.getFieldLength();
     auto width = field.getFieldWidth();

--- a/src/stp/new_plays/GetBallRisky.cpp
+++ b/src/stp/new_plays/GetBallRisky.cpp
@@ -68,33 +68,33 @@ void GetBallRisky::calculateInfoForRoles() noexcept {
 
     stpInfos["defender_0"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["defender_0"].setEnemyRobot(enemyAttacker);
-    stpInfos["defender_0"].setBlockDistance(HALFWAY);
+    stpInfos["defender_0"].setBlockDistance(BlockDistance::HALFWAY);
 
     stpInfos["defender_1"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["defender_1"].setEnemyRobot(enemyClosestToGoal);
-    stpInfos["defender_1"].setBlockDistance(HALFWAY);
+    stpInfos["defender_1"].setBlockDistance(BlockDistance::HALFWAY);
 
     if (enemyClosestToGoal)
         stpInfos["defender_2"].setPositionToDefend(enemyClosestToGoal.value()->getPos());
     else
         stpInfos["defender_2"].setPositionToDefend(field.getTheirGoalCenter() + Vector2{1, 1});
     stpInfos["defender_2"].setEnemyRobot(enemyAttacker);
-    stpInfos["defender_2"].setBlockDistance(HALFWAY);
+    stpInfos["defender_2"].setBlockDistance(BlockDistance::HALFWAY);
 
     stpInfos["midfielder_0"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["midfielder_0"].setEnemyRobot(enemyAttacker);
-    stpInfos["midfielder_0"].setBlockDistance(CLOSE);
+    stpInfos["midfielder_0"].setBlockDistance(BlockDistance::CLOSE);
 
     stpInfos["midfielder_1"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["midfielder_1"].setEnemyRobot(enemyClosestToGoal);
-    stpInfos["midfielder_1"].setBlockDistance(CLOSE);
+    stpInfos["midfielder_1"].setBlockDistance(BlockDistance::CLOSE);
 
     if (enemyClosestToGoal)
         stpInfos["midfielder_2"].setPositionToDefend(enemyClosestToGoal.value()->getPos());
     else
         stpInfos["midfielder_2"].setPositionToDefend(field.getTheirGoalCenter() + Vector2{1, 1});
     stpInfos["midfielder_2"].setEnemyRobot(enemyAttacker);
-    stpInfos["midfielder_2"].setBlockDistance(CLOSE);
+    stpInfos["midfielder_2"].setBlockDistance(BlockDistance::CLOSE);
 }
 
 bool GetBallRisky::shouldRoleSkipEndTactic() { return false; }

--- a/src/stp/new_plays/KickOffUs.cpp
+++ b/src/stp/new_plays/KickOffUs.cpp
@@ -35,7 +35,7 @@ void KickOffUs::calculateInfoForRoles() noexcept {
 
     // Kicker
     stpInfos["kicker"].setPositionToShootAt(Vector2{-1.0, 0.0});
-    stpInfos["kicker"].setKickChipType(PASS);
+    stpInfos["kicker"].setShotType(ShotType::PASS);
 }
 
 bool KickOffUs::shouldRoleSkipEndTactic() { return false; }

--- a/src/stp/new_plays/PenaltyUs.cpp
+++ b/src/stp/new_plays/PenaltyUs.cpp
@@ -62,7 +62,7 @@ void PenaltyUs::calculateInfoForRoles() noexcept {
 
     // TODO: the shoot position might need to change
     stpInfos["kicker"].setPositionToShootAt(field.getTheirGoalCenter() + Vector2{1.0, 0.5});
-    stpInfos["kicker"].setKickChipType(KickChipType::MAX);
+    stpInfos["kicker"].setShotType(ShotType::MAX);
 }
 
 bool PenaltyUs::shouldRoleSkipEndTactic() { return false; }

--- a/src/stp/new_plays/ReflectKick.cpp
+++ b/src/stp/new_plays/ReflectKick.cpp
@@ -102,7 +102,7 @@ void ReflectKick::calculateInfoForRoles() noexcept {
     // Reflector
     stpInfos["reflector"].setPositionToMoveTo(reflectPosition);
     stpInfos["reflector"].setPositionToShootAt(field.getTheirGoalCenter());
-    stpInfos["reflector"].setKickChipType(MAX);
+    stpInfos["reflector"].setShotType(ShotType::MAX);
 
     for (auto &role : roles) {
         if (role->getName() == "reflector") {
@@ -115,8 +115,8 @@ void ReflectKick::calculateInfoForRoles() noexcept {
 
     // Passer
     stpInfos["passer"].setPositionToShootAt(passPosition);
-    stpInfos["passer"].setKickChipType(TARGET);
-    stpInfos["passer"].setShootType(KICK);
+    stpInfos["passer"].setShotType(ShotType::TARGET);
+    stpInfos["passer"].setKickOrChip(KickOrChip::KICK);
 
     // Offenders
     stpInfos["offender_1"].setPositionToMoveTo(Vector2(field.getFieldLength() / 4, field.getFieldWidth() / 4));

--- a/src/stp/new_roles/Keeper.cpp
+++ b/src/stp/new_roles/Keeper.cpp
@@ -8,6 +8,7 @@
 #include "stp/new_tactics/KeeperBlockBall.h"
 #include "stp/new_tactics/KickAtPos.h"
 #include "world/FieldComputations.h"
+#include "roboteam_utils/Print.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/new_roles/PenaltyKeeper.cpp
+++ b/src/stp/new_roles/PenaltyKeeper.cpp
@@ -9,6 +9,7 @@
 #include "stp/new_tactics/GetBall.h"
 #include "stp/new_tactics/KickAtPos.h"
 #include "world/FieldComputations.h"
+#include "roboteam_utils/Print.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/new_skills/Chip.cpp
+++ b/src/stp/new_skills/Chip.cpp
@@ -6,8 +6,6 @@
 
 namespace rtt::ai::stp::skill {
 
-void Chip::onInitialize() noexcept {}
-
 Status Chip::onUpdate(const StpInfo &info) noexcept {
     // Clamp and set chip velocity
     double chipVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
@@ -32,8 +30,6 @@ Status Chip::onUpdate(const StpInfo &info) noexcept {
     ++chipAttempts;
     return Status::Running;
 }
-
-void Chip::onTerminate() noexcept {}
 
 const char *Chip::getName() { return "Chip"; }
 

--- a/src/stp/new_skills/GoToPos.cpp
+++ b/src/stp/new_skills/GoToPos.cpp
@@ -8,8 +8,6 @@
 
 namespace rtt::ai::stp::skill {
 
-void GoToPos::onInitialize() noexcept {}
-
 Status GoToPos::onUpdate(const StpInfo &info) noexcept {
     auto targetPosOpt = info.getPositionToMoveTo();
 
@@ -57,8 +55,6 @@ Status GoToPos::onUpdate(const StpInfo &info) noexcept {
         return Status::Running;
     }
 }
-
-void GoToPos::onTerminate() noexcept {}
 
 const char *GoToPos::getName() { return "Go To Position"; }
 

--- a/src/stp/new_skills/Kick.cpp
+++ b/src/stp/new_skills/Kick.cpp
@@ -6,8 +6,6 @@
 
 namespace rtt::ai::stp::skill {
 
-void Kick::onInitialize() noexcept {}
-
 Status Kick::onUpdate(const StpInfo &info) noexcept {
     // Clamp and set kick velocity
     double kickVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
@@ -40,8 +38,6 @@ Status Kick::onUpdate(const StpInfo &info) noexcept {
     ++kickAttempts;
     return Status::Running;
 }
-
-void Kick::onTerminate() noexcept {}
 
 const char *Kick::getName() { return "Kick"; }
 

--- a/src/stp/new_skills/Rotate.cpp
+++ b/src/stp/new_skills/Rotate.cpp
@@ -8,8 +8,6 @@
 
 namespace rtt::ai::stp::skill {
 
-void Rotate::onInitialize() noexcept {}
-
 Status Rotate::onUpdate(const StpInfo &info) noexcept {
     auto targetAngle = info.getAngle();
 
@@ -33,8 +31,6 @@ Status Rotate::onUpdate(const StpInfo &info) noexcept {
         return Status::Running;
     }
 }
-
-void Rotate::onTerminate() noexcept {}
 
 const char *Rotate::getName() { return "Rotate"; }
 

--- a/src/stp/new_skills/Shoot.cpp
+++ b/src/stp/new_skills/Shoot.cpp
@@ -8,8 +8,6 @@
 
 namespace rtt::ai::stp::skill {
 
-void Shoot::onInitialize() noexcept {}
-
 Status Shoot::onUpdate(const StpInfo &info) noexcept {
     if (info.getKickOrChip() == KickOrChip::CHIP) {
         return onUpdateChip(info);
@@ -48,31 +46,30 @@ Status Shoot::onUpdateKick(const StpInfo &info) noexcept {
     return Status::Running;
 }
 Status Shoot::onUpdateChip(const StpInfo &info) noexcept {
-    // Clamp and set chip velocity
-    double chipVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
+  // Clamp and set chip velocity
+  double chipVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
 
-    // Set chip command
-    command.set_chipper(true);
-    command.set_chip_kick_vel(chipVelocity);
+  // Set chip command
+  command.set_chipper(true);
+  command.set_chip_kick_vel(chipVelocity);
 
-    // Set angle command
-    command.set_w(info.getRobot().value()->getAngle());
+  // Set angle command
+  command.set_w(info.getRobot().value()->getAngle());
 
-    if (shootAttempts > control_constants::MAX_CHIP_ATTEMPTS) {
-        shootAttempts = 0;
-        command.set_chip_kick_forced(true);
-    }
+  if (shootAttempts > control_constants::MAX_CHIP_ATTEMPTS) {
+    shootAttempts = 0;
+    command.set_chip_kick_forced(true);
+  }
 
-    publishRobotCommand(info.getCurrentWorld());
+  publishRobotCommand(info.getCurrentWorld());
 
-    if (info.getBall()->get()->getVelocity().length() > stp::control_constants::HAS_CHIPPED_ERROR_MARGIN) {
-        shootAttempts = 0;
-        return Status::Success;
-    }
-    ++shootAttempts;
-    return Status::Running;
+  if (info.getBall()->get()->getVelocity().length() > stp::control_constants::HAS_CHIPPED_ERROR_MARGIN) {
+    shootAttempts = 0;
+    return Status::Success;
+  }
+  ++shootAttempts;
+  return Status::Running;
 }
-void Shoot::onTerminate() noexcept {}
 
 const char *Shoot::getName() { return "Shoot"; }
 

--- a/src/stp/new_skills/Shoot.cpp
+++ b/src/stp/new_skills/Shoot.cpp
@@ -11,9 +11,9 @@ namespace rtt::ai::stp::skill {
 void Shoot::onInitialize() noexcept {}
 
 Status Shoot::onUpdate(const StpInfo &info) noexcept {
-    if (info.getShootType() == rtt::ai::stp::KickChip::CHIP) {
+    if (info.getKickOrChip() == KickOrChip::CHIP) {
         return onUpdateChip(info);
-    } else if (info.getShootType() == rtt::ai::stp::KickChip::KICK) {
+    } else if (info.getKickOrChip() == KickOrChip::KICK) {
         return onUpdateKick(info);
     } else {
         RTT_ERROR("No ShootType set, kicking by default!")
@@ -23,7 +23,7 @@ Status Shoot::onUpdate(const StpInfo &info) noexcept {
 
 Status Shoot::onUpdateKick(const StpInfo &info) noexcept {
     // Clamp and set kick velocity
-    double kickVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
+    float kickVelocity = std::clamp(info.getKickChipVelocity(), 0.0, stp::control_constants::MAX_KICK_POWER);
 
     // Set kick command
     command.set_kicker(true);

--- a/src/stp/new_tactics/AvoidBall.cpp
+++ b/src/stp/new_tactics/AvoidBall.cpp
@@ -9,6 +9,8 @@
 #include "stp/new_skills/GoToPos.h"
 #include "stp/new_skills/Rotate.h"
 #include "utilities/GameStateManager.hpp"
+#include "roboteam_utils/Circle.h"
+
 namespace rtt::ai::stp::tactic {
 
 AvoidBall::AvoidBall() { skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::Rotate()}; }

--- a/src/stp/new_tactics/AvoidBall.cpp
+++ b/src/stp/new_tactics/AvoidBall.cpp
@@ -4,64 +4,53 @@
 
 #include "stp/new_tactics/AvoidBall.h"
 
-#include "roboteam_utils/Tube.h"
-#include "stp/invariants/game_states/StopGameStateInvariant.h"
+#include <roboteam_utils/Circle.h>
+#include <roboteam_utils/Tube.h>
+
 #include "stp/new_skills/GoToPos.h"
 #include "stp/new_skills/Rotate.h"
 #include "utilities/GameStateManager.hpp"
-#include "roboteam_utils/Circle.h"
 
 namespace rtt::ai::stp::tactic {
 
 AvoidBall::AvoidBall() { skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::Rotate()}; }
 
-void AvoidBall::onInitialize() noexcept {}
-
-void AvoidBall::onUpdate(Status const &status) noexcept {}
-
-void AvoidBall::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> AvoidBall::calculateInfoForSkill(StpInfo const &info) noexcept {
-    StpInfo skillStpInfo = info;
-    auto currentGameState = GameStateManager::getCurrentGameState().getStrategyName();
+  StpInfo skillStpInfo = info;
+  auto currentGameState = GameStateManager::getCurrentGameState().getStrategyName();
 
-    if (!skillStpInfo.getBall() || !skillStpInfo.getPositionToMoveTo()) return std::nullopt;
+  if (!skillStpInfo.getBall() || !skillStpInfo.getPositionToMoveTo()) return std::nullopt;
 
-    // If gameState == stop we need to avoid using a circle around the ball
-    if (currentGameState == "stop") {
-        auto ballPosition = skillStpInfo.getBall()->get()->getPos();
-        auto targetPosition = skillStpInfo.getPositionToMoveTo().value();
+  // If gameState == stop we need to avoid using a circle around the ball
+  if (currentGameState == "stop") {
+    auto ballPosition = skillStpInfo.getBall()->get()->getPos();
+    auto targetPosition = skillStpInfo.getPositionToMoveTo().value();
 
-        // Circle around the ball with default avoid radius (0.5m)
-        auto avoidCircle = Circle(ballPosition, control_constants::AVOID_BALL_DISTANCE);
+    // Circle around the ball with default avoid radius (0.5m)
+    auto avoidCircle = Circle(ballPosition, control_constants::AVOID_BALL_DISTANCE);
 
-        // If position is within the avoidCircle, project the position on this circle
-        if (avoidCircle.doesIntersectOrContain(targetPosition)) {
-            skillStpInfo.setPositionToMoveTo(avoidCircle.project(targetPosition));
-        }
+    // If position is within the avoidCircle, project the position on this circle
+    if (avoidCircle.doesIntersectOrContain(targetPosition)) {
+      skillStpInfo.setPositionToMoveTo(avoidCircle.project(targetPosition));
     }
+  }
 
-    // If gameState == ballPlacement we need to avoid using a tube on the shortest path from the ball to the ball placement position
-    else if (currentGameState == "ball_placement_us" || currentGameState == "ball_placement_them") {
-        auto ballPosition = skillStpInfo.getBall()->get()->getPos();
-        auto targetPosition = skillStpInfo.getPositionToMoveTo().value();
+  // If gameState == ballPlacement we need to avoid using a tube on the shortest path from the ball to the ball placement position
+  else if (currentGameState == "ball_placement_us" || currentGameState == "ball_placement_them") {
+    auto ballPosition = skillStpInfo.getBall()->get()->getPos();
+    auto targetPosition = skillStpInfo.getPositionToMoveTo().value();
 
-        // Tube around the shortest path from ball to placement position with default avoid radius (0.5m)
-        auto avoidTube = Tube(ballPosition, GameStateManager::getRefereeDesignatedPosition(), control_constants::AVOID_BALL_DISTANCE);
+    // Tube around the shortest path from ball to placement position with default avoid radius (0.5m)
+    auto avoidTube = Tube(ballPosition, GameStateManager::getRefereeDesignatedPosition(), control_constants::AVOID_BALL_DISTANCE);
 
-        // If position is within the avoidTube, project the position on this tube
-        if (avoidTube.contains(targetPosition)) {
-            skillStpInfo.setPositionToMoveTo(avoidTube.project(targetPosition));
-        }
+    // If position is within the avoidTube, project the position on this tube
+    if (avoidTube.contains(targetPosition)) {
+      skillStpInfo.setPositionToMoveTo(avoidTube.project(targetPosition));
     }
-    skillStpInfo.setAngle(0.00001);
+  }
+  skillStpInfo.setAngle(0.00001);
 
-    return skillStpInfo;
+  return skillStpInfo;
 }
 
 bool AvoidBall::isEndTactic() noexcept { return true; }
@@ -69,8 +58,8 @@ bool AvoidBall::isEndTactic() noexcept { return true; }
 bool AvoidBall::isTacticFailing(const StpInfo &info) noexcept { return false; }
 
 bool AvoidBall::shouldTacticReset(const StpInfo &info) noexcept {
-    double errorMargin = control_constants::GO_TO_POS_ERROR_MARGIN;
-    return (info.getRobot().value()->getPos() - info.getPositionToMoveTo().value()).length() > errorMargin;
+  double errorMargin = control_constants::GO_TO_POS_ERROR_MARGIN;
+  return (info.getRobot().value()->getPos() - info.getPositionToMoveTo().value()).length() > errorMargin;
 }
 
 const char *AvoidBall::getName() { return "Avoid Ball"; }

--- a/src/stp/new_tactics/BlockBall.cpp
+++ b/src/stp/new_tactics/BlockBall.cpp
@@ -6,7 +6,8 @@
 
 #include "control/ControlUtils.h"
 #include "stp/new_skills/GoToPos.h"
-#include "stp/new_skills/Rotate.h"
+
+#include "roboteam_utils/Circle.h"
 
 namespace rtt::ai::stp::tactic {
 

--- a/src/stp/new_tactics/BlockBall.cpp
+++ b/src/stp/new_tactics/BlockBall.cpp
@@ -13,17 +13,6 @@ namespace rtt::ai::stp::tactic {
 
 BlockBall::BlockBall() { skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos()}; }
 
-void BlockBall::onInitialize() noexcept {}
-
-void BlockBall::onUpdate(Status const &status) noexcept {}
-
-void BlockBall::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> BlockBall::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 

--- a/src/stp/new_tactics/BlockRobot.cpp
+++ b/src/stp/new_tactics/BlockRobot.cpp
@@ -12,17 +12,6 @@ BlockRobot::BlockRobot() {
     skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::Rotate()};
 }
 
-void BlockRobot::onInitialize() noexcept {}
-
-void BlockRobot::onUpdate(Status const &status) noexcept {}
-
-void BlockRobot::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> BlockRobot::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 
@@ -53,11 +42,8 @@ bool BlockRobot::isEndTactic() noexcept { return true; }
 bool BlockRobot::isTacticFailing(const StpInfo &info) noexcept { return false; }
 
 bool BlockRobot::shouldTacticReset(const StpInfo &info) noexcept {
-    // Reset if the robot is too far from its desired location
-    auto desiredRobotPosition = calculateDesiredRobotPosition(info.getBlockDistance(), info.getEnemyRobot().value(), info.getPositionToDefend().value());
-    auto currentRobotPosition = info.getRobot().value()->getPos();
-    auto cond = (desiredRobotPosition - currentRobotPosition).length() > errorMargin;
-    return cond;
+  double errorMargin = control_constants::GO_TO_POS_ERROR_MARGIN;
+  return (info.getRobot().value()->getPos() - info.getPositionToMoveTo().value()).length() > errorMargin;
 }
 
 const char *BlockRobot::getName() {

--- a/src/stp/new_tactics/ChipAtPos.cpp
+++ b/src/stp/new_tactics/ChipAtPos.cpp
@@ -37,7 +37,7 @@ std::optional<StpInfo> ChipAtPos::calculateInfoForSkill(StpInfo const &info) noe
 
     // Calculate the distance and the chip force
     double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
-    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineChipForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineChipForce(distanceBallToTarget, skillStpInfo.getShotType()));
 
     // When rotating, we need to dribble to keep the ball, but when chipping we don't
     if (skills.current_num() == 0) {

--- a/src/stp/new_tactics/ChipAtPos.cpp
+++ b/src/stp/new_tactics/ChipAtPos.cpp
@@ -15,17 +15,6 @@ ChipAtPos::ChipAtPos() {
     skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::Chip()};
 }
 
-void ChipAtPos::onInitialize() noexcept {}
-
-void ChipAtPos::onUpdate(Status const &status) noexcept {}
-
-void ChipAtPos::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> ChipAtPos::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 

--- a/src/stp/new_tactics/DriveWithBall.cpp
+++ b/src/stp/new_tactics/DriveWithBall.cpp
@@ -10,42 +10,42 @@
 namespace rtt::ai::stp::tactic {
 
 DriveWithBall::DriveWithBall() {
-  // Create state machine of skills and initialize first skill
-  // TODO: The rotate skill might be unnecessary in this tactic if our dribbler works well whilst driving backwards
-  skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::GoToPos()};
+    // Create state machine of skills and initialize first skill
+    // TODO: The rotate skill might be unnecessary in this tactic if our dribbler works well whilst driving backwards
+    skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::GoToPos()};
 }
 
 std::optional<StpInfo> DriveWithBall::calculateInfoForSkill(StpInfo const& info) noexcept {
-  StpInfo skillStpInfo = info;
+    StpInfo skillStpInfo = info;
 
-  if (!skillStpInfo.getPositionToMoveTo() || !skillStpInfo.getBall()) return std::nullopt;
+    if (!skillStpInfo.getPositionToMoveTo() || !skillStpInfo.getBall()) return std::nullopt;
 
-  double angleToBall = (info.getPositionToMoveTo().value() - info.getBall()->get()->getPos()).angle();
-  skillStpInfo.setAngle(angleToBall);
+    double angleToBall = (info.getPositionToMoveTo().value() - info.getBall()->get()->getPos()).angle();
+    skillStpInfo.setAngle(angleToBall);
 
-  // When driving with ball, we need to activate the dribbler
-  // For now, this means full power, but this might change later
-  // TODO: TUNE better way to determine dribblerspeed
-  skillStpInfo.setDribblerSpeed(100);
+    // When driving with ball, we need to activate the dribbler
+    // For now, this means full power, but this might change later
+    // TODO: TUNE better way to determine dribblerspeed
+    skillStpInfo.setDribblerSpeed(100);
 
-  return skillStpInfo;
+    return skillStpInfo;
 }
 
 bool DriveWithBall::isTacticFailing(const StpInfo& info) noexcept {
-  // Fail if we don't have the ball or there is no movement position
-  return !info.getRobot()->hasBall() || !info.getPositionToMoveTo();
+    // Fail if we don't have the ball or there is no movement position
+    return !info.getRobot()->hasBall() || !info.getPositionToMoveTo();
 }
 
 bool DriveWithBall::shouldTacticReset(const StpInfo& info) noexcept {
-  // Should reset if the angle the robot is at is no longer correct
-  auto ballToRobotAngle = (info.getBall()->get()->getPos() - info.getRobot()->get()->getPos()).angle();
-  double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
-  return info.getRobot().value()->getAngle().shortestAngleDiff(ballToRobotAngle) > errorMargin;
+    // Should reset if the angle the robot is at is no longer correct
+    auto robotAngle = info.getRobot()->get()->getAngle();
+    auto ballToRobotAngle = (info.getBall()->get()->getPos() - info.getRobot()->get()->getPos()).angle();
+    return fabs(robotAngle + Angle(ballToRobotAngle)) <= stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN;
 }
 
 bool DriveWithBall::isEndTactic() noexcept {
-  // This is not an end tactic
-  return false;
+    // This is not an end tactic
+    return false;
 }
 
 const char* DriveWithBall::getName() { return "Drive With Ball"; }

--- a/src/stp/new_tactics/DriveWithBall.cpp
+++ b/src/stp/new_tactics/DriveWithBall.cpp
@@ -10,58 +10,44 @@
 namespace rtt::ai::stp::tactic {
 
 DriveWithBall::DriveWithBall() {
-    // Create state machine of skills and initialize first skill
-    // TODO: The rotate skill might be unnecessary in this tactic if our dribbler works well whilst driving backwards
-    skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::GoToPos()};
-}
-
-void DriveWithBall::onInitialize() noexcept {}
-
-void DriveWithBall::onUpdate(Status const& status) noexcept {}
-
-void DriveWithBall::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto& x : skills) {
-        x->terminate();
-    }
+  // Create state machine of skills and initialize first skill
+  // TODO: The rotate skill might be unnecessary in this tactic if our dribbler works well whilst driving backwards
+  skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::GoToPos()};
 }
 
 std::optional<StpInfo> DriveWithBall::calculateInfoForSkill(StpInfo const& info) noexcept {
-    StpInfo skillStpInfo = info;
+  StpInfo skillStpInfo = info;
 
-    if(!skillStpInfo.getPositionToMoveTo() || !skillStpInfo.getBall()) return std::nullopt;
+  if (!skillStpInfo.getPositionToMoveTo() || !skillStpInfo.getBall()) return std::nullopt;
 
-    double angleToBall = (info.getPositionToMoveTo().value() - info.getBall()->get()->getPos()).angle();
-    skillStpInfo.setAngle(angleToBall);
+  double angleToBall = (info.getPositionToMoveTo().value() - info.getBall()->get()->getPos()).angle();
+  skillStpInfo.setAngle(angleToBall);
 
-    // When driving with ball, we need to activate the dribbler
-    // For now, this means full power, but this might change later
-    // TODO: TUNE better way to determine dribblerspeed
-    skillStpInfo.setDribblerSpeed(100);
+  // When driving with ball, we need to activate the dribbler
+  // For now, this means full power, but this might change later
+  // TODO: TUNE better way to determine dribblerspeed
+  skillStpInfo.setDribblerSpeed(100);
 
-    return skillStpInfo;
+  return skillStpInfo;
 }
 
 bool DriveWithBall::isTacticFailing(const StpInfo& info) noexcept {
-    // Fail if we don't have the ball or there is no movement position
-    return !info.getRobot()->hasBall() || !info.getPositionToMoveTo();
+  // Fail if we don't have the ball or there is no movement position
+  return !info.getRobot()->hasBall() || !info.getPositionToMoveTo();
 }
 
 bool DriveWithBall::shouldTacticReset(const StpInfo& info) noexcept {
-    // Should reset if the angle the robot is at is no longer correct
-    auto robotAngle = info.getRobot()->get()->getAngle();
-    auto ballToRobotAngle = (info.getBall()->get()->getPos() - info.getRobot()->get()->getPos()).angle();
-
-    return fabs(robotAngle + Angle(ballToRobotAngle)) <= stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN;
+  // Should reset if the angle the robot is at is no longer correct
+  auto ballToRobotAngle = (info.getBall()->get()->getPos() - info.getRobot()->get()->getPos()).angle();
+  double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
+  return info.getRobot().value()->getAngle().shortestAngleDiff(ballToRobotAngle) > errorMargin;
 }
 
 bool DriveWithBall::isEndTactic() noexcept {
-    // This is not an end tactic
-    return false;
+  // This is not an end tactic
+  return false;
 }
 
-const char *DriveWithBall::getName() {
-    return "Drive With Ball";
-}
+const char* DriveWithBall::getName() { return "Drive With Ball"; }
 
 }  // namespace rtt::ai::stp::tactic

--- a/src/stp/new_tactics/Formation.cpp
+++ b/src/stp/new_tactics/Formation.cpp
@@ -14,17 +14,6 @@ Formation::Formation() {
     skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::Rotate()};
 }
 
-void Formation::onInitialize() noexcept {}
-
-void Formation::onUpdate(Status const &status) noexcept {}
-
-void Formation::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> Formation::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 

--- a/src/stp/new_tactics/GetBall.cpp
+++ b/src/stp/new_tactics/GetBall.cpp
@@ -14,12 +14,6 @@
 namespace rtt::ai::stp::tactic {
 GetBall::GetBall() { skills = collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::Rotate()}; }
 
-void GetBall::onInitialize() noexcept {}
-
-void GetBall::onUpdate(Status const &status) noexcept {}
-
-void GetBall::onTerminate() noexcept {}
-
 std::optional<StpInfo> GetBall::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 

--- a/src/stp/new_tactics/GetBallInDirection.cpp
+++ b/src/stp/new_tactics/GetBallInDirection.cpp
@@ -11,12 +11,6 @@ namespace rtt::ai::stp::tactic {
         skills = collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::Rotate(), skill::GoToPos()};
     }
 
-    void GetBallInDirection::onInitialize() noexcept {}
-
-    void GetBallInDirection::onUpdate(Status const &status) noexcept {}
-
-    void GetBallInDirection::onTerminate() noexcept {}
-
     std::optional<StpInfo> GetBallInDirection::calculateInfoForSkill(StpInfo const &info) noexcept {
         StpInfo skillStpInfo = info;
 

--- a/src/stp/new_tactics/Halt.cpp
+++ b/src/stp/new_tactics/Halt.cpp
@@ -10,12 +10,6 @@ namespace rtt::ai::stp::tactic {
 
 Halt::Halt() { skills = collections::state_machine<Skill, Status, StpInfo>{skill::Rotate()}; }
 
-void Halt::onInitialize() noexcept {}
-
-void Halt::onUpdate(Status const &status) noexcept {}
-
-void Halt::onTerminate() noexcept {}
-
 std::optional<StpInfo> Halt::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillInfo = info;
     skillInfo.setAngle(0.00001);

--- a/src/stp/new_tactics/Intercept.cpp
+++ b/src/stp/new_tactics/Intercept.cpp
@@ -19,17 +19,6 @@ bool Intercept::isEndTactic() noexcept {
     return true;
 }
 
-void Intercept::onInitialize() noexcept {}
-
-void Intercept::onUpdate(const Status& status) noexcept {}
-
-void Intercept::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto& x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> Intercept::calculateInfoForSkill(const StpInfo& info) noexcept {
     StpInfo skillStpInfo = info;
 

--- a/src/stp/new_tactics/KeeperBlockBall.cpp
+++ b/src/stp/new_tactics/KeeperBlockBall.cpp
@@ -12,17 +12,6 @@ namespace rtt::ai::stp::tactic {
 
 KeeperBlockBall::KeeperBlockBall() { skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::Rotate()}; }
 
-void KeeperBlockBall::onInitialize() noexcept {}
-
-void KeeperBlockBall::onUpdate(Status const &status) noexcept {}
-
-void KeeperBlockBall::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> KeeperBlockBall::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 

--- a/src/stp/new_tactics/KeeperBlockBall.cpp
+++ b/src/stp/new_tactics/KeeperBlockBall.cpp
@@ -75,7 +75,7 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
 
             auto intersection = LineSegment(start, end).intersects(LineSegment(startGoal, endGoal));
             if (intersection) {
-                return std::make_pair(intersection.value(), KEEPER_INTERCEPT);
+                return std::make_pair(intersection.value(), PIDType::KEEPER_INTERCEPT);
             }
         }
 
@@ -93,9 +93,9 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
                 auto targetPositions = keeperArc.intersectionWithLine(start, intersection.value());
 
                 if (targetPositions.first) {
-                    return std::make_pair(targetPositions.first.value(), KEEPER);
+                    return std::make_pair(targetPositions.first.value(), PIDType::KEEPER);
                 } else if (targetPositions.second) {
-                    return std::make_pair(targetPositions.second.value(), KEEPER);
+                    return std::make_pair(targetPositions.second.value(), PIDType::KEEPER);
                 }
             }
         }
@@ -104,14 +104,14 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
         auto targetPositions = keeperArc.intersectionWithLine(ball->getPos(), field.getOurGoalCenter());
 
         if (targetPositions.first) {
-            return std::make_pair(targetPositions.first.value(), KEEPER);
+            return std::make_pair(targetPositions.first.value(), PIDType::KEEPER);
         } else if (targetPositions.second) {
-            return std::make_pair(targetPositions.second.value(), KEEPER);
+            return std::make_pair(targetPositions.second.value(), PIDType::KEEPER);
         }
     }
 
     // Default position
-    return std::make_pair(field.getOurGoalCenter() + Vector2(DISTANCE_FROM_GOAL_FAR, 0), KEEPER);
+    return std::make_pair(field.getOurGoalCenter() + Vector2(DISTANCE_FROM_GOAL_FAR, 0), PIDType::KEEPER);
 }
 
 }  // namespace rtt::ai::stp::tactic

--- a/src/stp/new_tactics/KickAtPos.cpp
+++ b/src/stp/new_tactics/KickAtPos.cpp
@@ -15,17 +15,6 @@ KickAtPos::KickAtPos() {
     skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::Kick()};
 }
 
-void KickAtPos::onInitialize() noexcept {}
-
-void KickAtPos::onUpdate(Status const &status) noexcept {}
-
-void KickAtPos::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> KickAtPos::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 

--- a/src/stp/new_tactics/KickAtPos.cpp
+++ b/src/stp/new_tactics/KickAtPos.cpp
@@ -37,7 +37,7 @@ std::optional<StpInfo> KickAtPos::calculateInfoForSkill(StpInfo const &info) noe
 
     // Calculate the distance and the kick force
     double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
-    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineKickForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineKickForce(distanceBallToTarget, skillStpInfo.getShotType()));
 
     // When the angle is not within the margin, dribble so we don't lose the ball while rotating
     double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;

--- a/src/stp/new_tactics/PositionAndAim.cpp
+++ b/src/stp/new_tactics/PositionAndAim.cpp
@@ -14,17 +14,6 @@ PositionAndAim::PositionAndAim() {
     skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::Rotate()};
 }
 
-void PositionAndAim::onInitialize() noexcept {}
-
-void PositionAndAim::onUpdate(Status const &status) noexcept {}
-
-void PositionAndAim::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> PositionAndAim::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
     if (!skillStpInfo.getPositionToShootAt() && !skillStpInfo.getRobot()) {

--- a/src/stp/new_tactics/Receive.cpp
+++ b/src/stp/new_tactics/Receive.cpp
@@ -32,7 +32,7 @@ std::optional<StpInfo> Receive::calculateInfoForSkill(StpInfo const &info) noexc
 
     // Rotate robot towards the ball
     skillStpInfo.setAngle(calculateAngle(info.getRobot().value(), info.getBall().value()));
-    skillStpInfo.setPidType(RECEIVE);
+    skillStpInfo.setPidType(PIDType::RECEIVE);
 
     // If ball is close to robot, turn on dribbler
     if (skillStpInfo.getRobot()->get()->getDistanceToBall() <= control_constants::TURN_ON_DRIBBLER_DISTANCE) {

--- a/src/stp/new_tactics/Receive.cpp
+++ b/src/stp/new_tactics/Receive.cpp
@@ -14,17 +14,6 @@ Receive::Receive() {
     skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::Rotate()};
 }
 
-void Receive::onInitialize() noexcept {}
-
-void Receive::onUpdate(Status const &status) noexcept {}
-
-void Receive::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> Receive::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 
@@ -65,8 +54,6 @@ double Receive::calculateAngle(const world_new::view::RobotView &robot, const wo
         return (ball->getPos() - robot->getPos()).angle();
     }
 }
-
-int Receive::determineDribblerSpeed(const world_new::view::RobotView &robot) { return robot->getDistanceToBall() < control_constants::TURN_ON_DRIBBLER_DISTANCE ? 100 : 0; }
 
 const char *Receive::getName() { return "Receive"; }
 

--- a/src/stp/new_tactics/ShootAtPos.cpp
+++ b/src/stp/new_tactics/ShootAtPos.cpp
@@ -19,16 +19,6 @@ ShootAtPos::ShootAtPos() {
     skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::Shoot()};
 }
 
-void ShootAtPos::onInitialize() noexcept {}
-
-void ShootAtPos::onUpdate(Status const &status) noexcept {}
-
-void ShootAtPos::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
 std::optional<StpInfo> ShootAtPos::calculateInfoForSkill(StpInfo const &info) noexcept {
     if (info.getKickOrChip() == stp::KickOrChip::KICK) {
         return calculateInfoForKick(info);

--- a/src/stp/new_tactics/ShootAtPos.cpp
+++ b/src/stp/new_tactics/ShootAtPos.cpp
@@ -10,6 +10,8 @@
 
 #include "stp/new_tactics/KickAtPos.h"
 
+#include "roboteam_utils/Print.h"
+
 namespace rtt::ai::stp::tactic {
 
 ShootAtPos::ShootAtPos() {
@@ -28,9 +30,9 @@ void ShootAtPos::onTerminate() noexcept {
     }
 }
 std::optional<StpInfo> ShootAtPos::calculateInfoForSkill(StpInfo const &info) noexcept {
-    if (info.getShootType() == stp::KickChip::KICK) {
+    if (info.getKickOrChip() == stp::KickOrChip::KICK) {
         return calculateInfoForKick(info);
-    } else if (info.getShootType() == stp::KickChip::CHIP) {
+    } else if (info.getKickOrChip() == stp::KickOrChip::CHIP) {
         return calculateInfoForChip(info);
     } else {
         RTT_ERROR("No ShootType is set, kicking by default")
@@ -49,7 +51,7 @@ std::optional<StpInfo> ShootAtPos::calculateInfoForKick(StpInfo const &info) noe
 
     // Calculate the distance and the kick force
     double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
-    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineKickForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineKickForce(distanceBallToTarget, skillStpInfo.getShotType()));
 
     // When the angle is not within the margin, dribble so we don't lose the ball while rotating
     double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
@@ -69,7 +71,7 @@ std::optional<StpInfo> ShootAtPos::calculateInfoForChip(StpInfo const &info) noe
 
     // Calculate the distance and the chip force
     double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
-    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineChipForce(distanceBallToTarget, skillStpInfo.getKickChipType()));
+    skillStpInfo.setKickChipVelocity(control::ControlUtils::determineChipForce(distanceBallToTarget, skillStpInfo.getShotType()));
 
     // When rotating, we need to dribble to keep the ball, but when chipping we don't
     if (skills.current_num() == 0) {

--- a/src/stp/new_tactics/TestTactic.cpp
+++ b/src/stp/new_tactics/TestTactic.cpp
@@ -14,17 +14,6 @@ TestTactic::TestTactic() {
     skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::GoToPos(), skill::GoToPos(), skill::GoToPos(), skill::GoToPos()};
 }
 
-void TestTactic::onInitialize() noexcept {}
-
-void TestTactic::onUpdate(Status const &status) noexcept {}
-
-void TestTactic::onTerminate() noexcept {
-    // Call terminate on all skills
-    for (auto &x : skills) {
-        x->terminate();
-    }
-}
-
 std::optional<StpInfo> TestTactic::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
     if(!skillStpInfo.getField()) return std::nullopt;

--- a/test/StpTests/TacticTests.cpp
+++ b/test/StpTests/TacticTests.cpp
@@ -10,11 +10,7 @@ using namespace rtt::ai::stp;
 
 class TestSkill : public Skill {
    protected:
-    void onTerminate() noexcept override {}
-
     Status onUpdate(StpInfo const &info) noexcept override { return Status::Failure; }
-
-    void onInitialize() noexcept override {}
 
     const char *getName() override { return "Test Skill"; }
 };
@@ -30,12 +26,6 @@ class MockTactic : public Tactic {
     }
 
     std::optional<StpInfo> calculateInfoForSkill(const StpInfo &info) noexcept override { return StpInfo(); }
-
-    void onInitialize() noexcept override {}
-
-    void onUpdate(const Status &status) noexcept override {}
-
-    void onTerminate() noexcept override {}
 
     MOCK_METHOD1(isTacticFailingMock, bool(const StpInfo &));
 


### PR DESCRIPTION
Considering the size of this PR already, I will refactor the implementations in a separate PR

- Reformatting of code using clang-format (according to @HaicoDorenbos his standard that can be found in roboteam_suite/formatting) ((basically clang-format google style with extended column size))
- Revision of documentation
- General cleanup things
- Renaming (Open for suggestions)

closes #1164 