### PR TITLE
STP < Refining Scoring for positions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,9 @@ set(EVALUATION_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/game_states/NormalPlayGameStateEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/game_states/StopGameStateEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/game_states/TimeOutGameStateEvaluation.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/evaluations/position/OpennessEvaluation.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/evaluations/position/LineOfSightEvaluation.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/evaluations/position/GoalShotEvaluation.cpp
         )
 
 set(COMPUTATION_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ set(EVALUATION_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/position/OpennessEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/position/LineOfSightEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/position/GoalShotEvaluation.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/evaluations/position/TimeToPositionEvaluation.cpp
         )
 
 set(COMPUTATION_SOURCES

--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -13,6 +13,7 @@
 #include "world/World.hpp"
 #include "PlayEvaluator.h"
 #include "computations/PositionComputations.h"
+#include "constants/GeneralizationConstants.h"
 
 namespace rtt::ai::stp {
 

--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -51,7 +51,10 @@ struct StpInfo {
 
     const std::optional<Vector2>& getPositionToMoveTo() const { return positionToMoveTo; }
     void setPositionToMoveTo(const std::optional<Vector2>& position) { this->positionToMoveTo = position; }
-    void setPositionToMoveTo(const std::optional<gen::ScoredPosition>& scoredPosition) { setRoleScore(scoredPosition->score); setPositionToMoveTo(scoredPosition->position);}
+    void setPositionToMoveTo(const std::optional<gen::ScoredPosition>& scoredPosition) { 
+        setRoleScore(scoredPosition->score); 
+        setPositionToMoveTo(scoredPosition->position);
+    }
 
     const std::optional<Vector2>& getPositionToShootAt() const { return positionToShootAt; }
     void setPositionToShootAt(const std::optional<Vector2>& position) { this->positionToShootAt = position; }

--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -8,6 +8,7 @@
 #include "world/Field.h"
 #include "world/views/BallView.hpp"
 #include "world/views/RobotView.hpp"
+#include "constants/GeneralizationConstants.h"
 
 namespace rtt::ai::stp {
 namespace world = ::rtt::world;
@@ -50,6 +51,7 @@ struct StpInfo {
 
     const std::optional<Vector2>& getPositionToMoveTo() const { return positionToMoveTo; }
     void setPositionToMoveTo(const std::optional<Vector2>& position) { this->positionToMoveTo = position; }
+    void setPositionToMoveTo(const std::optional<gen::ScoredPosition>& scoredPosition) { setRoleScore(scoredPosition->score); setPositionToMoveTo(scoredPosition->position);}
 
     const std::optional<Vector2>& getPositionToShootAt() const { return positionToShootAt; }
     void setPositionToShootAt(const std::optional<Vector2>& position) { this->positionToShootAt = position; }

--- a/include/roboteam_ai/stp/computations/PassComputations.h
+++ b/include/roboteam_ai/stp/computations/PassComputations.h
@@ -22,12 +22,12 @@ namespace rtt::ai::stp::computations {
          */
         static bool pathHasAnyRobots(Line passLine, std::vector<rtt_world::view::RobotView> robots);
 
-        /**
-         * Return the position (.first) with the highest score (.second) in the positions vector
-         * @param positions std::pair of the Vector2 in first and the given score in second
-         * @return Vector2 with highest scoring score.
-         */
-        static Vector2 determineBestPosForPass(std::vector<PositionComputations::PositionEvaluation>& positions);
+//        /**
+//         * Return the position (.first) with the highest score (.second) in the positions vector
+//         * @param positions std::pair of the Vector2 in first and the given score in second
+//         * @return Vector2 with highest scoring score.
+//         */
+//        static Vector2 determineBestPosForPass(std::vector<PositionComputations::PositionEvaluation>& positions);
     };
 }// namespace rtt::ai::stp::computations
 #endif //RTT_PASSCOMPUTATIONS_H

--- a/include/roboteam_ai/stp/computations/PassComputations.h
+++ b/include/roboteam_ai/stp/computations/PassComputations.h
@@ -21,13 +21,6 @@ namespace rtt::ai::stp::computations {
          * @return True if any of the given robots are inside the given Tube
          */
         static bool pathHasAnyRobots(Line passLine, std::vector<rtt_world::view::RobotView> robots);
-
-//        /**
-//         * Return the position (.first) with the highest score (.second) in the positions vector
-//         * @param positions std::pair of the Vector2 in first and the given score in second
-//         * @return Vector2 with highest scoring score.
-//         */
-//        static Vector2 determineBestPosForPass(std::vector<PositionComputations::PositionEvaluation>& positions);
     };
 }// namespace rtt::ai::stp::computations
 #endif //RTT_PASSCOMPUTATIONS_H

--- a/include/roboteam_ai/stp/computations/PositionComputations.h
+++ b/include/roboteam_ai/stp/computations/PositionComputations.h
@@ -52,6 +52,7 @@ namespace rtt::ai::stp {
          */
         static double determineGoalShotScore(Vector2 &point, const world::Field &field, world::World *world, gen::PositionScores &scores);
 
+    public:
         /**
          * Score a position using the given weights weights for a profile.
          * Will check if the position already has a pre-calculated score (from this tick) then throws the weight over it
@@ -66,8 +67,6 @@ namespace rtt::ai::stp {
         static uint8_t getScoreOfPosition(gen::ScoreProfile &profile, Vector2 position, gen::PositionScores &scores, world::World *world,
                                           const world::Field &field);
 
-
-    public:
         /**
          * unordered map of calculated scores of this tick.
          * must be cleared at start of tick
@@ -85,6 +84,14 @@ namespace rtt::ai::stp {
          */
         static std::vector<Vector2> determineWallPositions(const world::Field &field, world::World *world, int amountDefenders);
 
+        /**
+         * Returns the best scored position from a grid with a profile
+         * @param searchGrid the area (with points) that should be searched
+         * @param profile combination of weights for different factors that should be scored
+         * @param field
+         * @param world
+         * @return the best position within that grid with its score
+         */
         static gen::ScoredPosition getPosition(const Grid &searchGrid, gen::ScoreProfile profile, const world::Field &field, world::World *world);
     };
 } // namespace rtt::ai::stp::computations

--- a/include/roboteam_ai/stp/computations/PositionComputations.h
+++ b/include/roboteam_ai/stp/computations/PositionComputations.h
@@ -74,6 +74,11 @@ namespace rtt::ai::stp {
         inline static std::unordered_map<Vector2,gen::PositionScores> calculatedScores{};
 
         /**
+         * vector of determined wall positions
+         */
+        inline static std::vector<Vector2> calculatedWallPositions{};
+
+        /**
          * Determines the location for defenders around the defense area
          * Uses the defence area boundaries and the path from ball to center of goal to find the intersects of circles to
          * find the various positions.
@@ -93,6 +98,16 @@ namespace rtt::ai::stp {
          * @return the best position within that grid with its score
          */
         static gen::ScoredPosition getPosition(const Grid &searchGrid, gen::ScoreProfile profile, const world::Field &field, world::World *world);
+
+        /**
+         * Makes a wall if not ready done, saves it in calculatedWallPositions and deals the index
+         * @param index Index of the wall position (do unique positions)
+         * @param amountDefenders Amount of defenders the wall is made of
+         * @param field
+         * @param world
+         * @return Vector2 position of that index in the wall
+         */
+        static Vector2 getWallPosition(int index, int amountDefenders, const world::Field &field, world::World *world);
     };
 } // namespace rtt::ai::stp::computations
 #endif //RTT_POSITIONCOMPUTATIONS_H

--- a/include/roboteam_ai/stp/computations/PositionComputations.h
+++ b/include/roboteam_ai/stp/computations/PositionComputations.h
@@ -19,81 +19,100 @@
 #include "world/views/WorldDataView.hpp"
 
 
-namespace rtt::ai::stp::computations {
+namespace rtt::ai::stp {
 
     class PositionComputations {
-    public:
         /**
          * Struct that is used to store computations made with this module
          */
-        struct PositionEvaluation {
-            Vector2 position;
-            double score;
+        struct PositionScores {
+            std::optional<double> scoreOpen;
+            std::optional<double> scoreLineOfSight;
+            std::optional<double> scoreGoalShot;
         };
 
         /**
-         * Determine the best position for a midfielder
-         * @param searchGrid the grid you want to choose a position from
-         * @param field
-         * @param world
-         * @return a midfielder position
+         * Struct of a position profile
          */
-        static PositionEvaluation determineBestOpenPosition(const Grid &searchGrid, const rtt_world::Field &field, rtt_world::World *world);
+        struct ScoreProfile{
+            double weightOpen;
+            double weightLineOfSight;
+            double weightGoalShot;
+        };
 
-        /**
-         * Determine the best position for a midfielder
-         * @param searchGrid the grid you want to choose a position from
-         * @param field
-         * @param world
-         * @return a midfielder position
-         */
-        static PositionEvaluation determineBestLineOfSightPosition(const Grid &searchGrid, const rtt_world::Field &field, rtt_world::World *world);
-
-        /**
-         * Calculates the pass location
-         * @return a pair of the pass location and the score of that location
-         * The score is used to decide to which pass location to pass when there are more receivers
-         */
-        static PositionEvaluation determineBestGoalShotLocation(const Grid &searchGrid, const rtt::world::Field &field, rtt::world::World *world);
-
-        /**
-         * Determine best position using specification of contribution of factors
-         * @param search Gridthe grid you want to choose a position from
-         * @param field
-         * @param world
-         * @param factorOpen Factor at which Open specification should count (higher is more important)
-         * @param factorLineOfSight Factor at which Line of Sight to the ball specification should count (higher is more important)
-         * @param factorVisionGoal Factor at which Visibility of ENEMY goal specification should count (higher is more important)
-         * @return Best location with given specifications, Vector2 in first and the score in second
-         */
-        static PositionEvaluation
-        determineBestLocation(const Grid &searchGrid, const world::Field &field, world::World *world, int factorOpen,
-                              int factorLineOfSight, int factorVisionGoal);
-
+    private:
         /**
          * Determine score for the Open at given position
          * @param point Position to calculate from
          * @param world
+         * @param scores ref to struct linked to that pos
          * @return score value
          */
-        static double determineOpenScore(Vector2 point, world::World *world);
+        static double determineOpenScore(Vector2 &point, world::World *world, PositionScores &scores);
 
         /**
          * Determine score for the Line of Sight to the ball at given position
          * @param point Position to calculate from
          * @param world
+         * @param scores ref to struct linked to that pos
          * @return score value
          */
-        static double determineLineOfSightScore(Vector2 point, world::World *world);
+        static double determineLineOfSightScore(Vector2 &point, world::World *world, PositionScores &scores);
 
         /**
          * Determine score for the Visibility of the goal at given position
          * @param point Position to calculate from
          * @param field
          * @param world
+         * @param scores ref to struct linked to that pos
          * @return score value
          */
-        static double determineGoalShotScore(Vector2 point, const world::Field &field, world::World *world);
+        static double determineGoalShotScore(Vector2 &point, const world::Field &field, world::World *world, PositionScores &scores);
+
+        /**
+         * Score a position using the given weights weights for a profile.
+         * Will check if the position already has a pre-calculated score (from this tick) then throws the weight over it
+         * and sums the scores, resulting in a position scored a particular set of weights.
+         * @param profile set of weights of the different factors that determine the score
+         * @param position x,y coordinates
+         * @param scores reference to scores of said position in map
+         * @param world
+         * @param field
+         * @return score of position including the weights
+         */
+        static uint8_t getScoreOfPosition(ScoreProfile &profile, Vector2 position, PositionScores &scores, world::World *world,
+                                          const world::Field &field);
+
+
+    public:
+        /**
+         * Struct with a Vector2 (x,y) position with a score (normalized)
+         */
+        struct ScoredPosition{
+            Vector2 position;
+            uint8_t score;
+        };
+
+        /**
+         * Generalized Position Profiles
+         */
+        inline static ScoreProfile SafePosition = {1,1,0};
+        inline static ScoreProfile OffensivePosition = {1,0.5,0.5};
+        inline static ScoreProfile GoalShootPosition = {0, 0.5,1};
+
+        /**
+         * Generalized Grids
+         */
+        inline static Grid gridRightTop = Grid(3, 0, 2.5, 2.2, 5, 5);
+        inline static Grid gridRightBot = Grid(3, -2.5, 2.5, 2.2, 5, 5);
+        inline static Grid gridMidFieldTop = Grid(-1, 0, 2, 2.2, 5, 5);
+        inline static Grid gridMidFieldBot = Grid(-1, -2.5, 2, 2.2, 5, 5);
+
+        /**
+         * unordered map of calculated scores of this tick.
+         * must be cleared at start of tick
+         */
+        inline static std::unordered_map<Vector2,PositionScores> calculatedScores{};
 
         /**
          * Determines the location for defenders around the defense area
@@ -105,6 +124,8 @@ namespace rtt::ai::stp::computations {
          * @return vector with Vector2 positions for each of the defenders
          */
         static std::vector<Vector2> determineWallPositions(const world::Field &field, world::World *world, int amountDefenders);
+
+        static ScoredPosition getPosition(const Grid &searchGrid, ScoreProfile profile, const world::Field &field, world::World *world);
     };
 } // namespace rtt::ai::stp::computations
 #endif //RTT_POSITIONCOMPUTATIONS_H

--- a/include/roboteam_ai/stp/computations/PositionComputations.h
+++ b/include/roboteam_ai/stp/computations/PositionComputations.h
@@ -52,6 +52,19 @@ namespace rtt::ai::stp {
          */
         static double determineGoalShotScore(Vector2 &point, const world::Field &field, world::World *world, gen::PositionScores &scores);
 
+        /**
+         * Get score of a position, used in getPosition
+         * @param position Vector2 that needs to be scored
+         * @param profile combination of weights for different factors that should be scored
+         * @param field
+         * @param world
+         * @param bias value added to score
+         * @return Position with score
+         */
+        static gen::ScoredPosition scorePosition(const Vector2 &position, gen::ScoreProfile &profile, const world::Field &field,
+                      world::World *world, uint8_t bias = 0);
+
+
     public:
         /**
          * Score a position using the given weights weights for a profile.
@@ -91,13 +104,14 @@ namespace rtt::ai::stp {
 
         /**
          * Returns the best scored position from a grid with a profile
+         * @param currentPosition The position the robot it currently going to (small biased) if it exists
          * @param searchGrid the area (with points) that should be searched
          * @param profile combination of weights for different factors that should be scored
          * @param field
          * @param world
          * @return the best position within that grid with its score
          */
-        static gen::ScoredPosition getPosition(const Grid &searchGrid, gen::ScoreProfile profile, const world::Field &field, world::World *world);
+        static gen::ScoredPosition getPosition(std::optional<rtt::Vector2> currentPosition, const Grid &searchGrid, gen::ScoreProfile profile, const world::Field &field, world::World *world);
 
         /**
          * Makes a wall if not ready done, saves it in calculatedWallPositions and deals the index

--- a/include/roboteam_ai/stp/computations/PositionComputations.h
+++ b/include/roboteam_ai/stp/computations/PositionComputations.h
@@ -17,29 +17,12 @@
 #include "world/Field.h"
 #include "world/FieldComputations.h"
 #include "world/views/WorldDataView.hpp"
+#include "stp/constants/GeneralizationConstants.h"
 
 
 namespace rtt::ai::stp {
 
     class PositionComputations {
-        /**
-         * Struct that is used to store computations made with this module
-         */
-        struct PositionScores {
-            std::optional<double> scoreOpen;
-            std::optional<double> scoreLineOfSight;
-            std::optional<double> scoreGoalShot;
-        };
-
-        /**
-         * Struct of a position profile
-         */
-        struct ScoreProfile{
-            double weightOpen;
-            double weightLineOfSight;
-            double weightGoalShot;
-        };
-
     private:
         /**
          * Determine score for the Open at given position
@@ -48,7 +31,7 @@ namespace rtt::ai::stp {
          * @param scores ref to struct linked to that pos
          * @return score value
          */
-        static double determineOpenScore(Vector2 &point, world::World *world, PositionScores &scores);
+        static double determineOpenScore(Vector2 &point, world::World *world, gen::PositionScores &scores);
 
         /**
          * Determine score for the Line of Sight to the ball at given position
@@ -57,7 +40,7 @@ namespace rtt::ai::stp {
          * @param scores ref to struct linked to that pos
          * @return score value
          */
-        static double determineLineOfSightScore(Vector2 &point, world::World *world, PositionScores &scores);
+        static double determineLineOfSightScore(Vector2 &point, world::World *world, gen::PositionScores &scores);
 
         /**
          * Determine score for the Visibility of the goal at given position
@@ -67,7 +50,7 @@ namespace rtt::ai::stp {
          * @param scores ref to struct linked to that pos
          * @return score value
          */
-        static double determineGoalShotScore(Vector2 &point, const world::Field &field, world::World *world, PositionScores &scores);
+        static double determineGoalShotScore(Vector2 &point, const world::Field &field, world::World *world, gen::PositionScores &scores);
 
         /**
          * Score a position using the given weights weights for a profile.
@@ -80,39 +63,16 @@ namespace rtt::ai::stp {
          * @param field
          * @return score of position including the weights
          */
-        static uint8_t getScoreOfPosition(ScoreProfile &profile, Vector2 position, PositionScores &scores, world::World *world,
+        static uint8_t getScoreOfPosition(gen::ScoreProfile &profile, Vector2 position, gen::PositionScores &scores, world::World *world,
                                           const world::Field &field);
 
 
     public:
         /**
-         * Struct with a Vector2 (x,y) position with a score (normalized)
-         */
-        struct ScoredPosition{
-            Vector2 position;
-            uint8_t score;
-        };
-
-        /**
-         * Generalized Position Profiles
-         */
-        inline static ScoreProfile SafePosition = {1,1,0};
-        inline static ScoreProfile OffensivePosition = {1,0.5,0.5};
-        inline static ScoreProfile GoalShootPosition = {0, 0.5,1};
-
-        /**
-         * Generalized Grids
-         */
-        inline static Grid gridRightTop = Grid(3, 0, 2.5, 2.2, 5, 5);
-        inline static Grid gridRightBot = Grid(3, -2.5, 2.5, 2.2, 5, 5);
-        inline static Grid gridMidFieldTop = Grid(-1, 0, 2, 2.2, 5, 5);
-        inline static Grid gridMidFieldBot = Grid(-1, -2.5, 2, 2.2, 5, 5);
-
-        /**
          * unordered map of calculated scores of this tick.
          * must be cleared at start of tick
          */
-        inline static std::unordered_map<Vector2,PositionScores> calculatedScores{};
+        inline static std::unordered_map<Vector2,gen::PositionScores> calculatedScores{};
 
         /**
          * Determines the location for defenders around the defense area
@@ -125,7 +85,7 @@ namespace rtt::ai::stp {
          */
         static std::vector<Vector2> determineWallPositions(const world::Field &field, world::World *world, int amountDefenders);
 
-        static ScoredPosition getPosition(const Grid &searchGrid, ScoreProfile profile, const world::Field &field, world::World *world);
+        static gen::ScoredPosition getPosition(const Grid &searchGrid, gen::ScoreProfile profile, const world::Field &field, world::World *world);
     };
 } // namespace rtt::ai::stp::computations
 #endif //RTT_POSITIONCOMPUTATIONS_H

--- a/include/roboteam_ai/stp/constants/GeneralizationConstants.h
+++ b/include/roboteam_ai/stp/constants/GeneralizationConstants.h
@@ -1,0 +1,54 @@
+//
+// Created by maxl on 19-03-21.
+//
+
+#ifndef RTT_GENERALIZATIONCONSTANTS_H
+#define RTT_GENERALIZATIONCONSTANTS_H
+
+#include <roboteam_utils/Grid.h>
+
+namespace rtt::ai::stp::gen {
+    /**
+     * Struct that is used to store computations made with this module
+     */
+    struct PositionScores {
+        std::optional<double> scoreOpen;
+        std::optional<double> scoreLineOfSight;
+        std::optional<double> scoreGoalShot;
+    };
+
+    /**
+     * Struct of a position profile
+     */
+    struct ScoreProfile{
+        double weightOpen;
+        double weightLineOfSight;
+        double weightGoalShot;
+    };
+
+    /**
+     * Structure with a position and its score
+     */
+    struct ScoredPosition{
+        Vector2 position;
+        uint8_t score;
+    };
+
+    /**
+     * Generalized Position Profiles
+     */
+    inline static ScoreProfile SafePosition = {1,1,0};
+    inline static ScoreProfile OffensivePosition = {1,0.5,0.5};
+    inline static ScoreProfile GoalShootPosition = {0, 0.5,1};
+
+    /**
+     * Generalized Grids
+     */
+    inline static Grid gridRightTop = Grid(3, 0, 2.5, 2.2, 5, 5);
+    inline static Grid gridRightMid = Grid(3, -1.5, 2.5, 3, 5, 5);
+    inline static Grid gridRightBot = Grid(3, -2.5, 2.5, 2.2, 5, 5);
+    inline static Grid gridMidFieldTop = Grid(-1, 0, 2, 2.2, 5, 5);
+    inline static Grid gridMidFieldMid = Grid(-1, -1.5, 2, 3, 5, 5);
+    inline static Grid gridMidFieldBot = Grid(-1, -2.5, 2, 2.2, 5, 5);
+}
+#endif //RTT_GENERALIZATIONCONSTANTS_H

--- a/include/roboteam_ai/stp/constants/GeneralizationConstants.h
+++ b/include/roboteam_ai/stp/constants/GeneralizationConstants.h
@@ -15,9 +15,9 @@ namespace rtt::ai::stp::gen {
      * If a position's score for a specific evaluation already had been computed in the tick, it will
      * use that value instead of recomputing it. If it was not computed yet, it will compute and save it.
      *
-     * @parm scoreOpen : uint8_t score for the Openness of a position -> evaluations/position/OpennessEvaluation
-     * @parm scoreLineOfSight : uint8_t score for the LineOfSight to a position from a position -> ../LineOfSightEvaluation
-     * @parm scoreGoalShot : uint8_t score for the Goal Shot opportunity for a position -> ../GoalShotEvaluation
+     * @memberof scoreOpen : uint8_t score for the Openness of a position -> evaluations/position/OpennessEvaluation
+     * @memberof scoreLineOfSight : uint8_t score for the LineOfSight to a position from a position -> ../LineOfSightEvaluation
+     * @memberof scoreGoalShot : uint8_t score for the Goal Shot opportunity for a position -> ../GoalShotEvaluation
      */
     struct PositionScores {
         std::optional<double> scoreOpen;
@@ -30,9 +30,9 @@ namespace rtt::ai::stp::gen {
      * This will be used to determine the final score for a robot for a position.
      * All weights will be multiplied with the corresponding score and then normalized.
      *
-     * @parm weightOpen for scoreOpen
-     * @parm weightLineOfSight for scoreLineOfSight
-     * @parm weightGoalShot for scoreGoalShot
+     * @memberof weightOpen for scoreOpen
+     * @memberof weightLineOfSight for scoreLineOfSight
+     * @memberof weightGoalShot for scoreGoalShot
      */
     struct ScoreProfile{
         double weightOpen;
@@ -42,8 +42,8 @@ namespace rtt::ai::stp::gen {
 
     /**
      * Structure with a position and its score
-     * @parm position Vector2 coordinates of a position
-     * @parm score The score for said position
+     * @memberof position Vector2 coordinates of a position
+     * @memberof score The score for said position
      */
     struct ScoredPosition{
         Vector2 position;

--- a/include/roboteam_ai/stp/constants/GeneralizationConstants.h
+++ b/include/roboteam_ai/stp/constants/GeneralizationConstants.h
@@ -9,7 +9,15 @@
 
 namespace rtt::ai::stp::gen {
     /**
-     * Struct that is used to store computations made with this module
+     * Struct that is used to store computations made with this module.
+     * Save computations here that are usable for each robot for a position.
+     *       DO NOT save values specific to a robot in here (like TimeToPosition).
+     * If a position's score for a specific evaluation already had been computed in the tick, it will
+     * use that value instead of recomputing it. If it was not computed yet, it will compute and save it.
+     *
+     * @parm scoreOpen : uint8_t score for the Openness of a position -> evaluations/position/OpennessEvaluation
+     * @parm scoreLineOfSight : uint8_t score for the LineOfSight to a position from a position -> ../LineOfSightEvaluation
+     * @parm scoreGoalShot : uint8_t score for the Goal Shot opportunity for a position -> ../GoalShotEvaluation
      */
     struct PositionScores {
         std::optional<double> scoreOpen;
@@ -18,7 +26,13 @@ namespace rtt::ai::stp::gen {
     };
 
     /**
-     * Struct of a position profile
+     * Combination of weights for each of the scores.
+     * This will be used to determine the final score for a robot for a position.
+     * All weights will be multiplied with the corresponding score and then normalized.
+     *
+     * @parm weightOpen for scoreOpen
+     * @parm weightLineOfSight for scoreLineOfSight
+     * @parm weightGoalShot for scoreGoalShot
      */
     struct ScoreProfile{
         double weightOpen;
@@ -28,6 +42,8 @@ namespace rtt::ai::stp::gen {
 
     /**
      * Structure with a position and its score
+     * @parm position Vector2 coordinates of a position
+     * @parm score The score for said position
      */
     struct ScoredPosition{
         Vector2 position;
@@ -35,14 +51,17 @@ namespace rtt::ai::stp::gen {
     };
 
     /**
-     * Generalized Position Profiles
+     * Generalized Position Profiles to be used in plays.
+     * They consist of a generalized weight combination.
      */
-    inline static ScoreProfile SafePosition = {1,1,0};
-    inline static ScoreProfile OffensivePosition = {1,0.5,0.5};
-    inline static ScoreProfile GoalShootPosition = {0, 0.5,1};
+    constexpr ScoreProfile SafePosition = {1,1,0};
+    constexpr ScoreProfile OffensivePosition = {1,0.5,0.5};
+    constexpr ScoreProfile GoalShootPosition = {0, 0.5,1};
 
     /**
-     * Generalized Grids
+     * Generalized Grids to be used in plays
+     * These positions are meant to be used across plays to lower computations when computing which
+     * play is best by reducing the amount of unique position that need to be evaluated.
      */
     inline static Grid gridRightTop = Grid(3, 0, 2.5, 2.2, 5, 5);
     inline static Grid gridRightMid = Grid(3, -1.5, 2.5, 3, 5, 5);

--- a/include/roboteam_ai/stp/evaluations/position/GoalShotEvaluation.h
+++ b/include/roboteam_ai/stp/evaluations/position/GoalShotEvaluation.h
@@ -1,0 +1,37 @@
+//
+// Created by maxl on 23-03-21.
+//
+
+#ifndef RTT_GOALSHOTEVALUATION_H
+#define RTT_GOALSHOTEVALUATION_H
+
+#include <NFParam/Param.h>
+#include "stp/constants/ControlConstants.h"
+
+namespace rtt::ai::stp::evaluation {
+
+    class GoalShotEvaluation {
+    public:
+        GoalShotEvaluation() noexcept;
+
+        [[nodiscard]] uint8_t metricCheck(double vis, double dist, double angle) const noexcept;
+
+        const char* getName() { return "PositionOpenness"; }
+
+    private:
+        /**
+         * Calculates the actual metric value using the piecewise linear function member
+         * @param x the x of the function
+         * @return metric value between 0-255
+         */
+        [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+
+        /**
+         * Unique pointer to the piecewise linear function that calculates the fuzzy value
+         */
+        std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    };
+
+}  // namespace rtt::ai::stp::evaluation
+
+#endif //RTT_GOALSHOTEVALUATION_H

--- a/include/roboteam_ai/stp/evaluations/position/GoalShotEvaluation.h
+++ b/include/roboteam_ai/stp/evaluations/position/GoalShotEvaluation.h
@@ -13,10 +13,16 @@ namespace rtt::ai::stp::evaluation {
     class GoalShotEvaluation {
     public:
         GoalShotEvaluation() noexcept;
+        /**
+         * Returns a uint8_t score linked to a position for its possibility to score a goal from it
+         * @param goalVisibility % visibility of the goal (taking in account other robots)
+         * @param goalDistance distance from point to goal
+         * @param goalAngle angle from point to goal (0 is straight in front the middle)
+         * @return uint8_t score
+         */
+        [[nodiscard]] uint8_t metricCheck(double goalVisibility, double goalDistance, double goalAngle) const noexcept;
 
-        [[nodiscard]] uint8_t metricCheck(double vis, double dist, double angle) const noexcept;
-
-        const char* getName() { return "PositionOpenness"; }
+        const char* getName() { return "PositionGoalShot"; }
 
     private:
         /**

--- a/include/roboteam_ai/stp/evaluations/position/LineOfSightEvaluation.h
+++ b/include/roboteam_ai/stp/evaluations/position/LineOfSightEvaluation.h
@@ -1,0 +1,36 @@
+//
+// Created by maxl on 22-03-21.
+//
+
+#ifndef RTT_LINEOFSIGHTEVALUATION_H
+#define RTT_LINEOFSIGHTEVALUATION_H
+
+#include <NFParam/Param.h>
+#include "stp/constants/ControlConstants.h"
+
+namespace rtt::ai::stp::evaluation {
+
+    class LineOfSightEvaluation {
+    public:
+        LineOfSightEvaluation() noexcept;
+
+        [[nodiscard]] uint8_t metricCheck(double pDist, std::vector<double>& eDists, std::vector<double>& eAngles) const noexcept;
+
+        const char* getName() { return "PositionOpenness"; }
+
+    private:
+        /**
+         * Calculates the actual metric value using the piecewise linear function member
+         * @param x the x of the function
+         * @return metric value between 0-255
+         */
+        [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+
+        /**
+         * Unique pointer to the piecewise linear function that calculates the fuzzy value
+         */
+        std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    };
+
+}  // namespace rtt::ai::stp::evaluation
+#endif //RTT_LINEOFSIGHTEVALUATION_H

--- a/include/roboteam_ai/stp/evaluations/position/LineOfSightEvaluation.h
+++ b/include/roboteam_ai/stp/evaluations/position/LineOfSightEvaluation.h
@@ -14,9 +14,16 @@ namespace rtt::ai::stp::evaluation {
     public:
         LineOfSightEvaluation() noexcept;
 
-        [[nodiscard]] uint8_t metricCheck(double pDist, std::vector<double>& eDists, std::vector<double>& eAngles) const noexcept;
+        /**
+         * Returns a uint8_t score linked to a position for each enemy robot on the line to the position from the ball
+         * @param receiverDistance Receiver distance from ball
+         * @param enemyDistances Vector of all enemy distances from ball
+         * @param enemyAngles Vector of all enemy angels from ball compared to Receiver angle (= 0 degrees)
+         * @return uint8_t score
+         */
+        [[nodiscard]] uint8_t metricCheck(double receiverDistance, std::vector<double>& enemyDistances, std::vector<double>& enemyAngles) const noexcept;
 
-        const char* getName() { return "PositionOpenness"; }
+        const char* getName() { return "PositionLineOfSight"; }
 
     private:
         /**

--- a/include/roboteam_ai/stp/evaluations/position/OpennessEvaluation.h
+++ b/include/roboteam_ai/stp/evaluations/position/OpennessEvaluation.h
@@ -1,0 +1,38 @@
+//
+// Created by maxl on 19-03-21.
+//
+
+#ifndef RTT_OPENNESSEVALUATION_H
+#define RTT_OPENNESSEVALUATION_H
+
+#include <NFParam/Param.h>
+#include "stp/constants/ControlConstants.h"
+
+namespace rtt::ai::stp::evaluation {
+
+    class OpennessEvaluation {
+    public:
+        OpennessEvaluation() noexcept;
+
+        [[nodiscard]] uint8_t metricCheck(std::vector<double>& enemyDistances) const noexcept;
+
+        const char* getName() { return "PositionOpenness"; }
+
+    private:
+        /**
+         * Calculates the actual metric value using the piecewise linear function member
+         * @param x the x of the function
+         * @return metric value between 0-255
+         */
+        [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+
+        /**
+         * Unique pointer to the piecewise linear function that calculates the fuzzy value
+         */
+        std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    };
+
+}  // namespace rtt::ai::stp::evaluation
+
+
+#endif //RTT_OPENNESSEVALUATION_H

--- a/include/roboteam_ai/stp/evaluations/position/OpennessEvaluation.h
+++ b/include/roboteam_ai/stp/evaluations/position/OpennessEvaluation.h
@@ -14,6 +14,11 @@ namespace rtt::ai::stp::evaluation {
     public:
         OpennessEvaluation() noexcept;
 
+        /**
+         * Returns a uint8_t score linked to a position for its openness taken in account all enemy bots
+         * @param enemyDistances Vector of all enemy distances from the point
+         * @return uint8_t score
+         */
         [[nodiscard]] uint8_t metricCheck(std::vector<double>& enemyDistances) const noexcept;
 
         const char* getName() { return "PositionOpenness"; }

--- a/include/roboteam_ai/stp/evaluations/position/TimeToPositionEvaluation.h
+++ b/include/roboteam_ai/stp/evaluations/position/TimeToPositionEvaluation.h
@@ -1,0 +1,46 @@
+//
+// Created by maxl on 24-03-21.
+//
+
+#ifndef RTT_TIMETOPOSITIONEVALUATION_H
+#define RTT_TIMETOPOSITIONEVALUATION_H
+
+#include <NFParam/Param.h>
+#include "stp/constants/ControlConstants.h"
+#include "include/roboteam_ai/world/views/RobotView.hpp"
+
+namespace rtt::ai::stp::evaluation {
+
+    class TimeToPositionEvaluation {
+    public:
+        TimeToPositionEvaluation() noexcept;
+
+        /**
+         * Compares the time for 2 robots to get to a point
+         * @param robot1 First robot to compare with
+         * @param robot2 Second robot to compare with
+         * @param point Position that needs to be considered
+         * @return a score based on the ratio between the 2 robots, TRUE is for the first robot being first
+         */
+        [[nodiscard]] uint8_t metricCheck(std::optional<world::view::RobotView> robot1, std::optional<world::view::RobotView> robot2, Vector2 point) const noexcept;
+
+        const char* getName() { return "PositionTimeCompareToPoint"; }
+
+    private:
+        /**
+         * Calculates the actual metric value using the piecewise linear function member
+         * @param x the x of the function
+         * @return metric value between 0-255
+         */
+        [[nodiscard]] uint8_t calculateMetric(const double& x) const noexcept;
+
+        /**
+         * Unique pointer to the piecewise linear function that calculates the fuzzy value
+         */
+        std::unique_ptr<nativeformat::param::Param> piecewiseLinearFunction;
+    };
+
+}  // namespace rtt::ai::stp::evaluation
+
+
+#endif //RTT_TIMETOPOSITIONEVALUATION_H

--- a/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
+++ b/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
@@ -68,7 +68,7 @@ class AttackingPass : public Play {
      * Receivers will get positions to receive at, of which one will actually intercept the ball once it is close enough
      * @param ball
      */
-    void calculateInfoForPass(const world::ball::Ball* ball) noexcept;
+    //NEW PLAY -> void calculateInfoForPass(const world::ball::Ball* ball) noexcept;
 
    protected:
     /**
@@ -87,12 +87,6 @@ class AttackingPass : public Play {
     [[nodiscard]] bool passFinished() noexcept;
 
     /**
-     * Called every time the .initialize() is called on a play,
-     * runs exactly once at the start of this play when this play is picked to be executed
-     */
-    void onInitialize() noexcept override;
-
-    /**
      * Position that the passer will pass to
      */
     Vector2 passingPosition;
@@ -101,20 +95,6 @@ class AttackingPass : public Play {
      * Did the passer shoot or not
      */
     bool passerShot{false};
-
-    /**
-     * Two receive locations with their scores.
-     * The passer will shoot to the highest scoring position
-     */
-    computations::PositionComputations::PositionEvaluation receiverPositionLeft{};
-    computations::PositionComputations::PositionEvaluation receiverPositionRight{};
-
-    /**
-     * The two grids that are used to calculate pass locations within it.
-     * In this case the grids are on their side, one on the left and one on the right
-     */
-    Grid gridLeft = Grid(0.15 * field.getFieldWidth(), 0, 3, 2.5, 5, 5);
-    Grid gridRight = Grid(0.15 * field.getFieldWidth(), -2.5, 3, 2.5, 5, 5);
 };
 }  // namespace rtt::ai::stp::play
 

--- a/include/roboteam_ai/world/FieldComputations.h
+++ b/include/roboteam_ai/world/FieldComputations.h
@@ -183,6 +183,14 @@ class FieldComputations {
      */
     static Polygon getFieldEdge(const rtt_world::Field &field, double margin = 0.0);
 
+    /**
+     * Returns a point that is inside the field, clips the given point to the boarders of the field (RIGHT: x=6.2 becomes x=6)
+     * @param field
+     * @param point that needs to be inside field
+     * @return point inside field
+     */
+    Vector2 placePointInField(const rtt_world::Field &field, const Vector2 &point);
+
    private:
     /**
      * Check which part of the goal are blocked by robots, i.e. to which parts of the goal the ball can be shoot over the ground from a given point without hitting any robot

--- a/include/roboteam_ai/world/FieldComputations.h
+++ b/include/roboteam_ai/world/FieldComputations.h
@@ -189,7 +189,7 @@ class FieldComputations {
      * @param point that needs to be inside field
      * @return point inside field
      */
-    Vector2 placePointInField(const rtt_world::Field &field, const Vector2 &point);
+    static Vector2 placePointInField(const rtt_world::Field &field, const Vector2 &point);
 
    private:
     /**

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -155,6 +155,7 @@ void ApplicationManager::decidePlay(world::World *_world) {
     playEvaluator.clearGlobalScores(); //reset all evaluations
     playEvaluator.update(_world);
     playChecker.update(_world, playEvaluator);
+    ai::stp::PositionComputations::calculatedScores.clear();
 
     // Here for manual change with the interface
     if(rtt::ai::stp::PlayDecider::interfacePlayChanged) {
@@ -166,7 +167,7 @@ void ApplicationManager::decidePlay(world::World *_world) {
 
         currentPlay = playDecider.decideBestPlay(validPlays, playEvaluator);
         currentPlay->updateWorld(_world);
-        currentPlay->initialize();
+        currentPlay->initialize(currentPlay->getStpInfos());
         rtt::ai::stp::PlayDecider::interfacePlayChanged = false;
     }
 
@@ -183,7 +184,7 @@ void ApplicationManager::decidePlay(world::World *_world) {
             currentPlay = playDecider.decideBestPlay(validPlays, playEvaluator);
         }
         currentPlay->updateWorld(_world);
-        currentPlay->initialize();
+        currentPlay->initialize(currentPlay->getStpInfos());
     }
 
     currentPlay->update();

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -152,10 +152,13 @@ void ApplicationManager::runOneLoopCycle() {
 }
 
 void ApplicationManager::decidePlay(world::World *_world) {
+    //TODO make a clear function
     playEvaluator.clearGlobalScores(); //reset all evaluations
+    ai::stp::PositionComputations::calculatedScores.clear();
+    ai::stp::PositionComputations::calculatedWallPositions.clear();
+
     playEvaluator.update(_world);
     playChecker.update(_world, playEvaluator);
-    ai::stp::PositionComputations::calculatedScores.clear();
 
     // Here for manual change with the interface
     if(rtt::ai::stp::PlayDecider::interfacePlayChanged) {

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -117,7 +117,7 @@ std::unordered_map<Role*, Status> const& Play::getRoleStatuses() const { return 
 
 bool Play::isValidPlayToKeep(PlayEvaluator& playEvaluator) noexcept {
     if (!interface::MainControlsWidget::ignoreInvariants) {
-        return std::all_of(keepPlayEvaluation.begin(), keepPlayEvaluation.end(), [playEvaluator] (auto& x) { return playEvaluator.checkEvaluation(x); });
+        return std::all_of(keepPlayEvaluation.begin(), keepPlayEvaluation.end(), [&playEvaluator] (auto& x) { return playEvaluator.checkEvaluation(x); });
     } else {
         return true;
     }
@@ -125,7 +125,7 @@ bool Play::isValidPlayToKeep(PlayEvaluator& playEvaluator) noexcept {
 
 bool Play::isValidPlayToStart(PlayEvaluator& playEvaluator) const noexcept {
     if (!interface::MainControlsWidget::ignoreInvariants) {
-        return std::all_of(startPlayEvaluation.begin(), startPlayEvaluation.end(), [playEvaluator] (auto& x) { return playEvaluator.checkEvaluation(x); });
+        return std::all_of(startPlayEvaluation.begin(), startPlayEvaluation.end(), [&playEvaluator] (auto& x) { return playEvaluator.checkEvaluation(x); });
     } else {
         return true;
     }

--- a/src/stp/computations/PassComputations.cpp
+++ b/src/stp/computations/PassComputations.cpp
@@ -16,17 +16,17 @@ namespace rtt::ai::stp::computations {
                            [&](const auto &bot) { return passTube.contains(bot->getPos()); });
     }
 
-    Vector2 PassComputations::determineBestPosForPass(
-            std::vector<computations::PositionComputations::PositionEvaluation> &positions) {
-        if (!positions.empty()) {
-            return std::max_element(positions.begin(), positions.end(),
-                                    [](PositionComputations::PositionEvaluation &left,
-                                       PositionComputations::PositionEvaluation &right) {
-                                        return left.score < right.score;
-                                    })->position;
-        } else {
-            RTT_DEBUG("There were no possible locations to pass to.");
-            return {};
-        }
-    }
+//    Vector2 PassComputations::determineBestPosForPass(
+//            std::vector<computations::PositionComputations::PositionEvaluation> &positions) {
+//        if (!positions.empty()) {
+//            return std::max_element(positions.begin(), positions.end(),
+//                                    [](PositionComputations::PositionEvaluation &left,
+//                                       PositionComputations::PositionEvaluation &right) {
+//                                        return left.score < right.score;
+//                                    })->position;
+//        } else {
+//            RTT_DEBUG("There were no possible locations to pass to.");
+//            return {};
+//        }
+//    }
 } //namespace rtt::ai::stp::computations

--- a/src/stp/computations/PositionComputations.cpp
+++ b/src/stp/computations/PositionComputations.cpp
@@ -79,9 +79,14 @@ namespace rtt::ai::stp {
         return (scores.scoreGoalShot = stp::evaluation::GoalShotEvaluation().metricCheck(visibility,goalDistance,trialToGoalAngle)).value();
     }
 
+    Vector2 PositionComputations::getWallPosition(int index, int amountDefenders, const rtt::world::Field &field, rtt::world::World *world){
+        if(calculatedWallPositions.empty()) calculatedWallPositions = determineWallPositions(field,world,amountDefenders);
+        return calculatedWallPositions[index];
+    }
+
     std::vector<Vector2> PositionComputations::determineWallPositions(const rtt::world::Field &field, rtt::world::World *world, int amountDefenders) {
         auto w = world->getWorld().value();
-        auto b = w.getBall()->get();
+        Vector2 ballPos = FieldComputations::placePointInField(field,w.getBall()->get()->getPos());
         double spacingRobots = control_constants::ROBOT_RADIUS * 2;
 
         std::vector<Vector2> positions = {};
@@ -94,7 +99,7 @@ namespace rtt::ai::stp {
                                                                                        control_constants::GO_TO_POS_ERROR_MARGIN,
                                                                                        0).getBoundary();
         for (auto &i : defenseAreaBorder) {
-            LineSegment ball2GoalLine = LineSegment(b->getPos(), field.getOurGoalCenter());
+            LineSegment ball2GoalLine = LineSegment(ballPos, field.getOurGoalCenter());
             for (const LineSegment &line : defenseAreaBorder) { // Vector is made to check if there is only 1 intersect
                 if (line.doesIntersect(ball2GoalLine)) {
                     auto intersect = line.intersects(ball2GoalLine);

--- a/src/stp/computations/PositionComputations.cpp
+++ b/src/stp/computations/PositionComputations.cpp
@@ -21,6 +21,7 @@ namespace rtt::ai::stp {
         gen::ScoredPosition bestPosition = {{0,0},0};
         for (const auto &nestedPoints : searchGrid.getPoints()) {
             for (const auto &position : nestedPoints) {
+                if (!FieldComputations::pointIsValidPosition(field,position)) continue;
                 gen::PositionScores &scores = (calculatedScores.contains(position)) ? calculatedScores.at(position) : calculatedScores[position];
                 uint8_t positionScore = getScoreOfPosition(profile, position, scores, world, field);
                 if (positionScore > bestPosition.score) bestPosition = {position,positionScore};

--- a/src/stp/computations/PositionComputations.cpp
+++ b/src/stp/computations/PositionComputations.cpp
@@ -14,12 +14,12 @@
 
 namespace rtt::ai::stp {
 
-    PositionComputations::ScoredPosition PositionComputations::getPosition(const Grid &searchGrid, ScoreProfile profile,const rtt::world::Field &field,
+    gen::ScoredPosition PositionComputations::getPosition(const Grid &searchGrid, gen::ScoreProfile profile,const rtt::world::Field &field,
                                                                          rtt::world::World *world) {
-        ScoredPosition bestPosition = {{0,0},0};
+        gen::ScoredPosition bestPosition = {{0,0},0};
         for (const auto &nestedPoints : searchGrid.getPoints()) {
             for (const auto &position : nestedPoints) {
-                PositionScores &scores = (calculatedScores.contains(position)) ? calculatedScores.at(position) : calculatedScores[position];
+                gen::PositionScores &scores = (calculatedScores.contains(position)) ? calculatedScores.at(position) : calculatedScores[position];
                 uint8_t positionScore = getScoreOfPosition(profile, position, scores, world, field);
                 if (positionScore > bestPosition.score) bestPosition = {position,positionScore};
                 }
@@ -28,7 +28,7 @@ namespace rtt::ai::stp {
         return bestPosition;
     }
 
-    uint8_t PositionComputations::getScoreOfPosition(ScoreProfile &profile, Vector2 position, PositionScores &scores, rtt::world::World *world, const rtt::world::Field &field){
+    uint8_t PositionComputations::getScoreOfPosition(gen::ScoreProfile &profile, Vector2 position, gen::PositionScores &scores, rtt::world::World *world, const rtt::world::Field &field){
         double scoreTotal = 0;
         double weightTotal = 0;
         if (profile.weightGoalShot > 0){
@@ -46,7 +46,7 @@ namespace rtt::ai::stp {
         return static_cast<uint8_t>(scoreTotal/weightTotal);
     }
 
-    double PositionComputations::determineOpenScore(Vector2 &point, rtt::world::World *world, PositionScores &scores) {
+    double PositionComputations::determineOpenScore(Vector2 &point, rtt::world::World *world, gen::PositionScores &scores) {
         /// TODO-Max determine with all robots within a circle around
         /// TODO-Max maybe have a cone that aims at the ball (behind does not really matter?)
         double score = 0;
@@ -57,7 +57,7 @@ namespace rtt::ai::stp {
         return (scores.scoreOpen = score).value();
     }
 
-    double PositionComputations::determineLineOfSightScore(Vector2 &point, rtt::world::World *world, PositionScores &scores) {
+    double PositionComputations::determineLineOfSightScore(Vector2 &point, rtt::world::World *world, gen::PositionScores &scores) {
         /// TODO-Max make triangle
         auto passLine = Line(world->getWorld().value()->getBall()->get()->getPos(), point);
         double score = 0;
@@ -72,7 +72,7 @@ namespace rtt::ai::stp {
         return (scores.scoreOpen = score).value();
     }
 
-    double PositionComputations::determineGoalShotScore(Vector2 &point, const rtt::world::Field &field, rtt::world::World *world, PositionScores &scores) {
+    double PositionComputations::determineGoalShotScore(Vector2 &point, const rtt::world::Field &field, rtt::world::World *world, gen::PositionScores &scores) {
         auto fieldWidth = field.getFieldWidth();
         auto fieldLength = field.getFieldLength();
         auto w = world->getWorld().value();

--- a/src/stp/evaluations/position/GoalShotEvaluation.cpp
+++ b/src/stp/evaluations/position/GoalShotEvaluation.cpp
@@ -30,17 +30,11 @@ namespace rtt::ai::stp::evaluation {
          * -> Linear from 0% to 70%, after 70% max score.
          */
         double evalScore = std::max(std::min(0.7,vis)/0.7,0.0)
-                /**
-                 * Distance, Linear-Factor -> Favor closer
-                 * Closer is better, caps at far distances
-                 * -> Max score till 2 meters, linear from 2 to 7 meters.
-                 */
+                    /// Distance, Linear-Factor -> Favor closer
+                    //Closer is better, caps at far distances -> Max score till 2 meters, linear from 2 to 7 meters.
                  * std::max(std::min(5.0,(7-dist))/5,0.0)
-                 /**
-                  * Angle, Linear -> Favor in front
-                  * In front in better
-                  * -> Max score till 30 degrees, linear from 30 to 90.
-                  */
+                    ///Angle, Linear -> Favor in front
+                    // In front in better -> Max score till 30 degrees, linear from 30 to 90.
                   * std::max(std::min(M_PI_2-angle,M_PI/6)/M_PI/6,0.0);
         return calculateMetric(evalScore);
     }

--- a/src/stp/evaluations/position/GoalShotEvaluation.cpp
+++ b/src/stp/evaluations/position/GoalShotEvaluation.cpp
@@ -3,8 +3,7 @@
 //
 
 #include "include/roboteam_ai/stp/evaluations/position/GoalShotEvaluation.h"
-#include <math.h>
-#include <iostream>
+#include <cmath>
 
 namespace rtt::ai::stp::evaluation {
     GoalShotEvaluation::GoalShotEvaluation() noexcept {
@@ -28,18 +27,21 @@ namespace rtt::ai::stp::evaluation {
         /**
          * Visibility, Root-Function -> Favor Higher visibility
          * Too low vis means not a valid pos, difference between higher vis doesnt matter as much (not linear), high vis is caped.
+         * -> Linear from 0% to 70%, after 70% max score.
          */
         double evalScore = std::max(std::min(0.7,vis)/0.7,0.0)
                 /**
                  * Distance, Linear-Factor -> Favor closer
                  * Closer is better, caps at far distances
+                 * -> Max score till 2 meters, linear from 2 to 7 meters.
                  */
                  * std::max(std::min(5.0,(7-dist))/5,0.0)
                  /**
                   * Angle, Linear -> Favor in front
                   * In front in better
+                  * -> Max score till 30 degrees, linear from 30 to 90.
                   */
-                  * std::max(std::min(M_PI_2-angle,M_PI_4)/M_PI_4,0.0);
+                  * std::max(std::min(M_PI_2-angle,M_PI/6)/M_PI/6,0.0);
         return calculateMetric(evalScore);
     }
 

--- a/src/stp/evaluations/position/GoalShotEvaluation.cpp
+++ b/src/stp/evaluations/position/GoalShotEvaluation.cpp
@@ -1,0 +1,47 @@
+//
+// Created by maxl on 23-03-21.
+//
+
+#include "include/roboteam_ai/stp/evaluations/position/GoalShotEvaluation.h"
+#include <math.h>
+#include <iostream>
+
+namespace rtt::ai::stp::evaluation {
+    GoalShotEvaluation::GoalShotEvaluation() noexcept {
+        /**
+         * Creates a piecewise linear function that looks as follows:
+         *
+         * (0,255)  |        XXXXXX
+         *          |      XXX
+         *          |    XXX
+         *          |  XXX
+         *   (0,0)  |XXX
+         *                 (evalScore)
+         */
+        piecewiseLinearFunction = nativeformat::param::createParam(control_constants::FUZZY_FALSE, control_constants::FUZZY_TRUE, control_constants::FUZZY_FALSE, "positionGoalShot");
+        piecewiseLinearFunction->setYAtX(control_constants::FUZZY_FALSE, 0.0);
+        piecewiseLinearFunction->linearRampToYAtX(control_constants::FUZZY_TRUE, 1);
+        piecewiseLinearFunction->setYAtX(control_constants::FUZZY_TRUE, 1);
+    }
+
+    uint8_t GoalShotEvaluation::metricCheck(double vis, double dist, double angle) const noexcept {
+        /**
+         * Visibility, Root-Function -> Favor Higher visibility
+         * Too low vis means not a valid pos, difference between higher vis doesnt matter as much (not linear), high vis is caped.
+         */
+        double evalScore = std::max(std::min(0.7,vis)/0.7,0.0)
+                /**
+                 * Distance, Linear-Factor -> Favor closer
+                 * Closer is better, caps at far distances
+                 */
+                 * std::max(std::min(5.0,(7-dist))/5,0.0)
+                 /**
+                  * Angle, Linear -> Favor in front
+                  * In front in better
+                  */
+                  * std::max(std::min(M_PI_2-angle,M_PI_4)/M_PI_4,0.0);
+        return calculateMetric(evalScore);
+    }
+
+    uint8_t GoalShotEvaluation::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }
+}

--- a/src/stp/evaluations/position/LineOfSightEvaluation.cpp
+++ b/src/stp/evaluations/position/LineOfSightEvaluation.cpp
@@ -4,7 +4,6 @@
 
 #include <cmath>
 #include "include/roboteam_ai/stp/evaluations/position/LineOfSightEvaluation.h"
-#include <iostream>
 
 namespace rtt::ai::stp::evaluation {
     LineOfSightEvaluation::LineOfSightEvaluation() noexcept {

--- a/src/stp/evaluations/position/LineOfSightEvaluation.cpp
+++ b/src/stp/evaluations/position/LineOfSightEvaluation.cpp
@@ -1,0 +1,51 @@
+//
+// Created by maxl on 19-03-21.
+//
+
+#include <cmath>
+#include "include/roboteam_ai/stp/evaluations/position/LineOfSightEvaluation.h"
+#include <iostream>
+
+namespace rtt::ai::stp::evaluation {
+    LineOfSightEvaluation::LineOfSightEvaluation() noexcept {
+        /**
+         * Creates a piecewise linear function that looks as follows:
+         *
+         * (0,255)  |XXX
+         *          |   XXX
+         *          |      XXX
+         *          |         XXX
+         *   (0,0)  |------------XXX
+         *                 (evalScore)
+         */
+        piecewiseLinearFunction = nativeformat::param::createParam(control_constants::FUZZY_FALSE, control_constants::FUZZY_TRUE, control_constants::FUZZY_FALSE, "positionLineOfSight");
+        piecewiseLinearFunction->setYAtX(control_constants::FUZZY_TRUE, 0.0);
+        piecewiseLinearFunction->linearRampToYAtX(control_constants::FUZZY_FALSE, 50.0);
+        piecewiseLinearFunction->setYAtX(control_constants::FUZZY_FALSE, 50.0);
+    }
+
+    uint8_t LineOfSightEvaluation::metricCheck(double pDist, std::vector<double>& eDists, std::vector<double>& eAngles) const noexcept {
+        double evalScore = 0;
+        /**
+         *      /\                                            The positions in side the areas are evaluated.
+         *    /   \            __________-----------------|
+         *  /     |------------                           |    1. If there is a robot close and in front of the ball (1),
+         * B   1   ==================== 2================ T       OR the angle is near 0 (so in path) the position is
+         *  \     |------------__________                 |       returned as BAD = 0.
+         *    \   /                      -----------------|    2. If there is a robot in side (2), there angle is evaluated.
+         *      \/
+         */
+        for (int i = 0; i < eAngles.size(); i++){
+            if (eDists[i] < pDist && std::abs(eAngles[i])<M_PI_2/3) { // 30 degrees
+                if (eDists[i] < control_constants::DISTANCE_TO_ROBOT_FAR || std::abs(eAngles[i])<M_PI_2/18){ // 5 degrees
+                    return 0;
+                } else {
+                    evalScore += pow((M_PI_2/3/std::abs(eAngles[i])),2);
+                }
+            }
+        }
+        return calculateMetric(evalScore);
+    }
+
+    uint8_t LineOfSightEvaluation::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }
+}

--- a/src/stp/evaluations/position/OpennessEvaluation.cpp
+++ b/src/stp/evaluations/position/OpennessEvaluation.cpp
@@ -1,0 +1,44 @@
+//
+// Created by maxl on 19-03-21.
+//
+
+#include "include/roboteam_ai/stp/evaluations/position/OpennessEvaluation.h"
+
+namespace rtt::ai::stp::evaluation {
+OpennessEvaluation::OpennessEvaluation() noexcept {
+    /**
+     * Creates a piecewise linear function that looks as follows:
+     *
+     * (0,255)  |XXX
+     *          |   XXX
+     *          |      XXX
+     *          |         XXX
+     *   (0,0)  |------------XXX
+     *                 (evalScore)
+     */
+    piecewiseLinearFunction = nativeformat::param::createParam(control_constants::FUZZY_FALSE, control_constants::FUZZY_TRUE, control_constants::FUZZY_FALSE, "positionOpenness");
+    piecewiseLinearFunction->setYAtX(control_constants::FUZZY_TRUE, 0.0);
+    piecewiseLinearFunction->linearRampToYAtX(control_constants::FUZZY_FALSE, 2.5);
+    piecewiseLinearFunction->setYAtX(control_constants::FUZZY_FALSE, 2.5);
+}
+
+uint8_t OpennessEvaluation::metricCheck(std::vector<double>& enemyDistances) const noexcept {
+    double evalScore = 0.0;
+    /**
+     * Limit the ranges from 2.5 to 0.5. [y = 1/x - 0.4]
+     * (0,1.6)  |XX
+     *          |  X
+     *          |   X
+     *          |    XX
+     *          |      XXX
+     *   (0,0)  |---------XXXXXX
+     *              (Distance from Position)
+     */
+    for (auto& distance : enemyDistances){
+        evalScore += 1/((distance < 0.5) ? 0.5 : (distance > 2.5) ? 2.5 : distance)-0.4;
+    }
+    return calculateMetric(evalScore);
+}
+
+uint8_t OpennessEvaluation::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }
+}

--- a/src/stp/evaluations/position/TimeToPositionEvaluation.cpp
+++ b/src/stp/evaluations/position/TimeToPositionEvaluation.cpp
@@ -26,7 +26,7 @@ namespace rtt::ai::stp::evaluation {
     uint8_t TimeToPositionEvaluation::metricCheck(std::optional<world::view::RobotView> robot1, std::optional<world::view::RobotView> robot2, Vector2 point) const noexcept {
         if (!robot1.has_value()) return 0;
         if (!robot2.has_value()) return 255;
-        //TODO when new path-planning is implemented use integrated functions
+        //TODO when new path-planning is implemented use integrated functions, for now stupid, later path-planning
         double r1TimeEst = (point-robot1.value()->getPos()).length();
         double r2TimeEst = (point-robot2.value()->getPos()).length();
         return calculateMetric(r2TimeEst/r1TimeEst);

--- a/src/stp/evaluations/position/TimeToPositionEvaluation.cpp
+++ b/src/stp/evaluations/position/TimeToPositionEvaluation.cpp
@@ -1,0 +1,36 @@
+//
+// Created by maxl on 24-03-21.
+//
+
+#include "include/roboteam_ai/stp/evaluations/position/TimeToPositionEvaluation.h"
+
+namespace rtt::ai::stp::evaluation {
+    TimeToPositionEvaluation::TimeToPositionEvaluation() noexcept {
+        /**
+         * Creates a piecewise linear function that looks as follows:
+         *
+         * (0,255)  |           XXXX
+         *          |         XX
+         *          |       XX
+         *          |     XX
+         *   (0,0)  |XXXXX
+         *          ---|0.8|1|1.2|--
+         *                 (Ratio)
+         */
+        piecewiseLinearFunction = nativeformat::param::createParam(control_constants::FUZZY_FALSE, control_constants::FUZZY_TRUE, control_constants::FUZZY_FALSE, "PositionTimeCompareToPoint");
+        piecewiseLinearFunction->setYAtX(control_constants::FUZZY_FALSE, 0.8);
+        piecewiseLinearFunction->linearRampToYAtX(control_constants::FUZZY_TRUE, 1.2);
+        piecewiseLinearFunction->setYAtX(control_constants::FUZZY_TRUE, 1.2);
+    }
+
+    uint8_t TimeToPositionEvaluation::metricCheck(std::optional<world::view::RobotView> robot1, std::optional<world::view::RobotView> robot2, Vector2 point) const noexcept {
+        if (!robot1.has_value()) return 0;
+        if (!robot2.has_value()) return 255;
+        //TODO when new path-planning is implemented use integrated functions
+        double ourTimeEst = (point-robot1.value()->getPos()).length();
+        double theirTimeEst = (point-robot2.value()->getPos()).length();
+        return calculateMetric(theirTimeEst/ourTimeEst);
+    }
+
+    uint8_t TimeToPositionEvaluation::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }
+}

--- a/src/stp/evaluations/position/TimeToPositionEvaluation.cpp
+++ b/src/stp/evaluations/position/TimeToPositionEvaluation.cpp
@@ -27,9 +27,9 @@ namespace rtt::ai::stp::evaluation {
         if (!robot1.has_value()) return 0;
         if (!robot2.has_value()) return 255;
         //TODO when new path-planning is implemented use integrated functions
-        double ourTimeEst = (point-robot1.value()->getPos()).length();
-        double theirTimeEst = (point-robot2.value()->getPos()).length();
-        return calculateMetric(theirTimeEst/ourTimeEst);
+        double r1TimeEst = (point-robot1.value()->getPos()).length();
+        double r2TimeEst = (point-robot2.value()->getPos()).length();
+        return calculateMetric(r2TimeEst/r1TimeEst);
     }
 
     uint8_t TimeToPositionEvaluation::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -31,9 +31,9 @@ GetBallPossession::GetBallPossession() : Play() {
                                                                                  std::make_unique<role::Formation>(role::Formation("midfielder_0")),
                                                                                  std::make_unique<role::Formation>(role::Formation("midfielder_1")),
                                                                                  std::make_unique<role::Formation>(role::Formation("midfielder_2")),
-                                                                                 std::make_unique<role::Formation>(role::Formation("offender_0")),
-                                                                                 std::make_unique<role::Formation>(role::Formation("offender_1")),
-                                                                                 std::make_unique<role::Formation>(role::Formation("offender_2"))};
+                                                                                 std::make_unique<role::Formation>(role::Formation("waller_0")),
+                                                                                 std::make_unique<role::Formation>(role::Formation("waller_1")),
+                                                                                 std::make_unique<role::Formation>(role::Formation("waller_2"))};
 
     // initialize stpInfos
     stpInfos = std::unordered_map<std::string, StpInfo>{};
@@ -87,7 +87,7 @@ void GetBallPossession::calculateInfoForRoles() noexcept {
     int amountDefenders = 3;
     std::vector<Vector2> wallPositions = {};
     if(FieldComputations::pointIsValidPosition(field, world->getWorld().value().getBall().value()->getPos()))
-        wallPositions = computations::PositionComputations::determineWallPositions(field,world,amountDefenders);
+        wallPositions = PositionComputations::determineWallPositions(field,world,amountDefenders);
     if (!wallPositions.empty()) {
         stpInfos["waller_0"].setPositionToMoveTo(wallPositions.at(0));
         stpInfos["waller_1"].setPositionToMoveTo(wallPositions.at(1));

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -9,6 +9,7 @@
 #include "include/roboteam_ai/stp/roles/passive/Defender.h"
 #include "include/roboteam_ai/stp/roles/passive/Formation.h"
 #include "stp/roles/Keeper.h"
+#include "include/roboteam_ai/stp/evaluations/position/TimeToPositionEvaluation.h"
 
 namespace rtt::ai::stp::play {
 
@@ -55,7 +56,9 @@ uint8_t GetBallPossession::score(PlayEvaluator& playEvaluator) noexcept {
 void GetBallPossession::calculateInfoForScoredRoles(world::World* world) noexcept {
     //TODO-Jaro: Find out why GetBallPossession has a shootPos, and remove/improve if necessary
     stpInfos["ball_getter"].setPositionToShootAt(Vector2{0, 0});
-    stpInfos["ball_getter"].setRoleScore(100);
+    stpInfos["ball_getter"].setRoleScore(evaluation::TimeToPositionEvaluation().metricCheck(world->getWorld()->getRobotClosestToBall(world::us),
+                                                                                            world->getWorld()->getRobotClosestToBall(world::them),
+                                                                                            world->getWorld()->getBall().value()->getPos()));
 }
 
 void GetBallPossession::calculateInfoForRoles() noexcept {

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -77,26 +77,14 @@ void GetBallPossession::calculateInfoForRoles() noexcept {
     stpInfos["defender_2"].setEnemyRobot(world->getWorld()->getRobotClosestToPoint(field.getOurTopGoalSide(), world::them));
     stpInfos["defender_2"].setBlockDistance(BlockDistance::HALFWAY);
 
-    auto length = field.getFieldLength();
-    auto width = field.getFieldWidth();
-
     stpInfos["midfielder_0"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldBot, gen::SafePosition, field, world));
     stpInfos["midfielder_1"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldMid, gen::SafePosition, field, world));
     stpInfos["midfielder_2"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldTop, gen::SafePosition, field, world));
 
-    int amountDefenders = 3;
-    std::vector<Vector2> wallPositions = {};
-    if(FieldComputations::pointIsValidPosition(field, world->getWorld().value().getBall().value()->getPos()))
-        wallPositions = PositionComputations::determineWallPositions(field,world,amountDefenders);
-    if (!wallPositions.empty()) {
-        stpInfos["waller_0"].setPositionToMoveTo(wallPositions.at(0));
-        stpInfos["waller_1"].setPositionToMoveTo(wallPositions.at(1));
-        stpInfos["waller_2"].setPositionToMoveTo(wallPositions.at(2));
-    } else {
-        stpInfos["waller_0"].setPositionToMoveTo(Vector2(0,0));
-        stpInfos["waller_1"].setPositionToMoveTo(Vector2(0,0.2));
-        stpInfos["waller_2"].setPositionToMoveTo(Vector2(0,-0.2));
-    }
+    stpInfos["waller_0"].setPositionToMoveTo(PositionComputations::getWallPosition(0,3,field,world));
+    stpInfos["waller_1"].setPositionToMoveTo(PositionComputations::getWallPosition(1,3,field,world));
+    stpInfos["waller_2"].setPositionToMoveTo(PositionComputations::getWallPosition(2,3,field,world));
+
 }
 
 bool GetBallPossession::shouldRoleSkipEndTactic() { return false; }

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -77,9 +77,9 @@ void GetBallPossession::calculateInfoForRoles() noexcept {
     stpInfos["defender_2"].setEnemyRobot(world->getWorld()->getRobotClosestToPoint(field.getOurTopGoalSide(), world::them));
     stpInfos["defender_2"].setBlockDistance(BlockDistance::HALFWAY);
 
-    stpInfos["midfielder_0"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldBot, gen::SafePosition, field, world));
-    stpInfos["midfielder_1"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldMid, gen::SafePosition, field, world));
-    stpInfos["midfielder_2"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldTop, gen::SafePosition, field, world));
+    stpInfos["midfielder_0"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["midfielder_0"].getPositionToMoveTo(),gen::gridMidFieldBot, gen::SafePosition, field, world));
+    stpInfos["midfielder_1"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(),gen::gridMidFieldMid, gen::SafePosition, field, world));
+    stpInfos["midfielder_2"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["midfielder_2"].getPositionToMoveTo(),gen::gridMidFieldTop, gen::SafePosition, field, world));
 
     stpInfos["waller_0"].setPositionToMoveTo(PositionComputations::getWallPosition(0,3,field,world));
     stpInfos["waller_1"].setPositionToMoveTo(PositionComputations::getWallPosition(1,3,field,world));

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -80,9 +80,9 @@ void GetBallPossession::calculateInfoForRoles() noexcept {
     auto length = field.getFieldLength();
     auto width = field.getFieldWidth();
 
-    stpInfos["midfielder_0"].setPositionToMoveTo(Vector2(0.0, width / 4));
-    stpInfos["midfielder_1"].setPositionToMoveTo(Vector2(0.0, -width / 4));
-    stpInfos["midfielder_2"].setPositionToMoveTo(Vector2(-length / 8, 0.0));
+    stpInfos["midfielder_0"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldBot, gen::SafePosition, field, world));
+    stpInfos["midfielder_1"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldMid, gen::SafePosition, field, world));
+    stpInfos["midfielder_2"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldTop, gen::SafePosition, field, world));
 
     int amountDefenders = 3;
     std::vector<Vector2> wallPositions = {};

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -80,9 +80,27 @@ void GetBallPossession::calculateInfoForRoles() noexcept {
     stpInfos["defender_2"].setEnemyRobot(world->getWorld()->getRobotClosestToPoint(field.getOurTopGoalSide(), world::them));
     stpInfos["defender_2"].setBlockDistance(BlockDistance::HALFWAY);
 
-    stpInfos["midfielder_0"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["midfielder_0"].getPositionToMoveTo(),gen::gridMidFieldBot, gen::SafePosition, field, world));
-    stpInfos["midfielder_1"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(),gen::gridMidFieldMid, gen::SafePosition, field, world));
-    stpInfos["midfielder_2"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["midfielder_2"].getPositionToMoveTo(),gen::gridMidFieldTop, gen::SafePosition, field, world));
+    stpInfos["midfielder_0"].setPositionToMoveTo(
+        PositionComputations::getPosition(
+            stpInfos["midfielder_0"].getPositionToMoveTo(),
+            gen::gridMidFieldBot, 
+            gen::SafePosition, 
+            field, world)
+    );
+    stpInfos["midfielder_1"].setPositionToMoveTo(
+        PositionComputations::getPosition(
+            stpInfos["midfielder_1"].getPositionToMoveTo(),
+            gen::gridMidFieldMid, 
+            gen::SafePosition, 
+            field, world)
+    );
+    stpInfos["midfielder_2"].setPositionToMoveTo(
+        PositionComputations::getPosition(
+            stpInfos["midfielder_2"].getPositionToMoveTo(),
+            gen::gridMidFieldTop, 
+            gen::SafePosition, 
+            field, world)
+    );
 
     stpInfos["waller_0"].setPositionToMoveTo(PositionComputations::getWallPosition(0,3,field,world));
     stpInfos["waller_1"].setPositionToMoveTo(PositionComputations::getWallPosition(1,3,field,world));

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -81,8 +81,8 @@ void AttackingPass::calculateInfoForScoredRoles(world::World* world) noexcept {
     rtt::world::Field field = world->getField().value();
 
     // Receiver
-    stpInfos["receiver_left"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridRightBot, gen::GoalShootPosition, field, world));
-    stpInfos["receiver_right"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridRightTop, gen::GoalShootPosition, field, world));
+    stpInfos["receiver_left"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["receiver_left"].getPositionToMoveTo(), gen::gridRightBot, gen::GoalShootPosition, field, world));
+    stpInfos["receiver_right"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["receiver_right"].getPositionToMoveTo(),gen::gridRightTop, gen::GoalShootPosition, field, world));
     }
 
 void AttackingPass::calculateInfoForRoles() noexcept {
@@ -112,8 +112,8 @@ void AttackingPass::calculateInfoForRoles() noexcept {
     }
 
     /// Midfielders
-    stpInfos["midfielder_1"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldBot, gen::SafePosition, field, world));
-    stpInfos["midfielder_2"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldTop, gen::SafePosition, field, world));
+    stpInfos["midfielder_1"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(),gen::gridMidFieldBot, gen::SafePosition, field, world));
+    stpInfos["midfielder_2"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["midfielder_2"].getPositionToMoveTo(),gen::gridMidFieldTop, gen::SafePosition, field, world));
 }
 
 std::vector<Vector2> AttackingPass::calculateDefensivePositions(int numberOfDefenders, world::World* world, std::vector<world::view::RobotView> enemyRobots) {

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -79,14 +79,10 @@ Dealer::FlagMap AttackingPass::decideRoleFlags() const noexcept {
 
 void AttackingPass::calculateInfoForScoredRoles(world::World* world) noexcept {
     rtt::world::Field field = world->getField().value();
-    PositionComputations::ScoredPosition receiverPositionRight = PositionComputations::getPosition(PositionComputations::gridRightBot, PositionComputations::GoalShootPosition, field, world);
-    PositionComputations::ScoredPosition receiverPositionLeft = PositionComputations::getPosition(PositionComputations::gridRightTop, PositionComputations::GoalShootPosition, field, world);
 
     // Receiver
-    stpInfos["receiver_left"].setPositionToMoveTo(receiverPositionLeft.position);
-    stpInfos["receiver_left"].setRoleScore(receiverPositionLeft.score);
-    stpInfos["receiver_right"].setPositionToMoveTo(receiverPositionRight.position);
-    stpInfos["receiver_right"].setRoleScore(receiverPositionRight.score);
+    stpInfos["receiver_left"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridRightBot, gen::GoalShootPosition, field, world));
+    stpInfos["receiver_right"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridRightTop, gen::GoalShootPosition, field, world));
     }
 
 void AttackingPass::calculateInfoForRoles() noexcept {
@@ -116,8 +112,8 @@ void AttackingPass::calculateInfoForRoles() noexcept {
     }
 
     /// Midfielders
-    stpInfos["midfielder_1"].setPositionToMoveTo(PositionComputations::getPosition(PositionComputations::gridMidFieldBot, PositionComputations::SafePosition, field, world).position);
-    stpInfos["midfielder_2"].setPositionToMoveTo(PositionComputations::getPosition(PositionComputations::gridMidFieldTop, PositionComputations::SafePosition, field, world).position);
+    stpInfos["midfielder_1"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldBot, gen::SafePosition, field, world));
+    stpInfos["midfielder_2"].setPositionToMoveTo(PositionComputations::getPosition(gen::gridMidFieldTop, gen::SafePosition, field, world));
 }
 
 std::vector<Vector2> AttackingPass::calculateDefensivePositions(int numberOfDefenders, world::World* world, std::vector<world::view::RobotView> enemyRobots) {

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -14,20 +14,8 @@
 #include "stp/roles/Keeper.h"
 #include "include/roboteam_ai/stp/roles/active/PassReceiver.h"
 #include "include/roboteam_ai/stp/roles/active/Passer.h"
-#include "stp/computations/PositionComputations.h"
 
 namespace rtt::ai::stp::play {
-
-    void AttackingPass::onInitialize() noexcept {
-        // Make sure we reset the passerShot flag
-        passerShot = false;
-
-        // Make sure we calculate pass positions at least once
-        receiverPositionRight = computations::PositionComputations::determineBestLineOfSightPosition(gridRight, field, world);
-        receiverPositionLeft = computations::PositionComputations::determineBestLineOfSightPosition(gridLeft, field, world);
-        passingPosition = receiverPositionRight.position;
-    }
-
 AttackingPass::AttackingPass() : Play() {
     startPlayEvaluation.clear();
     startPlayEvaluation.emplace_back(GlobalEvaluation::NormalPlayGameState);
@@ -78,8 +66,8 @@ Dealer::FlagMap AttackingPass::decideRoleFlags() const noexcept {
     flagMap.insert({"passer", {DealerFlagPriority::REQUIRED,{passerFlag}}});
     flagMap.insert({"receiver_left", {DealerFlagPriority::HIGH_PRIORITY, {receiverFlag}}});
     flagMap.insert({"receiver_right", {DealerFlagPriority::HIGH_PRIORITY, {receiverFlag}}});
-    flagMap.insert({"midfielder_1", {DealerFlagPriority::LOW_PRIORITY, {}}});
-    flagMap.insert({"midfielder_2", {DealerFlagPriority::LOW_PRIORITY, {}}});
+    flagMap.insert({"midfielder_1", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"midfielder_2", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
     flagMap.insert({"test_role_5", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"test_role_6", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"test_role_7", {DealerFlagPriority::LOW_PRIORITY, {}}});
@@ -91,17 +79,14 @@ Dealer::FlagMap AttackingPass::decideRoleFlags() const noexcept {
 
 void AttackingPass::calculateInfoForScoredRoles(world::World* world) noexcept {
     rtt::world::Field field = world->getField().value();
-    /// Recalculate pass positions if we did not shoot yet
-    /// For the receive locations, divide the field up into grids where the passers should stand,
-    /// and find the best locations in those grids
-    receiverPositionRight = computations::PositionComputations::determineBestGoalShotLocation(gridRight, field, world);
-    receiverPositionLeft = computations::PositionComputations::determineBestGoalShotLocation(gridLeft, field, world);
+    PositionComputations::ScoredPosition receiverPositionRight = PositionComputations::getPosition(PositionComputations::gridRightBot, PositionComputations::GoalShootPosition, field, world);
+    PositionComputations::ScoredPosition receiverPositionLeft = PositionComputations::getPosition(PositionComputations::gridRightTop, PositionComputations::GoalShootPosition, field, world);
 
     // Receiver
-    stpInfos["receiver_left"].setPositionToMoveTo(receiverPositionLeft.first);
-    stpInfos["receiver_left"].setRoleScore(receiverPositionLeft.second);
-    stpInfos["receiver_right"].setPositionToMoveTo(receiverPositionRight.first);
-    stpInfos["receiver_right"].setRoleScore(receiverPositionRight.second);
+    stpInfos["receiver_left"].setPositionToMoveTo(receiverPositionLeft.position);
+    stpInfos["receiver_left"].setRoleScore(receiverPositionLeft.score);
+    stpInfos["receiver_right"].setPositionToMoveTo(receiverPositionRight.position);
+    stpInfos["receiver_right"].setRoleScore(receiverPositionRight.score);
     }
 
 void AttackingPass::calculateInfoForRoles() noexcept {
@@ -113,7 +98,7 @@ void AttackingPass::calculateInfoForRoles() noexcept {
 
     /// Passer and receivers
     // calculate all info necessary to execute a pass
-    calculateInfoForPass(ball);
+    //calculateInfoForPass(ball);
 
     /// Defenders
     // Calculate most important positions to defend
@@ -131,16 +116,8 @@ void AttackingPass::calculateInfoForRoles() noexcept {
     }
 
     /// Midfielders
-    if (stpInfos["midfielder_1"].getRobot() && stpInfos["midfielder_2"].getRobot()) {
-        stpInfos["midfielder_2"].setAngle((ball->getPos() - stpInfos["midfielder_2"].getRobot()->get()->getPos()).angle());
-        stpInfos["midfielder_1"].setAngle((ball->getPos() - stpInfos["midfielder_1"].getRobot()->get()->getPos()).angle());
-    }
-    auto fieldWidth = field.getFieldWidth();
-
-    auto searchGridLeft = Grid(-0.15 * fieldWidth, 0, 0.25 * fieldWidth, 1.5, 3, 3);
-    auto searchGridRight = Grid(-0.25 * fieldWidth, -1.5, 0.25 * fieldWidth, 1.5, 3, 3);
-    stpInfos["midfielder_1"].setPositionToMoveTo(computations::PositionComputations::determineBestOpenPosition(searchGridRight, field, world).position);
-    stpInfos["midfielder_2"].setPositionToMoveTo(computations::PositionComputations::determineBestOpenPosition(searchGridLeft, field, world).position);
+    stpInfos["midfielder_1"].setPositionToMoveTo(PositionComputations::getPosition(PositionComputations::gridMidFieldBot, PositionComputations::SafePosition, field, world).position);
+    stpInfos["midfielder_2"].setPositionToMoveTo(PositionComputations::getPosition(PositionComputations::gridMidFieldTop, PositionComputations::SafePosition, field, world).position);
 }
 
 std::vector<Vector2> AttackingPass::calculateDefensivePositions(int numberOfDefenders, world::World* world, std::vector<world::view::RobotView> enemyRobots) {
@@ -162,48 +139,49 @@ bool AttackingPass::shouldRoleSkipEndTactic() { return false; }
 
 const char* AttackingPass::getName() { return "AttackingPass"; }
 
-void AttackingPass::calculateInfoForPass(const world::ball::Ball* ball) noexcept {
-    /// Recalculate pass positions if we did not shoot yet
-        /// For the receive locations, divide the field up into grids where the passers should stand,
-        /// and find the best locations in those grids
-        receiverPositionRight = computations::PositionComputations::determineBestGoalShotLocation(gridRight, field, world);
-        receiverPositionLeft = computations::PositionComputations::determineBestGoalShotLocation(gridLeft, field, world);
-        std::vector<computations::PositionComputations::PositionEvaluation> positions = {receiverPositionLeft,receiverPositionRight};
+/// Should become new play that receives ball
+//void AttackingPass::calculateInfoForPass(const world::ball::Ball* ball) noexcept {
+//    /// Recalculate pass positions if we did not shoot yet
+//        /// For the receive locations, divide the field up into grids where the passers should stand,
+//        /// and find the best locations in those grids
+//        receiverPositionRight = computations::PositionComputations::determineBestGoalShotLocation(gridRight, field, world);
+//        receiverPositionLeft = computations::PositionComputations::determineBestGoalShotLocation(gridLeft, field, world);
+//        std::vector<computations::PositionComputations::PositionEvaluation> positions = {receiverPositionLeft,receiverPositionRight};
+//
+//        Vector2 passLocation = computations::PassComputations::determineBestPosForPass(positions);
+//    /// Receiver should intercept when constraints are met
+//    if (ball->getVelocity().length() > control_constants::HAS_KICKED_ERROR_MARGIN) {
+//        receiverPositionLeft.position = Line(ball->getPos(), ball->getPos() + ball->getFilteredVelocity()).project(passingPosition);
+//    } else if (ball->getVelocity().length() > control_constants::HAS_KICKED_ERROR_MARGIN) {
+//        receiverPositionRight.position = Line(ball->getPos(), ball->getPos() + ball->getFilteredVelocity()).project(passingPosition);
+//    }
+//
+//    // Receiver
+//    stpInfos["receiver_left"].setPositionToMoveTo(receiverPositionLeft.position);
+//    stpInfos["receiver_right"].setPositionToMoveTo(receiverPositionRight.position);
+//
+//    // decide kick or chip
+//    auto passLine = Tube(ball->getPos(), passingPosition, control_constants::ROBOT_CLOSE_TO_POINT / 2);
+//    auto allBots = world->getWorld()->getRobotsNonOwning();
+//    // For all bots except passer and receivers, check if they are on the pass line, aka robot should chip
+//    if (std::any_of(allBots.begin(), allBots.end(), [&](const auto& bot) {
+//            if ((stpInfos["passer"].getRobot() && bot->getId() == stpInfos["passer"].getRobot()->get()->getId()) ||
+//                (stpInfos["receiver_left"].getRobot() && bot->getId() == stpInfos["receiver_left"].getRobot()->get()->getId()) ||
+//                (stpInfos["receiver_right"].getRobot() && bot->getId() == stpInfos["receiver_right"].getRobot()->get()->getId())) {
+//                return false;
+//            }
+//            return passLine.contains(bot->getPos());
+//        })) {
+//        stpInfos["passer"].setKickOrChip(KickOrChip::CHIP);
+//    } else {
+//        stpInfos["passer"].setKickOrChip(KickOrChip::KICK);
+//    }
+//    // Passer
+//    stpInfos["passer"].setPositionToShootAt(passingPosition);
+//    stpInfos["passer"].setShotType(ShotType::TARGET);
+//}
 
-        Vector2 passLocation = computations::PassComputations::determineBestPosForPass(positions);
-    /// Receiver should intercept when constraints are met
-    if (ball->getVelocity().length() > control_constants::HAS_KICKED_ERROR_MARGIN) {
-        receiverPositionLeft.position = Line(ball->getPos(), ball->getPos() + ball->getFilteredVelocity()).project(passingPosition);
-    } else if (ball->getVelocity().length() > control_constants::HAS_KICKED_ERROR_MARGIN) {
-        receiverPositionRight.position = Line(ball->getPos(), ball->getPos() + ball->getFilteredVelocity()).project(passingPosition);
-    }
-  
-    // Receiver
-    stpInfos["receiver_left"].setPositionToMoveTo(receiverPositionLeft.position);
-    stpInfos["receiver_right"].setPositionToMoveTo(receiverPositionRight.position);
-
-    // decide kick or chip
-    auto passLine = Tube(ball->getPos(), passingPosition, control_constants::ROBOT_CLOSE_TO_POINT / 2);
-    auto allBots = world->getWorld()->getRobotsNonOwning();
-    // For all bots except passer and receivers, check if they are on the pass line, aka robot should chip
-    if (std::any_of(allBots.begin(), allBots.end(), [&](const auto& bot) {
-            if ((stpInfos["passer"].getRobot() && bot->getId() == stpInfos["passer"].getRobot()->get()->getId()) ||
-                (stpInfos["receiver_left"].getRobot() && bot->getId() == stpInfos["receiver_left"].getRobot()->get()->getId()) ||
-                (stpInfos["receiver_right"].getRobot() && bot->getId() == stpInfos["receiver_right"].getRobot()->get()->getId())) {
-                return false;
-            }
-            return passLine.contains(bot->getPos());
-        })) {
-        stpInfos["passer"].setKickOrChip(KickOrChip::CHIP);
-    } else {
-        stpInfos["passer"].setKickOrChip(KickOrChip::KICK);
-    }
-    // Passer
-    stpInfos["passer"].setPositionToShootAt(passingPosition);
-    stpInfos["passer"].setShotType(ShotType::TARGET);
-}
-
-/// To be reimplemented
+/// To be reimplemented, removed as the implementation of the default isValidPlayToStart is changing
 //bool AttackingPass::isValidPlayToStart(PlayEvaluator* playEvaluator) noexcept {
 //    auto closestToBall = world->getWorld()->getRobotClosestToBall();
 //    auto canKeep = std::all_of(keepPlayInvariants.begin(), keepPlayInvariants.end(), [world, field](auto& x) { return x->checkInvariant(world->getWorld().value(), &field); }) &&

--- a/src/stp/roles/active/Passer.cpp
+++ b/src/stp/roles/active/Passer.cpp
@@ -11,6 +11,6 @@ namespace rtt::ai::stp::role {
 
 Passer::Passer(std::string name) : Role(std::move(name)) {
     // create state machine and initializes the first state
-    robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::GetBall(), tactic::ShootAtPos()};
+    robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::GetBall()}; //, tactic::ShootAtPos()};
 }
 }  // namespace rtt::ai::stp::role

--- a/src/stp/tactics/TestTactic.cpp
+++ b/src/stp/tactics/TestTactic.cpp
@@ -4,43 +4,19 @@
 
 #include "stp/tactics/TestTactic.h"
 
-#include "stp/skills/GoToPos.h"
+#include "stp/skills/Rotate.h"
 
 namespace rtt::ai::stp {
 
 TestTactic::TestTactic() {
     // Create state machine of skills and initialize first skill
-    skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::GoToPos(), skill::GoToPos(), skill::GoToPos(), skill::GoToPos()};
+    skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate()};
 }
 
 std::optional<StpInfo> TestTactic::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
     if (!skillStpInfo.getField()) return std::nullopt;
-
-    auto length = skillStpInfo.getField()->getFieldLength();
-    auto width = skillStpInfo.getField()->getFieldWidth();
-
-    // Set positions based on the current_num() of the state machine
-    // This switch will let a robot drive in a square
-    switch (skills.current_num()) {
-        case 0:
-            skillStpInfo.setPositionToMoveTo(Vector2(length / 8, width / 8));
-            break;
-        case 1:
-            skillStpInfo.setPositionToMoveTo(Vector2(length / 8, -width / 8));
-            break;
-        case 2:
-            skillStpInfo.setPositionToMoveTo(Vector2(-length / 8, -width / 8));
-            break;
-        case 3:
-            skillStpInfo.setPositionToMoveTo(Vector2(-length / 8, width / 8));
-            break;
-        case 4:
-            skillStpInfo.setPositionToMoveTo(Vector2(length / 8, width / 8));
-            skills.reset();
-            break;
-    }
-
+    skillStpInfo.setAngle(0.1);
     return skillStpInfo;
 }
 
@@ -50,7 +26,7 @@ bool TestTactic::shouldTacticReset(const StpInfo &info) noexcept { return false;
 
 bool TestTactic::isEndTactic() noexcept {
     // This is not an end tactic
-    return false;
+    return true;
 }
 
 const char *TestTactic::getName() { return "Test Tactic"; }

--- a/src/world/FieldComputations.cpp
+++ b/src/world/FieldComputations.cpp
@@ -196,5 +196,15 @@ std::vector<LineSegment> FieldComputations::mergeBlockades(std::vector<LineSegme
     return blockades;
 }
 
+Vector2 FieldComputations::placePointInField(const rtt_world::Field &field, const Vector2 &point){
+    if (pointIsValidPosition(field,point)) return point;
+    Vector2 fixedPoint = point;
+    if (point.y > field.getTopLeftCorner().y) fixedPoint.y = field.getTopLeftCorner().y; //Top
+    if (point.x > field.getBottomRightCorner().x) fixedPoint.x =field.getBottomRightCorner().x; //Right
+    if (point.y > field.getBottomRightCorner().y) fixedPoint.y = field.getBottomRightCorner().y; //Bot
+    if (point.x < field.getTopLeftCorner().x) fixedPoint.x = field.getTopLeftCorner().x; //Left
+    return fixedPoint;
+}
+
 }  // namespace ai
 }  // namespace rtt


### PR DESCRIPTION
### Summary
Generalized position computations for a more modular functions to be used in play creation. Made the function more efficient and split up the computations and evaluations from each other. Added functionality where positions are only calculated a single time and then saved for the rest of the tick.

### Related issues
When picking a new play to change to, the important positions of the active roles will be computed and evaluated. Before the information of each computation was not saved and it would do the same computations for each alike play. Now the base score of each position is saved in a map where the weights for a particular profile (combination of weights) is used.

The efficiency and effectiveness of the position evaluations have been increased.