### PR TITLE
STP < Dealer option to force ID

### DIFF
--- a/include/roboteam_ai/utilities/Dealer.h
+++ b/include/roboteam_ai/utilities/Dealer.h
@@ -57,6 +57,7 @@ class Dealer {
     struct RoleInfo {
         DealerFlagPriority priority;
         std::vector<DealerFlag> flags;
+        int forcedID = -1;
     };
 
     using FlagMap = std::map<std::string, RoleInfo>;
@@ -176,6 +177,9 @@ class Dealer {
      */
     void distribute_remove(DealerDistribute &current, std::vector<int> &indexRoles, std::vector<int> &indexID,
                            std::vector<RoleScores> &scores);
+
+    void distribute_forcedIDs(const std::vector<v::RobotView> &allRobots, const FlagMap &flagMap,
+                              std::unordered_map<std::string, v::RobotView> &output);
 };
 }  // namespace rtt::ai
 #endif  // RTT_ROBOTEAM_AI_SRC_UTILITIES_DEALER_H_

--- a/include/roboteam_ai/utilities/Dealer.h
+++ b/include/roboteam_ai/utilities/Dealer.h
@@ -64,7 +64,7 @@ class Dealer {
     Dealer(v::WorldDataView world, rtt::world::Field *field);
     virtual ~Dealer() = default;  // needed for test
     // Create a distribution of robots
-    std::unordered_map<std::string, v::RobotView> distribute(const std::vector<v::RobotView> &allRobots, const FlagMap &flagMap,
+    std::unordered_map<std::string, v::RobotView> distribute(const std::vector<v::RobotView> &_allRobots, FlagMap &flagMap,
                                                              const std::unordered_map<std::string, stp::StpInfo> &stpInfoMap);
 
    protected:
@@ -165,7 +165,7 @@ class Dealer {
      * @param roleNames vector with roleNames (order matters)
      * @param flagMap has info for the other parameters
      */
-    void distribute_init(std::vector<int> &indexRoles, std::vector<int> &indexID, std::vector<std::string> &roleNames,
+    static void distribute_init(std::vector<int> &indexRoles, std::vector<int> &indexID, std::vector<std::string> &roleNames,
                          const FlagMap &flagMap);
 
     /**
@@ -175,10 +175,16 @@ class Dealer {
      * @param indexID vector with ID numbering
      * @param scores vector with all Scores for Robots for each role and its priority
      */
-    void distribute_remove(DealerDistribute &current, std::vector<int> &indexRoles, std::vector<int> &indexID,
+    static void distribute_remove(DealerDistribute &current, std::vector<int> &indexRoles, std::vector<int> &indexID,
                            std::vector<RoleScores> &scores);
 
-    void distribute_forcedIDs(const std::vector<v::RobotView> &allRobots, const FlagMap &flagMap,
+    /**
+     * Distributes the forced roles first, so that other rest of the function does not need to compute extra information
+     * @param allRobots a copy of all our robots, where in the robots will be removed
+     * @param flagMap wherein the roles will be removed
+     * @param output
+     */
+    static void distribute_forcedIDs(std::vector<v::RobotView> &allRobots, FlagMap &flagMap,
                               std::unordered_map<std::string, v::RobotView> &output);
 };
 }  // namespace rtt::ai

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -63,8 +63,8 @@ Dealer::FlagMap AttackingPass::decideRoleFlags() const noexcept {
     Dealer::DealerFlag receiverFlag(DealerFlagTitle::WITH_WORKING_DRIBBLER, DealerFlagPriority::REQUIRED);
 
     flagMap.insert({"keeper", {DealerFlagPriority::KEEPER,{}}});
-    flagMap.insert({"passer", {DealerFlagPriority::REQUIRED,{passerFlag}}});
-    flagMap.insert({"receiver_left", {DealerFlagPriority::HIGH_PRIORITY, {receiverFlag}}});
+    flagMap.insert({"passer", {DealerFlagPriority::REQUIRED,{passerFlag},5}});
+    flagMap.insert({"receiver_left", {DealerFlagPriority::HIGH_PRIORITY, {receiverFlag}, 6}});
     flagMap.insert({"receiver_right", {DealerFlagPriority::HIGH_PRIORITY, {receiverFlag}}});
     flagMap.insert({"midfielder_1", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"midfielder_2", {DealerFlagPriority::LOW_PRIORITY, {}}});

--- a/src/utilities/Dealer.cpp
+++ b/src/utilities/Dealer.cpp
@@ -7,6 +7,7 @@
 /// This issue occurs when there are multiple roles classes (defender+midfielder) that have the same priority
 
 #include "utilities/Dealer.h"
+#include <iterator>
 
 #include <roboteam_utils/Hungarian.h>
 #include <roboteam_utils/Print.h>
@@ -24,6 +25,8 @@ Dealer::DealerFlag::DealerFlag(DealerFlagTitle title, DealerFlagPriority priorit
 std::unordered_map<std::string, v::RobotView> Dealer::distribute(const std::vector<v::RobotView> &allRobots, const FlagMap &flagMap,
                                                                  const std::unordered_map<std::string, stp::StpInfo> &stpInfoMap) {
     std::unordered_map<std::string, v::RobotView> output;
+    distribute_forcedIDs(allRobots,flagMap,output);
+
     std::vector<RoleScores> scores = getScoreMatrix(allRobots, flagMap, stpInfoMap);
     // Make index of roles and ID to keep track which are the original indexes of each and get roleNames
     std::vector<int> indexRoles;
@@ -60,6 +63,20 @@ std::unordered_map<std::string, v::RobotView> Dealer::distribute(const std::vect
         }
     }
     return output;
+}
+
+void Dealer::distribute_forcedIDs(const std::vector<v::RobotView>& _allRobots, const FlagMap& _flagMap, std::unordered_map<std::string, v::RobotView>& output){
+    FlagMap flagMap = _flagMap;
+    std::vector<v::RobotView> allRobots = _allRobots;
+    for (auto role = flagMap.begin(); role != flagMap.end(); ++role) {
+        if (role->second.forcedID != -1){
+            output.insert({role->first,allRobots[role->second.forcedID]});
+            allRobots.erase(std::remove(allRobots.begin(), allRobots.end(), allRobots[role->second.forcedID]));
+            flagMap.erase(role--);
+        }
+    }
+    _flagMap = flagMap;
+    _allRobots = allRobots;
 }
 
 void Dealer::distribute_init(std::vector<int>& indexRoles, std::vector<int>& indexID, std::vector<std::string>& roleNames, const Dealer::FlagMap &flagMap) {

--- a/src/utilities/Dealer.cpp
+++ b/src/utilities/Dealer.cpp
@@ -22,9 +22,10 @@ Dealer::Dealer(v::WorldDataView world, rtt_world::Field *field) : world(world), 
 Dealer::DealerFlag::DealerFlag(DealerFlagTitle title, DealerFlagPriority priority) : title(title), priority(priority) {}
 
 // Create a distribution of robots according to their flags
-std::unordered_map<std::string, v::RobotView> Dealer::distribute(const std::vector<v::RobotView> &allRobots, const FlagMap &flagMap,
+std::unordered_map<std::string, v::RobotView> Dealer::distribute(const std::vector<v::RobotView> &_allRobots, FlagMap &flagMap,
                                                                  const std::unordered_map<std::string, stp::StpInfo> &stpInfoMap) {
     std::unordered_map<std::string, v::RobotView> output;
+    std::vector<v::RobotView> allRobots = _allRobots;           //copy to bypass the const of allRobots, needed in the next function
     distribute_forcedIDs(allRobots,flagMap,output);
 
     std::vector<RoleScores> scores = getScoreMatrix(allRobots, flagMap, stpInfoMap);
@@ -65,18 +66,14 @@ std::unordered_map<std::string, v::RobotView> Dealer::distribute(const std::vect
     return output;
 }
 
-void Dealer::distribute_forcedIDs(const std::vector<v::RobotView>& _allRobots, const FlagMap& _flagMap, std::unordered_map<std::string, v::RobotView>& output){
-    FlagMap flagMap = _flagMap;
-    std::vector<v::RobotView> allRobots = _allRobots;
+void Dealer::distribute_forcedIDs(std::vector<v::RobotView> &allRobots, FlagMap& flagMap, std::unordered_map<std::string, v::RobotView>& output){
     for (auto role = flagMap.begin(); role != flagMap.end(); ++role) {
         if (role->second.forcedID != -1){
             output.insert({role->first,allRobots[role->second.forcedID]});
-            allRobots.erase(std::remove(allRobots.begin(), allRobots.end(), allRobots[role->second.forcedID]));
+            allRobots.erase(allRobots.begin() + role->second.forcedID);
             flagMap.erase(role--);
         }
     }
-    _flagMap = flagMap;
-    _allRobots = allRobots;
 }
 
 void Dealer::distribute_init(std::vector<int>& indexRoles, std::vector<int>& indexID, std::vector<std::string>& roleNames, const Dealer::FlagMap &flagMap) {


### PR DESCRIPTION
### Summary
All the playmaker to define roles that need to go to a specific robot ID.

### Related issues
This seems like a option that a real AI would not want to have, however due to the delay of accurate information between the world and the AI (in particular positioning of the ball) a bypass can be added to increase efficiency of the AI.

**I.e. Passing;** Robot X passes to Robot Y and the play ends. In the next play the AI should decide whom is going to receive the ball, but doesnt know that the previous play this was already decided and the action was finalized. Instead of letting the AI estimate that the ball is heading towards Robot Y, this information is send to the next play and the receiver can be forced on Robot Y.

This should ofc be validated by the play and if the ball is not heading the correct direction, the play should fail and reconsider its options.