### PR TITLE
STP < PlayInfo from previous play

### DIFF
--- a/include/roboteam_ai/ApplicationManager.h
+++ b/include/roboteam_ai/ApplicationManager.h
@@ -32,11 +32,6 @@ class ApplicationManager {
     ai::stp::Play* currentPlay{nullptr};
 
     /**
-     * The last play that was picked
-     */
-    ai::stp::Play* lastPlay;
-
-    /**
      * Checks which plays are valid out of all the plays
      */
 

--- a/include/roboteam_ai/ApplicationManager.h
+++ b/include/roboteam_ai/ApplicationManager.h
@@ -32,6 +32,11 @@ class ApplicationManager {
     ai::stp::Play* currentPlay{nullptr};
 
     /**
+     * The last play that was picked
+     */
+    ai::stp::Play* lastPlay;
+
+    /**
      * Checks which plays are valid out of all the plays
      */
 

--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -130,14 +130,21 @@ class Play {
      */
     uint8_t getLastScore();
 
-    /// Place to store info in that is needed between Plays
-    using PlayInfo = std::unordered_map<int, StpInfo>;
+    struct PlayInfo {
+
+    };
+
+    /**
+     * Place to store info in that is needed between Plays.
+     * E
+     */
+    using PlayInfos = std::unordered_map<int, StpInfo>;
 
     /**
      * Saves all necessary information (that is needed for a potential next Play), when this Play will be finished
      * @return List of all the necessary information
      */
-    PlayInfo finalizePlay();
+    PlayInfos storePlayInfo();
 
 protected:
     /**

--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -114,8 +114,8 @@ class Play {
     virtual const char* getName() = 0;
 
     /**
-
-     * Gets the
+     *
+     * Gets the current StpInfos from a Play
      */
     std::unordered_map<std::string, StpInfo> getStpInfos();
 
@@ -129,6 +129,12 @@ class Play {
      * @return score if no value -> 0
      */
     uint8_t getLastScore();
+
+    /**
+     * Saves all necessary information (that is needed for a potential next Play), when this Play will be finished
+     * @return List of all the necessary information
+     */
+    std::unordered_map<int, StpInfo> finalizePlay();
 
 protected:
     /**

--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -24,13 +24,21 @@ class Play {
    public:
 
     //TODO move to gen cpp
+    /**
+     * Generalized Keys for passing information form the old play to the new.
+     * Usage in the storePlayInfo where KeyInfo is the key for the elements in the map.
+     */
     enum class KeyInfo{
-        isPasser = 0,
-        isReceiver,
-        isShooter,
-        hasBall
+        isPasser = 0,   // Robot that passes the ball last play
+        isReceiver,     // Robot that should receive the ball (as passer shot to there)
+        isShooter,      // Robot that Shot the ball last play
+        hasBall         // Robot that had the ball last play
     };
 
+    /**
+     * Generalized information structure for the map of storePlayInfo.
+     * Allows for saving specific information from the old play to the new.
+     */
     struct StoreInfo {
         std::optional<int> robotID;
         std::optional<Vector2> robotPosition;
@@ -41,7 +49,7 @@ class Play {
     };
 
     /**
-     * Place to store info in that is needed between Plays.
+     * Place to store info in that is needed between Plays. Used in storePlayInfo.
      */
     using PlayInfos = std::unordered_map<KeyInfo, StoreInfo>;
 

--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -22,6 +22,36 @@ namespace rtt::ai::stp {
  */
 class Play {
    public:
+
+    //TODO move to gen cpp
+    enum class KeyInfo{
+        isPasser = 0,
+        isReceiver,
+        isShooter,
+        hasBall
+    };
+
+    struct StoreInfo {
+        std::optional<int> robotID;
+        std::optional<Vector2> moveToPosition;
+        std::optional<Vector2> defendPosition;
+        std::optional<Vector2> shootAtPosition;
+        std::optional<Vector2> passToRobot;
+    };
+
+    /**
+     * Place to store info in that is needed between Plays.
+     */
+    using PlayInfos = std::unordered_map<KeyInfo, StoreInfo>;
+
+     //// -------
+
+    /**
+     * Saves all necessary information (that is needed for a potential next Play), when this Play will be finished
+     * @return Map of all the necessary information
+     */
+    virtual PlayInfos storePlayInfo() noexcept = 0;
+
     /**
      * Invariant vector that contains invariants that need to be true to continue execution of this play
      */
@@ -35,7 +65,7 @@ class Play {
     /**
      * Initializes stpInfos struct, distributes roles, sets the previousRobotNum variable and calls onInitialize()
      */
-    void initialize(const std::unordered_map<std::string, StpInfo>&) noexcept;
+    void initialize(PlayInfos& previousPlayInfo) noexcept;
 
     /**
      * Virtual function that is called in initialize().
@@ -114,12 +144,6 @@ class Play {
     virtual const char* getName() = 0;
 
     /**
-     *
-     * Gets the current StpInfos from a Play
-     */
-    std::unordered_map<std::string, StpInfo> getStpInfos();
-
-    /**
      * If score was calculated, save here
      */
     std::optional<uint8_t> lastScore;
@@ -129,22 +153,6 @@ class Play {
      * @return score if no value -> 0
      */
     uint8_t getLastScore();
-
-    struct PlayInfo {
-
-    };
-
-    /**
-     * Place to store info in that is needed between Plays.
-     * E
-     */
-    using PlayInfos = std::unordered_map<int, StpInfo>;
-
-    /**
-     * Saves all necessary information (that is needed for a potential next Play), when this Play will be finished
-     * @return List of all the necessary information
-     */
-    PlayInfos storePlayInfo();
 
 protected:
     /**
@@ -192,14 +200,7 @@ protected:
      */
     virtual bool shouldRoleSkipEndTactic() = 0;
 
-    /**
-     * Virtual function that returns all Roles necessary for scoring a Play.
-     * This will be used to loop through these Roles, saving all necessary information for each of them in a struct
-     * @return vector with names of scored Roles in a Play
-     */
-    virtual std::vector<std::string> getScoredRoles() = 0;
-
-   private:
+private:
     /**
      * This function refreshes the RobotViews, the BallViews and the Fields for all stpInfos.
      * This is necessary because the views are stored for a limited time; not refreshing will lead to UB
@@ -223,7 +224,11 @@ protected:
      */
     int previousRobotNum{};
 
-    int getRobotIdForRole(const std::string& roleName);
+    /**
+     * Map that holds info from the previous play
+     */
+    std::optional<PlayInfos> previousPlayInfos;
+
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -35,7 +35,7 @@ class Play {
     /**
      * Initializes stpInfos struct, distributes roles, sets the previousRobotNum variable and calls onInitialize()
      */
-    void initialize(std::unordered_map<std::basic_string<char>, StpInfo>) noexcept;
+    void initialize(const std::unordered_map<std::string, StpInfo>&) noexcept;
 
     /**
      * Virtual function that is called in initialize().
@@ -130,11 +130,14 @@ class Play {
      */
     uint8_t getLastScore();
 
+    /// Place to store info in that is needed between Plays
+    using PlayInfo = std::unordered_map<int, StpInfo>;
+
     /**
      * Saves all necessary information (that is needed for a potential next Play), when this Play will be finished
      * @return List of all the necessary information
      */
-    std::unordered_map<int, StpInfo> finalizePlay();
+    PlayInfo finalizePlay();
 
 protected:
     /**
@@ -182,6 +185,13 @@ protected:
      */
     virtual bool shouldRoleSkipEndTactic() = 0;
 
+    /**
+     * Virtual function that returns all Roles necessary for scoring a Play.
+     * This will be used to loop through these Roles, saving all necessary information for each of them in a struct
+     * @return vector with names of scored Roles in a Play
+     */
+    virtual std::vector<std::string> getScoredRoles() = 0;
+
    private:
     /**
      * This function refreshes the RobotViews, the BallViews and the Fields for all stpInfos.
@@ -205,6 +215,8 @@ protected:
      * This is used to check if we need to redeal (if a robot disappears for example)
      */
     int previousRobotNum{};
+
+    int getRobotIdForRole(const std::string& roleName);
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -33,6 +33,7 @@ class Play {
 
     struct StoreInfo {
         std::optional<int> robotID;
+        std::optional<Vector2> robotPosition;
         std::optional<Vector2> moveToPosition;
         std::optional<Vector2> defendPosition;
         std::optional<Vector2> shootAtPosition;
@@ -50,7 +51,7 @@ class Play {
      * Saves all necessary information (that is needed for a potential next Play), when this Play will be finished
      * @return Map of all the necessary information
      */
-    virtual PlayInfos storePlayInfo() noexcept = 0;
+    virtual void storePlayInfo(PlayInfos& previousPlayInfo) noexcept;
 
     /**
      * Invariant vector that contains invariants that need to be true to continue execution of this play
@@ -200,6 +201,11 @@ protected:
      */
     virtual bool shouldRoleSkipEndTactic() = 0;
 
+    /**
+     * Map that holds info from the previous play
+     */
+    std::optional<PlayInfos> previousPlayInfos;
+
 private:
     /**
      * This function refreshes the RobotViews, the BallViews and the Fields for all stpInfos.
@@ -223,11 +229,6 @@ private:
      * This is used to check if we need to redeal (if a robot disappears for example)
      */
     int previousRobotNum{};
-
-    /**
-     * Map that holds info from the previous play
-     */
-    std::optional<PlayInfos> previousPlayInfos;
 
 };
 }  // namespace rtt::ai::stp

--- a/include/roboteam_ai/stp/plays/contested/GetBallPossession.h
+++ b/include/roboteam_ai/stp/plays/contested/GetBallPossession.h
@@ -54,7 +54,7 @@ class GetBallPossession : public Play {
    protected:
     bool shouldRoleSkipEndTactic() override;
 
-    std::vector<std::string> getScoredRoles() override;
+    PlayInfos storePlayInfo() noexcept override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/plays/contested/GetBallPossession.h
+++ b/include/roboteam_ai/stp/plays/contested/GetBallPossession.h
@@ -54,7 +54,7 @@ class GetBallPossession : public Play {
    protected:
     bool shouldRoleSkipEndTactic() override;
 
-    PlayInfos storePlayInfo() noexcept override;
+    void storePlayInfo(PlayInfos& info) noexcept override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/plays/contested/GetBallPossession.h
+++ b/include/roboteam_ai/stp/plays/contested/GetBallPossession.h
@@ -53,6 +53,8 @@ class GetBallPossession : public Play {
 
    protected:
     bool shouldRoleSkipEndTactic() override;
+
+    std::vector<std::string> getScoredRoles() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
+++ b/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
@@ -115,6 +115,8 @@ class AttackingPass : public Play {
      */
     Grid gridLeft = Grid(0.15 * field.getFieldWidth(), 0, 3, 2.5, 5, 5);
     Grid gridRight = Grid(0.15 * field.getFieldWidth(), -2.5, 3, 2.5, 5, 5);
+
+    std::vector<std::string> getScoredRoles() override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
+++ b/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
@@ -116,7 +116,7 @@ class AttackingPass : public Play {
     Grid gridLeft = Grid(0.15 * field.getFieldWidth(), 0, 3, 2.5, 5, 5);
     Grid gridRight = Grid(0.15 * field.getFieldWidth(), -2.5, 3, 2.5, 5, 5);
 
-    PlayInfos storePlayInfo() noexcept override;
+    void storePlayInfo(PlayInfos& info) noexcept override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
+++ b/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
@@ -116,7 +116,7 @@ class AttackingPass : public Play {
     Grid gridLeft = Grid(0.15 * field.getFieldWidth(), 0, 3, 2.5, 5, 5);
     Grid gridRight = Grid(0.15 * field.getFieldWidth(), -2.5, 3, 2.5, 5, 5);
 
-    std::vector<std::string> getScoredRoles() override;
+    PlayInfos storePlayInfo() noexcept override;
 };
 }  // namespace rtt::ai::stp::play
 

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -160,7 +160,7 @@ void ApplicationManager::decidePlay(world::World *_world) {
     if(rtt::ai::stp::PlayDecider::interfacePlayChanged) {
         auto validPlays = playChecker.getValidPlays();
         rtt::ai::stp::Play::PlayInfos previousPlayInfo{};
-        if(currentPlay) previousPlayInfo = currentPlay->storePlayInfo();
+        if(currentPlay) currentPlay->storePlayInfo(previousPlayInfo);
 
         //Before a new play is possibly chosen: save all info of current Play that is necessary for a next Play
         currentPlay = playDecider.decideBestPlay(validPlays, playEvaluator);
@@ -173,7 +173,7 @@ void ApplicationManager::decidePlay(world::World *_world) {
     if (!currentPlay || !currentPlay->isValidPlayToKeep(playEvaluator)) {
         auto validPlays = playChecker.getValidPlays();
         rtt::ai::stp::Play::PlayInfos previousPlayInfo{};
-        if(currentPlay) previousPlayInfo = currentPlay->storePlayInfo();
+        if(currentPlay) currentPlay->storePlayInfo(previousPlayInfo);
 
         if (validPlays.empty()) {
             RTT_ERROR("No valid plays")

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -161,16 +161,22 @@ void ApplicationManager::decidePlay(world::World *_world) {
         auto validPlays = playChecker.getValidPlays();
 
         //Before a new play is possibly chosen: save all info of current Play that is necessary for a next Play
-        auto betweenPlayInfo = currentPlay->finalizePlay();
+        if(lastPlay) {
+            auto betweenPlayInfo = lastPlay->storePlayInfo();
+        }
         currentPlay = playDecider.decideBestPlay(validPlays, playEvaluator);
         currentPlay->updateWorld(_world);
         currentPlay->initialize(currentPlay->getStpInfos());
+        lastPlay = currentPlay;
         rtt::ai::stp::PlayDecider::interfacePlayChanged = false;
     }
 
     // A new play will be chosen if the current play is not valid to keep
     if (!currentPlay || !currentPlay->isValidPlayToKeep(playEvaluator)) {
         auto validPlays = playChecker.getValidPlays();
+        if(lastPlay) {
+            //auto betweenPlayInfo = lastPlay->storePlayInfo();
+        }
         if (validPlays.empty()) {
             RTT_ERROR("No valid plays")
             currentPlay = playChecker.getPlayForName("Defend Shot"); //TODO Try out different default plays so both teams dont get stuck in Defend Shot when playing against yourself
@@ -182,6 +188,7 @@ void ApplicationManager::decidePlay(world::World *_world) {
         }
         currentPlay->updateWorld(_world);
         currentPlay->initialize(currentPlay->getStpInfos());
+        lastPlay = currentPlay;
     }
 
     currentPlay->update();

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -159,10 +159,9 @@ void ApplicationManager::decidePlay(world::World *_world) {
     // Here for manual change with the interface
     if(rtt::ai::stp::PlayDecider::interfacePlayChanged) {
         auto validPlays = playChecker.getValidPlays();
-        //TODO: To make the higher abstraction layer, code below to save necessary info of the previous Play:
-        auto StpInfosPreviousPlay = currentPlay->getStpInfos();
-        //currentPlay->initialize(STPInfoPreviousPlay)
 
+        //Before a new play is possibly chosen: save all info of current Play that is necessary for a next Play
+        auto betweenPlayInfo = currentPlay->finalizePlay();
         currentPlay = playDecider.decideBestPlay(validPlays, playEvaluator);
         currentPlay->updateWorld(_world);
         currentPlay->initialize(currentPlay->getStpInfos());

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -159,24 +159,22 @@ void ApplicationManager::decidePlay(world::World *_world) {
     // Here for manual change with the interface
     if(rtt::ai::stp::PlayDecider::interfacePlayChanged) {
         auto validPlays = playChecker.getValidPlays();
+        rtt::ai::stp::Play::PlayInfos previousPlayInfo{};
+        if(currentPlay) previousPlayInfo = currentPlay->storePlayInfo();
 
         //Before a new play is possibly chosen: save all info of current Play that is necessary for a next Play
-        if(lastPlay) {
-            auto betweenPlayInfo = lastPlay->storePlayInfo();
-        }
         currentPlay = playDecider.decideBestPlay(validPlays, playEvaluator);
         currentPlay->updateWorld(_world);
-        currentPlay->initialize(currentPlay->getStpInfos());
-        lastPlay = currentPlay;
+        currentPlay->initialize(previousPlayInfo);
         rtt::ai::stp::PlayDecider::interfacePlayChanged = false;
     }
 
     // A new play will be chosen if the current play is not valid to keep
     if (!currentPlay || !currentPlay->isValidPlayToKeep(playEvaluator)) {
         auto validPlays = playChecker.getValidPlays();
-        if(lastPlay) {
-            //auto betweenPlayInfo = lastPlay->storePlayInfo();
-        }
+        rtt::ai::stp::Play::PlayInfos previousPlayInfo{};
+        if(currentPlay) previousPlayInfo = currentPlay->storePlayInfo();
+
         if (validPlays.empty()) {
             RTT_ERROR("No valid plays")
             currentPlay = playChecker.getPlayForName("Defend Shot"); //TODO Try out different default plays so both teams dont get stuck in Defend Shot when playing against yourself
@@ -187,10 +185,8 @@ void ApplicationManager::decidePlay(world::World *_world) {
             currentPlay = playDecider.decideBestPlay(validPlays, playEvaluator);
         }
         currentPlay->updateWorld(_world);
-        currentPlay->initialize(currentPlay->getStpInfos());
-        lastPlay = currentPlay;
+        currentPlay->initialize(previousPlayInfo);
     }
-
     currentPlay->update();
     mainWindow->updatePlay(currentPlay);
 }

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -134,7 +134,12 @@ bool Play::isValidPlayToStart(PlayEvaluator& playEvaluator) const noexcept {
     std::unordered_map<std::string, StpInfo> Play::getStpInfos() {
         return stpInfos;
     }
+
     uint8_t Play::getLastScore() {
         return lastScore.value_or(0);
+    }
+
+    std::unordered_map<int, StpInfo> finalizePlay() {
+        return {};
     }
 }  // namespace rtt::ai::stp

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -9,6 +9,7 @@ namespace rtt::ai::stp {
 
 void Play::initialize(PlayInfos& _previousPlayInfos) noexcept {
     previousPlayInfos = _previousPlayInfos;
+    if (!previousPlayInfos->empty()) RTT_DEBUG(std::to_string(previousPlayInfos->begin()->second.robotID.value_or(-1)));
     calculateInfoForRoles();
     distributeRoles();
     previousRobotNum = world->getWorld()->getRobotsNonOwning().size();
@@ -134,4 +135,6 @@ bool Play::isValidPlayToStart(PlayEvaluator& playEvaluator) const noexcept {
     uint8_t Play::getLastScore() {
         return lastScore.value_or(0);
     }
+
+    void Play::storePlayInfo(Play::PlayInfos& previousPlayInfo) noexcept {}
 }  // namespace rtt::ai::stp

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -116,7 +116,7 @@ std::unordered_map<Role*, Status> const& Play::getRoleStatuses() const { return 
 
 bool Play::isValidPlayToKeep(PlayEvaluator& playEvaluator) noexcept {
     if (!interface::MainControlsWidget::ignoreInvariants) {
-        return std::all_of(keepPlayEvaluation.begin(), keepPlayEvaluation.end(), [playEvaluator] (auto& x) { return playEvaluator.checkEvaluation(x); });
+        return std::all_of(keepPlayEvaluation.begin(), keepPlayEvaluation.end(), [&playEvaluator] (auto& x) { return playEvaluator.checkEvaluation(x); });
     } else {
         return true;
     }
@@ -124,7 +124,7 @@ bool Play::isValidPlayToKeep(PlayEvaluator& playEvaluator) noexcept {
 
 bool Play::isValidPlayToStart(PlayEvaluator& playEvaluator) const noexcept {
     if (!interface::MainControlsWidget::ignoreInvariants) {
-        return std::all_of(startPlayEvaluation.begin(), startPlayEvaluation.end(), [playEvaluator] (auto& x) { return playEvaluator.checkEvaluation(x); });
+        return std::all_of(startPlayEvaluation.begin(), startPlayEvaluation.end(), [&playEvaluator] (auto& x) { return playEvaluator.checkEvaluation(x); });
     } else {
         return true;
     }
@@ -142,8 +142,8 @@ bool Play::isValidPlayToStart(PlayEvaluator& playEvaluator) const noexcept {
         return stpInfos[roleName].getRobot()->get()->getId();
     }
 
-    Play::PlayInfo Play::finalizePlay() {
-        PlayInfo playInfo;
+    Play::PlayInfos Play::storePlayInfo() {
+        PlayInfos playInfo;
         std::vector<std::string> allScoredRoles = getScoredRoles();
             for(const std::string& roleName : allScoredRoles) {
                  playInfo.emplace(getRobotIdForRole(roleName), stpInfos[roleName]);

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -117,19 +117,15 @@ void Play::distributeRoles() noexcept {
 std::unordered_map<Role*, Status> const& Play::getRoleStatuses() const { return roleStatuses; }
 
 bool Play::isValidPlayToKeep(PlayEvaluator& playEvaluator) noexcept {
-    if (!interface::MainControlsWidget::ignoreInvariants) {
-        return std::all_of(keepPlayEvaluation.begin(), keepPlayEvaluation.end(), [&playEvaluator] (auto& x) { return playEvaluator.checkEvaluation(x); });
-    } else {
-        return true;
-    }
+    return (interface::MainControlsWidget::ignoreInvariants || std::all_of(keepPlayEvaluation.begin(), keepPlayEvaluation.end(), [&playEvaluator] (auto& x) {
+        return playEvaluator.checkEvaluation(x);
+    }));
 }
 
 bool Play::isValidPlayToStart(PlayEvaluator& playEvaluator) const noexcept {
-    if (!interface::MainControlsWidget::ignoreInvariants) {
-        return std::all_of(startPlayEvaluation.begin(), startPlayEvaluation.end(), [&playEvaluator] (auto& x) { return playEvaluator.checkEvaluation(x); });
-    } else {
-        return true;
-    }
+    return (interface::MainControlsWidget::ignoreInvariants || std::all_of(startPlayEvaluation.begin(), startPlayEvaluation.end(), [&playEvaluator] (auto& x) {
+        return playEvaluator.checkEvaluation(x);
+    }));
 }
 
     uint8_t Play::getLastScore() {

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -3,12 +3,11 @@
 //
 
 #include "stp/Play.hpp"
-
 #include "interface/widgets/MainControlsWidget.h"
 
 namespace rtt::ai::stp {
 
-void Play::initialize(std::unordered_map<std::basic_string<char>, StpInfo>) noexcept {
+void Play::initialize(const std::unordered_map<std::string, StpInfo>&) noexcept {
     calculateInfoForRoles();
     distributeRoles();
     previousRobotNum = world->getWorld()->getRobotsNonOwning().size();
@@ -139,7 +138,15 @@ bool Play::isValidPlayToStart(PlayEvaluator& playEvaluator) const noexcept {
         return lastScore.value_or(0);
     }
 
-    std::unordered_map<int, StpInfo> finalizePlay() {
-        return {};
+    int Play::getRobotIdForRole(const std::string& roleName) {
+        return stpInfos[roleName].getRobot()->get()->getId();
+    }
+
+    Play::PlayInfo Play::finalizePlay() {
+        PlayInfo playInfo;
+        std::vector<std::string> allScoredRoles = getScoredRoles();
+            for(const std::string& roleName : allScoredRoles) {
+                 playInfo.emplace(getRobotIdForRole(roleName), stpInfos[roleName]);
+            }
     }
 }  // namespace rtt::ai::stp

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -9,7 +9,8 @@ namespace rtt::ai::stp {
 
 void Play::initialize(PlayInfos& _previousPlayInfos) noexcept {
     previousPlayInfos = _previousPlayInfos;
-    if (!previousPlayInfos->empty()) RTT_DEBUG(std::to_string(previousPlayInfos->begin()->second.robotID.value_or(-1)));
+    if (!previousPlayInfos->empty()) 
+        RTT_DEBUG(std::to_string(previousPlayInfos->begin()->second.robotID.value_or(-1)));
     calculateInfoForRoles();
     distributeRoles();
     previousRobotNum = world->getWorld()->getRobotsNonOwning().size();

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -7,7 +7,8 @@
 
 namespace rtt::ai::stp {
 
-void Play::initialize(const std::unordered_map<std::string, StpInfo>&) noexcept {
+void Play::initialize(PlayInfos& _previousPlayInfos) noexcept {
+    previousPlayInfos = _previousPlayInfos;
     calculateInfoForRoles();
     distributeRoles();
     previousRobotNum = world->getWorld()->getRobotsNonOwning().size();
@@ -130,23 +131,7 @@ bool Play::isValidPlayToStart(PlayEvaluator& playEvaluator) const noexcept {
     }
 }
 
-    std::unordered_map<std::string, StpInfo> Play::getStpInfos() {
-        return stpInfos;
-    }
-
     uint8_t Play::getLastScore() {
         return lastScore.value_or(0);
-    }
-
-    int Play::getRobotIdForRole(const std::string& roleName) {
-        return stpInfos[roleName].getRobot()->get()->getId();
-    }
-
-    Play::PlayInfos Play::storePlayInfo() {
-        PlayInfos playInfo;
-        std::vector<std::string> allScoredRoles = getScoredRoles();
-            for(const std::string& roleName : allScoredRoles) {
-                 playInfo.emplace(getRobotIdForRole(roleName), stpInfos[roleName]);
-            }
     }
 }  // namespace rtt::ai::stp

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -125,13 +125,10 @@ Dealer::FlagMap GetBallPossession::decideRoleFlags() const noexcept {
 
 const char* GetBallPossession::getName() { return "Get Ball Possession"; }
 
-    Play::PlayInfos GetBallPossession::storePlayInfo() noexcept {
+    void GetBallPossession::storePlayInfo(PlayInfos& info) noexcept {
         StoreInfo ball_getter;
         ball_getter.robotID = stpInfos["ball_getter"].getRobot()->get()->getId();
         ball_getter.moveToPosition = stpInfos["ball_getter"].getPositionToMoveTo();
-
-        PlayInfos info{};
         info.insert({KeyInfo::hasBall, ball_getter});
-        return info;
     }
 }  // namespace rtt::ai::stp::play

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -125,4 +125,7 @@ Dealer::FlagMap GetBallPossession::decideRoleFlags() const noexcept {
 
 const char* GetBallPossession::getName() { return "Get Ball Possession"; }
 
+    std::vector<std::string> GetBallPossession::getScoredRoles() {
+        return {"ball_getter"};
+    }
 }  // namespace rtt::ai::stp::play

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -125,7 +125,13 @@ Dealer::FlagMap GetBallPossession::decideRoleFlags() const noexcept {
 
 const char* GetBallPossession::getName() { return "Get Ball Possession"; }
 
-    std::vector<std::string> GetBallPossession::getScoredRoles() {
-        return {"ball_getter"};
+    Play::PlayInfos GetBallPossession::storePlayInfo() noexcept {
+        StoreInfo ball_getter;
+        ball_getter.robotID = stpInfos["ball_getter"].getRobot()->get()->getId();
+        ball_getter.moveToPosition = stpInfos["ball_getter"].getPositionToMoveTo();
+
+        PlayInfos info{};
+        info.insert({KeyInfo::hasBall, ball_getter});
+        return info;
     }
 }  // namespace rtt::ai::stp::play

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -225,13 +225,10 @@ bool AttackingPass::passFinished() noexcept {
            (stpInfos["receiver_right"].getRobot() && stpInfos["receiver_right"].getRobot()->get()->getDistanceToBall() < 0.08);
 }
 
-    Play::PlayInfos AttackingPass::storePlayInfo() noexcept {
+   void AttackingPass::storePlayInfo(PlayInfos& info) noexcept {
         StoreInfo passer;
         passer.robotID = stpInfos["passer"].getRobot()->get()->getId();
         passer.passToRobot = stpInfos["passer"].getPositionToShootAt();
-
-        PlayInfos info{};
         info.insert({KeyInfo::isPasser,passer});
-        return info;
     }
 }  // namespace rtt::ai::stp::play

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -98,10 +98,10 @@ void AttackingPass::calculateInfoForScoredRoles(world::World* world) noexcept {
     receiverPositionLeft = computations::PositionComputations::determineBestGoalShotLocation(gridLeft, field, world);
 
     // Receiver
-    stpInfos["receiver_left"].setPositionToMoveTo(receiverPositionLeft.first);
-    stpInfos["receiver_left"].setRoleScore(receiverPositionLeft.second);
-    stpInfos["receiver_right"].setPositionToMoveTo(receiverPositionRight.first);
-    stpInfos["receiver_right"].setRoleScore(receiverPositionRight.second);
+    stpInfos["receiver_left"].setPositionToMoveTo(receiverPositionLeft.position);
+    stpInfos["receiver_left"].setRoleScore(receiverPositionLeft.score);
+    stpInfos["receiver_right"].setPositionToMoveTo(receiverPositionRight.position);
+    stpInfos["receiver_right"].setRoleScore(receiverPositionRight.score);
     }
 
 void AttackingPass::calculateInfoForRoles() noexcept {
@@ -224,4 +224,8 @@ bool AttackingPass::passFinished() noexcept {
     return (stpInfos["receiver_left"].getRobot() && stpInfos["receiver_left"].getRobot()->get()->getDistanceToBall() < 0.08) ||
            (stpInfos["receiver_right"].getRobot() && stpInfos["receiver_right"].getRobot()->get()->getDistanceToBall() < 0.08);
 }
+
+std::vector<std::string> AttackingPass::getScoredRoles() {
+        return {"receiver_left", "receiver_right"};
+    }
 }  // namespace rtt::ai::stp::play

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -225,7 +225,13 @@ bool AttackingPass::passFinished() noexcept {
            (stpInfos["receiver_right"].getRobot() && stpInfos["receiver_right"].getRobot()->get()->getDistanceToBall() < 0.08);
 }
 
-std::vector<std::string> AttackingPass::getScoredRoles() {
-        return {"receiver_left", "receiver_right"};
+    Play::PlayInfos AttackingPass::storePlayInfo() noexcept {
+        StoreInfo passer;
+        passer.robotID = stpInfos["passer"].getRobot()->get()->getId();
+        passer.passToRobot = stpInfos["passer"].getPositionToShootAt();
+
+        PlayInfos info{};
+        info.insert({KeyInfo::isPasser,passer});
+        return info;
     }
 }  // namespace rtt::ai::stp::play


### PR DESCRIPTION
### Summary
Added a structure to where information from the previous play can be saved and passed on to the next play.

### Related issues
An example would be that if a ball is passed to a other robot, that the other robot should become the reciever in the net play.
The neat method of doing this is letting the AI decide to whom the ball is passed to, however that would require an instant update of the world with correct velocities of the ball (which is not the case at this point). Therefore passing the already known information between plays should work. This assumes that the previous play has succeeded and that the skills like shootatpos are somewhat accurate, if not the play should fail with.