### PR TITLE
Fix notImportant flag

### DIFF
--- a/src/utilities/Dealer.cpp
+++ b/src/utilities/Dealer.cpp
@@ -145,7 +145,7 @@ double Dealer::getDefaultFlagScores(const v::RobotView &robot, const Dealer::Dea
         case DealerFlagTitle::WITH_WORKING_BALL_SENSOR:
             return costForProperty(robot->isWorkingBallSensor());
         case DealerFlagTitle::NOT_IMPORTANT:
-            return costForProperty(true);
+            return costForProperty(false);
         case DealerFlagTitle::WITH_WORKING_DRIBBLER:
             return costForProperty(robot->isWorkingDribbler());
         case DealerFlagTitle::READY_TO_INTERCEPT_GOAL_SHOT: {


### PR DESCRIPTION
In a previous PR I messed up the notImportant flag :(
Not important would default to `costForProperty(false)`, which would return a 0, which means notImportant would get a score of 0, which means it is "the perfect robot" for the task. This is the opposite of the behaviour we actually want.

closes #1161 