### PR TITLE
MacOS support and build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,8 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(roboteam_ai)
 
 add_subdirectory(src)
 
-include(LocateQt5)
 set(CMAKE_AUTORCC OFF)
 set(CMAKE_AUTOUIC OFF)
 set(CMAKE_INCLUDE_CURRENT_DIR OFF) #Find includes in corresponding build directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,19 +2,15 @@ cmake_minimum_required(VERSION 3.10)
 project(roboteam_ai)
 
 add_subdirectory(src)
-# QT settings
-set(CMAKE_INCLUDE_CURRENT_DIR ON) #Find includes in corresponding build directories
-set(CMAKE_AUTOMOC ON) #Instruct CMake to run moc automatically when needed
-set(CMAKE_AUTOUIC OFF) #Create code from a list of Qt designer ui files
+
+include(LocateQt5)
+set(CMAKE_AUTORCC OFF)
+set(CMAKE_AUTOUIC OFF)
+set(CMAKE_INCLUDE_CURRENT_DIR OFF) #Find includes in corresponding build directories
 
 #for MacOS X or iOS, watchOS, tvOS(since 3.10.3)
 if (APPLE)
-    set(Qt5Widgets_DIR "/usr/local/opt/qt5/lib/cmake/Qt5Widgets")
-    set(Qt5Core_DIR "/usr/local/opt/qt/lib/cmake/Qt5Core")
-    set(Qt5Gui_DIR "/usr/local/opt/qt/lib/cmake/Qt5Gui")
-    SET(Qt5Charts_DIR "/usr/local/opt/qt/lib/cmake/Qt5Charts")
-    find_package(Qt5Core REQUIRED)
-    find_package(Qt5Gui REQUIRED)
+    set(CMAKE_AUTOMOC OFF)
     set(GTEST_LIB
             /usr/local/lib/libgtest.a
             /usr/local/lib/libgtest_main.a
@@ -22,15 +18,14 @@ if (APPLE)
             /usr/local/lib/libgmock_main.a
             )
 else (NOT APPLE)
-    SET(Qt5Widgets_DIR "/usr/include/x86_64-linux-gnu/qt5/QtWidgets")
-    SET(Qt5Charts_DIR "/usr/include/x86_64-linux-gnu/qt5/QtCharts")
+    set(CMAKE_AUTOMOC ON)
     set(GTEST_LIB
             PRIVATE gtest
             PRIVATE gmock)
 endif ()
 
-find_package(Qt5Charts REQUIRED)
-find_package(Qt5Widgets REQUIRED)
+find_package(Qt5 COMPONENTS Core Widgets Gui Charts REQUIRED)
+
 
 set(UTILS_SOURCES
         ${PROJECT_SOURCE_DIR}/src/utilities/GameStateManager.cpp
@@ -228,6 +223,22 @@ set(TEST_SOURCES
         ${PROJECT_SOURCE_DIR}/test/StpTests/TacticTests.cpp
         test/ControlTests/BBTrajectory/BBTrajectory1DTest.cpp)
 
+set(INTERFACE_HEADERS
+        #QT wants to know about these headers
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/PidBox.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/PidsWidget.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/MainControlsWidget.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/mainWindow.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/RobotsWidget.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/RuleSetWidget.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/STPVisualizerWidget.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/VisualizationSettingsWidget.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/widget.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/SettingsWidget.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/ManualControlWidget.h
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/PlaysWidget.hpp
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/GraphWidget.h
+        )
 
 set(INTERFACE_SOURCES
         ${PROJECT_SOURCE_DIR}/src/interface/widgets/mainWindow.cpp
@@ -246,20 +257,6 @@ set(INTERFACE_SOURCES
         ${PROJECT_SOURCE_DIR}/src/interface/widgets/SettingsWidget.cpp
         ${PROJECT_SOURCE_DIR}/src/interface/widgets/ManualControlWidget.cpp
         ${PROJECT_SOURCE_DIR}/src/interface/widgets/PlaysWidget.cpp
-
-        #QT wants to know about these headers
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/PidBox.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/PidsWidget.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/MainControlsWidget.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/mainWindow.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/RobotsWidget.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/RuleSetWidget.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/STPVisualizerWidget.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/VisualizationSettingsWidget.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/widget.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/SettingsWidget.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/ManualControlWidget.h
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/PlaysWidget.hpp
         )
 
 set(WORLD_SOURCES
@@ -291,6 +288,7 @@ set(AI_SOURCES
         )
 
 set(AI_LIBS
+        PRIVATE Qt5::Core
         PRIVATE Qt5::Widgets
         PRIVATE Qt5::Gui
         PRIVATE Qt5::Charts
@@ -304,13 +302,26 @@ set(AI_INCLUDES
         PRIVATE include/roboteam_ai
         )
 
+# Apple-specific fixes and separate out old interface for performance
+if(APPLE)
+    # AUTOMOC is borked on CMAKE 3.21.0 + moc 5.15.2 + libprotoc 3.17.3
+    # AUTOMOC tries to moc *.pb.h and fails because ./moc dislikes strange enums?
+    QT5_WRAP_CPP(ai_iface_moc ${INTERFACE_HEADERS})
+    add_library(ai_iface ${ai_iface_moc})
+else()
+    add_library(ai_iface ${INTERFACE_HEADERS})
+endif()
+
+target_link_libraries(ai_iface ${AI_LIBS})
+target_include_directories(ai_iface ${AI_INCLUDES})
+
 add_library(ai_lib ${AI_SOURCES})
 target_link_libraries(ai_lib ${AI_LIBS})
 target_include_directories(ai_lib ${AI_INCLUDES})
 
 # Main Executable
 add_executable(roboteam_ai src/roboteam_ai.cpp)
-target_link_libraries(roboteam_ai ${AI_LIBS} ai_lib)
+target_link_libraries(roboteam_ai ${AI_LIBS} ai_lib ai_iface)
 target_include_directories(roboteam_ai ${AI_INCLUDES})
 
 # Testing #

--- a/include/roboteam_ai/control/positionControl/BBTrajectories/WorldObjects.h
+++ b/include/roboteam_ai/control/positionControl/BBTrajectories/WorldObjects.h
@@ -5,10 +5,10 @@
 #ifndef RTT_WORLDOBJECTS_H
 #define RTT_WORLDOBJECTS_H
 
-#include <include/roboteam_ai/control/ControlUtils.h>
+#include "control/ControlUtils.h"
 #include "world/FieldComputations.h"
 #include "control/positionControl/BBTrajectories/BBTrajectory2D.h"
-#include <include/roboteam_ai/utilities/GameStateManager.hpp>
+#include "utilities/GameStateManager.hpp"
 #include "control/RobotCommand.h"
 
 

--- a/include/roboteam_ai/interface/widgets/MainControlsWidget.h
+++ b/include/roboteam_ai/interface/widgets/MainControlsWidget.h
@@ -5,14 +5,14 @@
 #ifndef ROBOTEAM_AI_MAINCONTROLSWIDGET_H
 #define ROBOTEAM_AI_MAINCONTROLSWIDGET_H
 
-#include <include/roboteam_ai/ApplicationManager.h>
+#include "ApplicationManager.h"
 
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QPushButton>
 #include <QtWidgets/QShortcut>
 
-#include "QLayout"
+#include <QLayout>
 #include "widget.h"
 
 namespace rtt::ai::interface {

--- a/include/roboteam_ai/interface/widgets/ManualControlWidget.h
+++ b/include/roboteam_ai/interface/widgets/ManualControlWidget.h
@@ -5,10 +5,10 @@
 #ifndef RTT_MANUALCONTROLWIDGET_H
 #define RTT_MANUALCONTROLWIDGET_H
 
-#include <include/roboteam_ai/interface/api/Toggles.h>
+#include "interface/api/Toggles.h"
 #include <QWidget>
 #include <thread>
-#include <include/roboteam_ai/manual/JoystickManager.h>
+#include "manual/JoystickManager.h"
 
 namespace rtt::ai::interface {
 class ManualControlWidget : public QWidget {

--- a/include/roboteam_ai/interface/widgets/PidBox.h
+++ b/include/roboteam_ai/interface/widgets/PidBox.h
@@ -5,7 +5,7 @@
 #ifndef ROBOTEAM_AI_PIDBOX_H
 #define ROBOTEAM_AI_PIDBOX_H
 
-#include <interface/api/Output.h>
+#include "interface/api/Output.h"
 #include <QtWidgets/QDoubleSpinBox>
 #include <QtWidgets/QGroupBox>
 #include <QtWidgets/QHBoxLayout>

--- a/include/roboteam_ai/interface/widgets/PidsWidget.h
+++ b/include/roboteam_ai/interface/widgets/PidsWidget.h
@@ -5,7 +5,7 @@
 #ifndef ROBOTEAM_AI_PIDSWIDGET_H
 #define ROBOTEAM_AI_PIDSWIDGET_H
 
-#include "QLayout"
+#include <QLayout>
 #include "widget.h"
 
 namespace rtt::ai::interface {

--- a/include/roboteam_ai/interface/widgets/RobotsWidget.h
+++ b/include/roboteam_ai/interface/widgets/RobotsWidget.h
@@ -5,7 +5,7 @@
 #ifndef ROBOTEAM_AI_ROBOTSWIDGET_H
 #define ROBOTEAM_AI_ROBOTSWIDGET_H
 
-#include "QLayout"
+#include <QLayout>
 #include "widget.h"
 #include "world/Field.h"
 

--- a/include/roboteam_ai/interface/widgets/STPVisualizerWidget.h
+++ b/include/roboteam_ai/interface/widgets/STPVisualizerWidget.h
@@ -8,7 +8,7 @@
 #include <sstream>
 
 #include <QtWidgets/QTextEdit>
-#include <include/roboteam_ai/stp/StpInfo.h>
+#include "stp/StpInfo.h"
 
 namespace rtt::ai::stp {
     class Play;

--- a/include/roboteam_ai/interface/widgets/mainWindow.h
+++ b/include/roboteam_ai/interface/widgets/mainWindow.h
@@ -14,7 +14,7 @@
 #include <QtGui>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QDoubleSpinBox>
-#include <include/roboteam_ai/world/World.hpp>
+#include "world/World.hpp"
 #include <iostream>
 #include <memory>
 

--- a/include/roboteam_ai/interface/widgets/widget.h
+++ b/include/roboteam_ai/interface/widgets/widget.h
@@ -11,11 +11,11 @@
 #include <QWidget>
 #include <memory>
 
-#include <interface/api/Toggles.h>
+#include "interface/api/Toggles.h"
 #include <roboteam_utils/Line.h>
 #include <roboteam_utils/Vector2.h>
-#include <world/Field.h>
-#include <include/roboteam_ai/world/World.hpp>
+#include "world/Field.h"
+#include "world/World.hpp"
 
 namespace rtt::ai::interface {
 

--- a/include/roboteam_ai/stp/roles/active/BallPlacer.h
+++ b/include/roboteam_ai/stp/roles/active/BallPlacer.h
@@ -2,8 +2,8 @@
 // Created by RobotJesse
 //
 
-#ifndef RTT_ATTACKER_H
-#define RTT_ATTACKER_H
+#ifndef RTT_BALLPLACER_H
+#define RTT_BALLPLACER_H
 
 #include "stp/Role.hpp"
 
@@ -19,4 +19,4 @@ class BallPlacer : public Role {
 };
 }  // namespace rtt::ai::stp::role
 
-#endif  // RTT_ATTACKER_H
+#endif  // RTT_BALLPLACER_H

--- a/include/roboteam_ai/utilities/IOManager.h
+++ b/include/roboteam_ai/utilities/IOManager.h
@@ -1,19 +1,18 @@
 #ifndef ROBOTEAM_AI_IO_MANAGERRRR_H
 #define ROBOTEAM_AI_IO_MANAGERRRR_H
 
-#include <iostream>
-#include <mutex>
-
-#include <roboteam_proto/State.pb.h>
+#include <networking/Publisher.h>
+#include <networking/Subscriber.h>
 #include <roboteam_proto/AICommand.pb.h>
 #include <roboteam_proto/Setting.pb.h>
+#include <roboteam_proto/State.pb.h>
 
-#include <Subscriber.h>
-#include <Publisher.h>
+#include <iostream>
+#include <mutex>
+#include <networking/Pair.hpp>
 
-#include "world/Field.h"
 #include "utilities/Constants.h"
-#include <roboteam_utils/networking/include/Pair.hpp>
+#include "world/Field.h"
 
 namespace rtt::world {
 class World;

--- a/include/roboteam_ai/utilities/IOManager.h
+++ b/include/roboteam_ai/utilities/IOManager.h
@@ -11,7 +11,7 @@
 #include <Subscriber.h>
 #include <Publisher.h>
 
-#include "include/roboteam_ai/world/Field.h"
+#include "world/Field.h"
 #include "utilities/Constants.h"
 #include <roboteam_utils/networking/include/Pair.hpp>
 

--- a/include/roboteam_ai/utilities/StrategyManager.h
+++ b/include/roboteam_ai/utilities/StrategyManager.h
@@ -9,7 +9,7 @@
 
 #include <iostream>
 #include <map>
-#include <include/roboteam_ai/world/views/WorldDataView.hpp>
+#include "world/views/WorldDataView.hpp"
 #include "Constants.h"
 #include "RefGameState.h"
 #include <roboteam_proto/messages_robocup_ssl_referee.pb.h>

--- a/include/roboteam_ai/world/BallPossession.h
+++ b/include/roboteam_ai/world/BallPossession.h
@@ -1,9 +1,9 @@
 #ifndef ROBOTEAM_AI_BALLPOSSESSION_H
 #define ROBOTEAM_AI_BALLPOSSESSION_H
 
-#include <include/roboteam_ai/world/views/WorldDataView.hpp>
+#include "world/views/WorldDataView.hpp"
 #include "Field.h"
-#include "gtest/gtest_prod.h"
+#include <gtest/gtest_prod.h>
 
 namespace rtt::ai {
 

--- a/include/roboteam_ai/world/Robot.hpp
+++ b/include/roboteam_ai/world/Robot.hpp
@@ -10,7 +10,7 @@
 
 #include "roboteam_utils/Angle.h"
 #include "Team.hpp"
-#include "include/roboteam_ai/world/views/BallView.hpp"
+#include "world/views/BallView.hpp"
 
 namespace rtt::world::robot {
 

--- a/include/roboteam_ai/world/World.hpp
+++ b/include/roboteam_ai/world/World.hpp
@@ -8,7 +8,7 @@
 #include "WorldData.hpp"
 #include "control/positionControl/PositionControl.h"
 #include <roboteam_proto/RobotFeedback.pb.h>
-#include "include/roboteam_ai/world/views/WorldDataView.hpp"
+#include "world/views/WorldDataView.hpp"
 #include <roboteam_utils/Print.h>
 
 namespace rtt::world {

--- a/include/roboteam_ai/world/WorldData.hpp
+++ b/include/roboteam_ai/world/WorldData.hpp
@@ -6,13 +6,13 @@
 #define RTT_WORLD_DATA_HPP
 
 #include <vector>
-#include <include/roboteam_ai/world/views/RobotView.hpp>
+#include "world/views/RobotView.hpp"
 
 #include <roboteam_proto/RobotFeedback.pb.h>
 #include <roboteam_proto/Setting.pb.h>
 #include <roboteam_proto/World.pb.h>
 
-#include "include/roboteam_ai/utilities/Settings.h"
+#include "utilities/Settings.h"
 
 namespace rtt::world {
 class World;

--- a/include/roboteam_ai/world/views/BallView.hpp
+++ b/include/roboteam_ai/world/views/BallView.hpp
@@ -6,7 +6,7 @@
 #define RTT_BALL_VIEW_HPP
 
 #include "roboteam_utils/Vector2.h"
-#include "include/roboteam_ai/world/Ball.hpp"
+#include "world/Ball.hpp"
 
 namespace rtt::world::view {
 

--- a/include/roboteam_ai/world/views/WorldDataView.hpp
+++ b/include/roboteam_ai/world/views/WorldDataView.hpp
@@ -9,9 +9,9 @@
 #include "BallView.hpp"
 #include "RobotView.hpp"
 #include "utilities/Constants.h"
-#include "include/roboteam_ai/world/Ball.hpp"
-#include "include/roboteam_ai/world/Team.hpp"
-#include "include/roboteam_ai/world/Robot.hpp"
+#include "world/Ball.hpp"
+#include "world/Team.hpp"
+#include "world/Robot.hpp"
 
 namespace rtt::world {
 class WorldData;

--- a/src/control/AnglePID.cpp
+++ b/src/control/AnglePID.cpp
@@ -2,7 +2,7 @@
 // Created by rolf on 01-06-21.
 //
 
-#include "include/roboteam_ai/control/AnglePID.h"
+#include "control/AnglePID.h"
 
 double rtt::AnglePID::getOutput(rtt::Angle target_angle, rtt::Angle current_angle) {
     // Calculate error; note that crossing the 'border' between two angles

--- a/src/control/ControlUtils.cpp
+++ b/src/control/ControlUtils.cpp
@@ -6,11 +6,11 @@
 
 #include <roboteam_utils/Grid.h>
 
-#include <utilities/GameStateManager.hpp>
-#include <include/roboteam_ai/world/Field.h>
+#include "utilities/GameStateManager.hpp"
+#include "world/Field.h"
 
 #include "stp/StpInfo.h"
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/World.hpp"
 
 namespace rtt::ai::control {
 /// Limits velocity to maximum velocity. it defaults to the max velocity stored in Referee.

--- a/src/control/positionControl/BBTrajectories/BBTrajectory1D.cpp
+++ b/src/control/positionControl/BBTrajectories/BBTrajectory1D.cpp
@@ -1,7 +1,7 @@
 //
 // Created by rolf on 26-09-20.
 //
-#include <include/roboteam_ai/control/positionControl/BBTrajectories/BBTrajectory1D.h>
+#include "control/positionControl/BBTrajectories/BBTrajectory1D.h"
 #include <cmath>
 
 namespace rtt::BB {

--- a/src/control/positionControl/BBTrajectories/BBTrajectory2D.cpp
+++ b/src/control/positionControl/BBTrajectories/BBTrajectory2D.cpp
@@ -3,8 +3,8 @@
 //
 
 #include <cmath>
-#include <include/roboteam_ai/control/positionControl/BBTrajectories/BBTrajectory2D.h>
-#include <include/roboteam_ai/utilities/Constants.h>
+#include "control/positionControl/BBTrajectories/BBTrajectory2D.h"
+#include "utilities/Constants.h"
 namespace rtt::BB {
 
     BBTrajectory2D::BBTrajectory2D(const Vector2 &initialPos, const Vector2 &initialVel, const Vector2 &finalPos,

--- a/src/control/positionControl/BBTrajectories/WorldObjects.cpp
+++ b/src/control/positionControl/BBTrajectories/WorldObjects.cpp
@@ -1,9 +1,9 @@
 //
 // Created by floris on 15-11-20.
 //
-#include <include/roboteam_ai/world/WorldData.hpp>
+#include "world/WorldData.hpp"
 #include <utility>
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/World.hpp"
 #include "control/positionControl/BBTrajectories/WorldObjects.h"
 #include <algorithm>
 

--- a/src/interface/api/Output.cpp
+++ b/src/interface/api/Output.cpp
@@ -4,7 +4,7 @@
 
 #include "interface/api/Output.h"
 
-#include <include/roboteam_ai/world/World.hpp>
+#include "world/World.hpp"
 
 namespace rtt::ai::interface {
 

--- a/src/interface/widgets/GraphWidget.cpp
+++ b/src/interface/widgets/GraphWidget.cpp
@@ -65,5 +65,3 @@ void GraphWidget::updateContents() {
 
 }  // namespace rtt::ai::interface
 
-// QT performance improvement
-#include "include/roboteam_ai/interface/widgets/moc_GraphWidget.cpp"

--- a/src/interface/widgets/ManualControlWidget.cpp
+++ b/src/interface/widgets/ManualControlWidget.cpp
@@ -1,4 +1,4 @@
-#include "include/roboteam_ai/interface/widgets/ManualControlWidget.h"
+#include "interface/widgets/ManualControlWidget.h"
 #include <QCheckBox>
 #include <QVBoxLayout>
 

--- a/src/interface/widgets/PlaysWidget.cpp
+++ b/src/interface/widgets/PlaysWidget.cpp
@@ -2,8 +2,8 @@
 // Created by john on 4/30/20.
 //
 
-#include <include/roboteam_ai/ApplicationManager.h>
-#include "include/roboteam_ai/interface/widgets/PlaysWidget.hpp"
+#include "ApplicationManager.h"
+#include "interface/widgets/PlaysWidget.hpp"
 
 namespace rtt::ai::interface {
     inline QString formatPlay(stp::Play* play)

--- a/src/interface/widgets/SettingsWidget.cpp
+++ b/src/interface/widgets/SettingsWidget.cpp
@@ -1,7 +1,7 @@
 
 #include "interface/widgets/SettingsWidget.h"
 
-#include <include/roboteam_ai/utilities/Settings.h>
+#include "utilities/Settings.h"
 
 #include "interface/widgets/mainWindow.h"
 

--- a/src/interface/widgets/widget.cpp
+++ b/src/interface/widgets/widget.cpp
@@ -3,7 +3,8 @@
 //
 
 #include "interface/widgets/widget.h"
-#include <utilities/GameStateManager.hpp>
+#include "utilities/GameStateManager.hpp"
+#include <QPainterPath>
 
 namespace io = rtt::ai::io;
 namespace rtt::ai::interface {

--- a/src/manual/JoystickHandler.cpp
+++ b/src/manual/JoystickHandler.cpp
@@ -1,7 +1,7 @@
 //
 // Created by luukkn on 23-10-19.
 //
-#include "include/roboteam_ai/manual/JoystickHandler.h"
+#include "manual/JoystickHandler.h"
 
 namespace rtt {
 namespace input {

--- a/src/manual/JoystickManager.cpp
+++ b/src/manual/JoystickManager.cpp
@@ -1,6 +1,6 @@
 #include "manual/JoystickManager.h"
 #include <roboteam_utils/Print.h>
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/World.hpp"
 #include "world/views/RobotView.hpp"
 
 using namespace std::chrono;

--- a/src/roboteam_ai.cpp
+++ b/src/roboteam_ai.cpp
@@ -1,6 +1,6 @@
-#include <utilities/IOManager.h>
+#include "utilities/IOManager.h"
 #include <roboteam_utils/Print.h>
-#include <include/roboteam_ai/world/World.hpp>
+#include "world/World.hpp"
 #include "ApplicationManager.h"
 
 namespace ui = rtt::ai::interface;
@@ -80,9 +80,9 @@ int main(int argc, char* argv[]) {
 
     rtt::ai::io::io.init(rtt::SETTINGS.getId());
 
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     // initialize the interface
     QApplication a(argc, argv);
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     setDarkTheme();
 
     // Todo make this a not-global-static thingy

--- a/src/stp/computations/GoalComputations.cpp
+++ b/src/stp/computations/GoalComputations.cpp
@@ -7,8 +7,8 @@
 
 #include <roboteam_utils/Grid.h>
 
-#include <include/roboteam_ai/world/Field.h>
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/Field.h"
+#include "world/World.hpp"
 
 namespace rtt::ai::stp::computations {
       Vector2 GoalComputations::calculateGoalTarget(rtt_world::World *world, const rtt_world::Field &field) {

--- a/src/stp/computations/PositionComputations.cpp
+++ b/src/stp/computations/PositionComputations.cpp
@@ -7,8 +7,8 @@
 
 #include <roboteam_utils/Grid.h>
 
-#include <include/roboteam_ai/world/Field.h>
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/Field.h"
+#include "world/World.hpp"
 
 #include "stp/evaluations/position/OpennessEvaluation.h"
 #include "stp/evaluations/position/LineOfSightEvaluation.h"

--- a/src/stp/evaluations/position/BlockingEvaluation.cpp
+++ b/src/stp/evaluations/position/BlockingEvaluation.cpp
@@ -4,7 +4,7 @@
 
 #include <cmath>
 #include <roboteam_utils/Vector2.h>
-#include "include/roboteam_ai/stp/evaluations/position/BlockingEvaluation.h"
+#include "stp/evaluations/position/BlockingEvaluation.h"
 
 namespace rtt::ai::stp::evaluation {
 BlockingEvaluation::BlockingEvaluation() noexcept {

--- a/src/stp/evaluations/position/GoalShotEvaluation.cpp
+++ b/src/stp/evaluations/position/GoalShotEvaluation.cpp
@@ -2,8 +2,9 @@
 // Created by maxl on 23-03-21.
 //
 
-#include "include/roboteam_ai/stp/evaluations/position/GoalShotEvaluation.h"
+#include "stp/evaluations/position/GoalShotEvaluation.h"
 #include <cmath>
+#include <string>
 
 namespace rtt::ai::stp::evaluation {
     GoalShotEvaluation::GoalShotEvaluation() noexcept {

--- a/src/stp/evaluations/position/LineOfSightEvaluation.cpp
+++ b/src/stp/evaluations/position/LineOfSightEvaluation.cpp
@@ -2,8 +2,9 @@
 // Created by maxl on 19-03-21.
 //
 
+#include <string>
 #include <cmath>
-#include "include/roboteam_ai/stp/evaluations/position/LineOfSightEvaluation.h"
+#include "stp/evaluations/position/LineOfSightEvaluation.h"
 
 namespace rtt::ai::stp::evaluation {
     LineOfSightEvaluation::LineOfSightEvaluation() noexcept {
@@ -17,6 +18,7 @@ namespace rtt::ai::stp::evaluation {
          *   (0,0)  |------------XXX
          *                 (evalScore)
          */
+
         piecewiseLinearFunction = nativeformat::param::createParam(control_constants::FUZZY_FALSE, control_constants::FUZZY_TRUE, control_constants::FUZZY_FALSE, "positionLineOfSight");
         piecewiseLinearFunction->setYAtX(control_constants::FUZZY_TRUE, 0.0);
         piecewiseLinearFunction->linearRampToYAtX(control_constants::FUZZY_FALSE, 50.0);

--- a/src/stp/evaluations/position/OpennessEvaluation.cpp
+++ b/src/stp/evaluations/position/OpennessEvaluation.cpp
@@ -2,7 +2,8 @@
 // Created by maxl on 19-03-21.
 //
 
-#include "include/roboteam_ai/stp/evaluations/position/OpennessEvaluation.h"
+#include <string>
+#include "stp/evaluations/position/OpennessEvaluation.h"
 
 namespace rtt::ai::stp::evaluation {
 OpennessEvaluation::OpennessEvaluation() noexcept {

--- a/src/stp/evaluations/position/TimeToPositionEvaluation.cpp
+++ b/src/stp/evaluations/position/TimeToPositionEvaluation.cpp
@@ -2,7 +2,7 @@
 // Created by maxl on 24-03-21.
 //
 
-#include "include/roboteam_ai/stp/evaluations/position/TimeToPositionEvaluation.h"
+#include "stp/evaluations/position/TimeToPositionEvaluation.h"
 
 namespace rtt::ai::stp::evaluation {
     TimeToPositionEvaluation::TimeToPositionEvaluation() noexcept {

--- a/src/stp/plays/PlayTemplate.cpp
+++ b/src/stp/plays/PlayTemplate.cpp
@@ -10,11 +10,11 @@
 /// 3. Follow the instructions of each comment
 /// 4. Remove the unused optional functions
 
-#include "include/roboteam_ai/stp/plays/PlayTemplate.h"
-#include "include/roboteam_ai/stp/roles/Keeper.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
-#include "include/roboteam_ai/stp/roles/passive/Waller.h"
-#include "include/roboteam_ai/stp/computations/PositionComputations.h"
+#include "stp/plays/PlayTemplate.h"
+#include "stp/roles/Keeper.h"
+#include "stp/roles/passive/Formation.h"
+#include "stp/roles/passive/Waller.h"
+#include "stp/computations/PositionComputations.h"
 
 namespace rtt::ai::stp::play {
     const char* PlayTemplate::getName() { return "Play Template"; }

--- a/src/stp/plays/ReflectKick.cpp
+++ b/src/stp/plays/ReflectKick.cpp
@@ -8,11 +8,11 @@
 #include "stp/evaluations/global/BallClosestToUsGlobalEvaluation.h"
 #include "stp/evaluations/global/WeHaveBallGlobalEvaluation.h"
 #include "stp/evaluations/game_states/NormalOrFreeKickUsGameStateEvaluation.h"
-#include "include/roboteam_ai/stp/roles/active/BallReflector.h"
-#include "include/roboteam_ai/stp/roles/passive/Defender.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
+#include "stp/roles/active/BallReflector.h"
+#include "stp/roles/passive/Defender.h"
+#include "stp/roles/passive/Formation.h"
 #include "stp/roles/Keeper.h"
-#include "include/roboteam_ai/stp/roles/active/Passer.h"
+#include "stp/roles/active/Passer.h"
 
 namespace rtt::ai::stp::play {
 

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -2,14 +2,14 @@
 // Created by jordi on 11-05-20.
 //
 
-#include <stp/roles/passive/Waller.h>
-#include "include/roboteam_ai/stp/plays/contested/GetBallPossession.h"
-#include "include/roboteam_ai/stp/computations/PositionComputations.h"
-#include "include/roboteam_ai/stp/roles/active/BallGetter.h"
-#include "include/roboteam_ai/stp/roles/passive/Defender.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
+#include "stp/roles/passive/Waller.h"
+#include "stp/plays/contested/GetBallPossession.h"
+#include "stp/computations/PositionComputations.h"
+#include "stp/roles/active/BallGetter.h"
+#include "stp/roles/passive/Defender.h"
+#include "stp/roles/passive/Formation.h"
 #include "stp/roles/Keeper.h"
-#include "include/roboteam_ai/stp/evaluations/position/TimeToPositionEvaluation.h"
+#include "stp/evaluations/position/TimeToPositionEvaluation.h"
 
 namespace rtt::ai::stp::play {
 

--- a/src/stp/plays/contested/GetBallRisky.cpp
+++ b/src/stp/plays/contested/GetBallRisky.cpp
@@ -2,11 +2,11 @@
 // Created by timovdk on 5/15/20.
 //
 
-#include "include/roboteam_ai/stp/plays/contested/GetBallRisky.h"
-#include "include/roboteam_ai/stp/roles/active/BallGetter.h"
-#include "include/roboteam_ai/stp/roles/passive/Defender.h"
+#include "stp/plays/contested/GetBallRisky.h"
+#include "stp/roles/active/BallGetter.h"
+#include "stp/roles/passive/Defender.h"
 #include "stp/roles/Keeper.h"
-#include "include/roboteam_ai/stp/roles/active/PassReceiver.h"
+#include "stp/roles/active/PassReceiver.h"
 
 namespace rtt::ai::stp::play {
 

--- a/src/stp/plays/defensive/DefendPass.cpp
+++ b/src/stp/plays/defensive/DefendPass.cpp
@@ -2,11 +2,11 @@
 // Created by jordi on 14-05-20.
 //
 
-#include "include/roboteam_ai/stp/plays/defensive/DefendPass.h"
+#include "stp/plays/defensive/DefendPass.h"
 
-#include "include/roboteam_ai/stp/roles/passive/Defender.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
-#include "include/roboteam_ai/stp/roles/passive/Harasser.h"
+#include "stp/roles/passive/Defender.h"
+#include "stp/roles/passive/Formation.h"
+#include "stp/roles/passive/Harasser.h"
 #include "stp/roles/Keeper.h"
 
 namespace rtt::ai::stp::play {

--- a/src/stp/plays/defensive/DefendShot.cpp
+++ b/src/stp/plays/defensive/DefendShot.cpp
@@ -2,11 +2,11 @@
 // Created by jordi on 27-03-20.
 //
 
-#include "include/roboteam_ai/stp/plays/defensive/DefendShot.h"
+#include "stp/plays/defensive/DefendShot.h"
 
-#include "include/roboteam_ai/stp/roles/passive/Defender.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
-#include "include/roboteam_ai/stp/roles/passive/Harasser.h"
+#include "stp/roles/passive/Defender.h"
+#include "stp/roles/passive/Formation.h"
+#include "stp/roles/passive/Harasser.h"
 #include "stp/roles/Keeper.h"
 #include "stp/computations/PositionComputations.h"
 

--- a/src/stp/plays/offensive/Attack.cpp
+++ b/src/stp/plays/offensive/Attack.cpp
@@ -3,11 +3,11 @@
 /// TODO-Max change to take ShootAtGoal
 //
 
-#include "include/roboteam_ai/stp/plays/offensive/Attack.h"
-#include "include/roboteam_ai/stp/computations/GoalComputations.h"
-#include "include/roboteam_ai/stp/roles/active/Attacker.h"
-#include "include/roboteam_ai/stp/roles/passive/Defender.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
+#include "stp/plays/offensive/Attack.h"
+#include "stp/computations/GoalComputations.h"
+#include "stp/roles/active/Attacker.h"
+#include "stp/roles/passive/Defender.h"
+#include "stp/roles/passive/Formation.h"
 #include "stp/roles/Keeper.h"
 
 namespace rtt::ai::stp::play {

--- a/src/stp/plays/offensive/GenericPass.cpp
+++ b/src/stp/plays/offensive/GenericPass.cpp
@@ -3,16 +3,16 @@
 /// TODO-Max specify play (Forward/Backwards/..)
 //
 
-#include "include/roboteam_ai/stp/plays/offensive/GenericPass.h"
+#include "stp/plays/offensive/GenericPass.h"
 
 #include <roboteam_utils/Tube.h>
 
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
-#include "include/roboteam_ai/stp/roles/passive/Halt.h"
+#include "stp/roles/passive/Formation.h"
+#include "stp/roles/passive/Halt.h"
 #include "stp/roles/Keeper.h"
-#include "include/roboteam_ai/stp/roles/active/PassReceiver.h"
-#include "include/roboteam_ai/stp/roles/active/Passer.h"
-#include "include/roboteam_ai/stp/roles/passive/Defender.h"
+#include "stp/roles/active/PassReceiver.h"
+#include "stp/roles/active/Passer.h"
+#include "stp/roles/passive/Defender.h"
 #include "stp/computations/PositionComputations.h"
 
 namespace rtt::ai::stp::play {

--- a/src/stp/plays/referee_specific/AggressiveStopFormation.cpp
+++ b/src/stp/plays/referee_specific/AggressiveStopFormation.cpp
@@ -2,9 +2,9 @@
 // Created by timovdk on 3/30/20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/AggressiveStopFormation.h"
-#include "include/roboteam_ai/stp/roles/passive/BallAvoider.h"
-#include "include/roboteam_ai/stp/roles/Keeper.h"
+#include "stp/plays/referee_specific/AggressiveStopFormation.h"
+#include "stp/roles/passive/BallAvoider.h"
+#include "stp/roles/Keeper.h"
 
 namespace rtt::ai::stp::play {
     AggressiveStopFormation::AggressiveStopFormation() : Play() {

--- a/src/stp/plays/referee_specific/BallPlacementThem.cpp
+++ b/src/stp/plays/referee_specific/BallPlacementThem.cpp
@@ -2,9 +2,9 @@
 // Created by jessevw on 24.03.20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/BallPlacementThem.h"
-#include "include/roboteam_ai/stp/roles/passive/BallAvoider.h"
-#include "include/roboteam_ai/stp/roles/Keeper.h"
+#include "stp/plays/referee_specific/BallPlacementThem.h"
+#include "stp/roles/passive/BallAvoider.h"
+#include "stp/roles/Keeper.h"
 
 namespace rtt::ai::stp::play {
 

--- a/src/stp/plays/referee_specific/BallPlacementUs.cpp
+++ b/src/stp/plays/referee_specific/BallPlacementUs.cpp
@@ -2,9 +2,9 @@
 // Created by jessevw on 24.03.20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/BallPlacementUs.h"
-#include "include/roboteam_ai/stp/roles/passive/BallAvoider.h"
-#include "include/roboteam_ai/stp/roles/active/BallPlacer.h"
+#include "stp/plays/referee_specific/BallPlacementUs.h"
+#include "stp/roles/passive/BallAvoider.h"
+#include "stp/roles/active/BallPlacer.h"
 #include "utilities/GameStateManager.hpp"
 
 namespace rtt::ai::stp::play {

--- a/src/stp/plays/referee_specific/DefensiveStopFormation.cpp
+++ b/src/stp/plays/referee_specific/DefensiveStopFormation.cpp
@@ -2,9 +2,9 @@
 // Created by timo on 3/27/20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/DefensiveStopFormation.h"
-#include "include/roboteam_ai/stp/roles/passive/BallAvoider.h"
-#include "include/roboteam_ai/stp/roles/Keeper.h"
+#include "stp/plays/referee_specific/DefensiveStopFormation.h"
+#include "stp/roles/passive/BallAvoider.h"
+#include "stp/roles/Keeper.h"
 
 namespace rtt::ai::stp::play {
 

--- a/src/stp/plays/referee_specific/FreeKickThem.cpp
+++ b/src/stp/plays/referee_specific/FreeKickThem.cpp
@@ -2,11 +2,11 @@
 // Created by jordi on 07-05-20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/FreeKickThem.h"
-#include "include/roboteam_ai/stp/roles/passive/Defender.h"
-#include "include/roboteam_ai/stp/computations/PositionComputations.h"
-#include "include/roboteam_ai/stp/roles/Keeper.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
+#include "stp/plays/referee_specific/FreeKickThem.h"
+#include "stp/roles/passive/Defender.h"
+#include "stp/computations/PositionComputations.h"
+#include "stp/roles/Keeper.h"
+#include "stp/roles/passive/Formation.h"
 
 namespace rtt::ai::stp::play {
 const char* FreeKickThem::getName() { return "Free Kick Them"; }

--- a/src/stp/plays/referee_specific/Halt.cpp
+++ b/src/stp/plays/referee_specific/Halt.cpp
@@ -2,10 +2,10 @@
 // Created by jessevw on 24.03.20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/Halt.h"
+#include "stp/plays/referee_specific/Halt.h"
 
 #include "stp/evaluations/game_states/HaltGameStateEvaluation.h"
-#include "include/roboteam_ai/stp/roles/passive/Halt.h"
+#include "stp/roles/passive/Halt.h"
 
 namespace rtt::ai::stp::play {
 

--- a/src/stp/plays/referee_specific/KickOffThem.cpp
+++ b/src/stp/plays/referee_specific/KickOffThem.cpp
@@ -2,8 +2,8 @@
 // Created by timovdk on 5/1/20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/KickOffThem.h"
-#include "include/roboteam_ai/stp/roles/passive/Halt.h"
+#include "stp/plays/referee_specific/KickOffThem.h"
+#include "stp/roles/passive/Halt.h"
 #include "stp/roles/Keeper.h"
 
 namespace rtt::ai::stp::play {

--- a/src/stp/plays/referee_specific/KickOffThemPrepare.cpp
+++ b/src/stp/plays/referee_specific/KickOffThemPrepare.cpp
@@ -2,8 +2,8 @@
 // Created by jordi on 30-04-20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/KickOffThemPrepare.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
+#include "stp/plays/referee_specific/KickOffThemPrepare.h"
+#include "stp/roles/passive/Formation.h"
 
 namespace rtt::ai::stp::play {
 

--- a/src/stp/plays/referee_specific/KickOffUs.cpp
+++ b/src/stp/plays/referee_specific/KickOffUs.cpp
@@ -4,8 +4,8 @@
 
 #include "stp/plays/referee_specific/KickOffUs.h"
 
-#include <include/roboteam_ai/stp/roles/passive/Formation.h>
-#include <stp/roles/active/PassReceiver.h>
+#include "stp/roles/passive/Formation.h"
+#include "stp/roles/active/PassReceiver.h"
 
 #include "stp/roles/Keeper.h"
 #include "stp/roles/active/Passer.h"

--- a/src/stp/plays/referee_specific/KickOffUsPrepare.cpp
+++ b/src/stp/plays/referee_specific/KickOffUsPrepare.cpp
@@ -2,8 +2,8 @@
 // Created by jordi on 30-04-20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/KickOffUsPrepare.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
+#include "stp/plays/referee_specific/KickOffUsPrepare.h"
+#include "stp/roles/passive/Formation.h"
 #include "stp/roles/Keeper.h"
 #include "stp/roles/passive/BallAvoider.h"
 

--- a/src/stp/plays/referee_specific/PenaltyThem.cpp
+++ b/src/stp/plays/referee_specific/PenaltyThem.cpp
@@ -2,8 +2,8 @@
 // Created by timovdk on 4/28/20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/PenaltyThem.h"
-#include "include/roboteam_ai/stp/roles/passive/Halt.h"
+#include "stp/plays/referee_specific/PenaltyThem.h"
+#include "stp/roles/passive/Halt.h"
 #include "stp/roles/PenaltyKeeper.h"
 #include "stp/roles/Keeper.h"
 

--- a/src/stp/plays/referee_specific/PenaltyThemPrepare.cpp
+++ b/src/stp/plays/referee_specific/PenaltyThemPrepare.cpp
@@ -2,8 +2,8 @@
 // Created by timovdk on 5/1/20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/PenaltyThemPrepare.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
+#include "stp/plays/referee_specific/PenaltyThemPrepare.h"
+#include "stp/roles/passive/Formation.h"
 
 namespace rtt::ai::stp::play {
 

--- a/src/stp/plays/referee_specific/PenaltyUs.cpp
+++ b/src/stp/plays/referee_specific/PenaltyUs.cpp
@@ -2,14 +2,14 @@
 // Created by timovdk on 5/1/20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/PenaltyUs.h"
+#include "stp/plays/referee_specific/PenaltyUs.h"
 
-#include <stp/roles/Keeper.h>
-#include <stp/roles/PenaltyKeeper.h>
-#include <stp/roles/active/Attacker.h>
-#include <stp/roles/passive/Halt.h>
+#include "stp/roles/Keeper.h"
+#include "stp/roles/PenaltyKeeper.h"
+#include "stp/roles/active/Attacker.h"
+#include "stp/roles/passive/Halt.h"
 
-#include "include/roboteam_ai/stp/computations/PositionComputations.h"
+#include "stp/computations/PositionComputations.h"
 
 namespace rtt::ai::stp::play {
 const char* PenaltyUs::getName() { return "Penalty Us"; }

--- a/src/stp/plays/referee_specific/PenaltyUsPrepare.cpp
+++ b/src/stp/plays/referee_specific/PenaltyUsPrepare.cpp
@@ -2,8 +2,8 @@
 // Created by timovdk on 5/1/20.
 //
 
-#include "include/roboteam_ai/stp/plays/referee_specific/PenaltyUsPrepare.h"
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
+#include "stp/plays/referee_specific/PenaltyUsPrepare.h"
+#include "stp/roles/passive/Formation.h"
 
 namespace rtt::ai::stp::play {
 

--- a/src/stp/roles/PenaltyKeeper.cpp
+++ b/src/stp/roles/PenaltyKeeper.cpp
@@ -7,10 +7,10 @@
 
 #include <roboteam_utils/Print.h>
 
-#include "include/roboteam_ai/stp/tactics/passive/Formation.h"
-#include "include/roboteam_ai/stp/tactics/active/GetBall.h"
-#include "include/roboteam_ai/stp/tactics/active/KickAtPos.h"
-#include "include/roboteam_ai/stp/tactics/active/ChipAtPos.h"
+#include "stp/tactics/passive/Formation.h"
+#include "stp/tactics/active/GetBall.h"
+#include "stp/tactics/active/KickAtPos.h"
+#include "stp/tactics/active/ChipAtPos.h"
 #include "stp/tactics/KeeperBlockBall.h"
 #include "world/FieldComputations.h"
 

--- a/src/stp/roles/active/Attacker.cpp
+++ b/src/stp/roles/active/Attacker.cpp
@@ -3,10 +3,10 @@
 /// TODO-Max change to ShooterGoal
 //
 
-#include "include/roboteam_ai/stp/roles/active/Attacker.h"
+#include "stp/roles/active/Attacker.h"
 
-#include "include/roboteam_ai/stp/tactics/active/GetBall.h"
-#include "include/roboteam_ai/stp/tactics/active/KickAtPos.h"
+#include "stp/tactics/active/GetBall.h"
+#include "stp/tactics/active/KickAtPos.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/roles/active/BallGetter.cpp
+++ b/src/stp/roles/active/BallGetter.cpp
@@ -2,10 +2,10 @@
 // Created by jordi on 11-05-20.
 //
 
-#include <stp/tactics/GetBehindBallInDirection.h>
-#include "include/roboteam_ai/stp/roles/active/BallGetter.h"
+#include "stp/tactics/GetBehindBallInDirection.h"
+#include "stp/roles/active/BallGetter.h"
 
-#include "include/roboteam_ai/stp/tactics/active/GetBall.h"
+#include "stp/tactics/active/GetBall.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/roles/active/BallPlacer.cpp
+++ b/src/stp/roles/active/BallPlacer.cpp
@@ -3,11 +3,11 @@
 /// TODO-Max check if T:AvoidBall() can be done otherwise (end of play?)
 //
 
-#include "include/roboteam_ai/stp/roles/active/BallPlacer.h"
+#include "stp/roles/active/BallPlacer.h"
 
-#include "include/roboteam_ai/stp/tactics/passive/AvoidBall.h"
-#include "include/roboteam_ai/stp/tactics/active/DriveWithBall.h"
-#include "include/roboteam_ai/stp/tactics/active/GetBall.h"
+#include "stp/tactics/passive/AvoidBall.h"
+#include "stp/tactics/active/DriveWithBall.h"
+#include "stp/tactics/active/GetBall.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/roles/active/BallReflector.cpp
+++ b/src/stp/roles/active/BallReflector.cpp
@@ -3,9 +3,9 @@
 /// TODO-Max Linked to ReflectKick, check use
 //
 
-#include "include/roboteam_ai/stp/roles/active/BallReflector.h"
+#include "stp/roles/active/BallReflector.h"
 
-#include "include/roboteam_ai/stp/tactics/active/KickAtPos.h"
+#include "stp/tactics/active/KickAtPos.h"
 #include "stp/tactics/PositionAndAim.h"
 
 namespace rtt::ai::stp::role {

--- a/src/stp/roles/active/PassReceiver.cpp
+++ b/src/stp/roles/active/PassReceiver.cpp
@@ -3,9 +3,9 @@
 /// TODO-Max require GoToPos from previous play somehow (AbstractLayer to communicate between plays?)
 //
 
-#include "include/roboteam_ai/stp/roles/active/PassReceiver.h"
+#include "stp/roles/active/PassReceiver.h"
 
-#include "include/roboteam_ai/stp/tactics/active/Receive.h"
+#include "stp/tactics/active/Receive.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/roles/active/Passer.cpp
+++ b/src/stp/roles/active/Passer.cpp
@@ -2,10 +2,10 @@
 // Created by jessevw on 17.03.20.
 //
 
-#include "include/roboteam_ai/stp/roles/active/Passer.h"
+#include "stp/roles/active/Passer.h"
 
-#include "include/roboteam_ai/stp/tactics/active/GetBall.h"
-#include "include/roboteam_ai/stp/tactics/active/ShootAtPos.h"
+#include "stp/tactics/active/GetBall.h"
+#include "stp/tactics/active/ShootAtPos.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/roles/passive/BallAvoider.cpp
+++ b/src/stp/roles/passive/BallAvoider.cpp
@@ -2,9 +2,9 @@
 // Created by jesse on 30-04-20.
 //
 
-#include "include/roboteam_ai/stp/roles/passive/BallAvoider.h"
+#include "stp/roles/passive/BallAvoider.h"
 
-#include "include/roboteam_ai/stp/tactics/passive/AvoidBall.h"
+#include "stp/tactics/passive/AvoidBall.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/roles/passive/Defender.cpp
+++ b/src/stp/roles/passive/Defender.cpp
@@ -3,9 +3,9 @@
 /// TODO-Max Fix Intercept usage in play (mimics "Oppertunic Behavior")
 //
 
-#include "include/roboteam_ai/stp/roles/passive/Defender.h"
+#include "stp/roles/passive/Defender.h"
 
-#include "include/roboteam_ai/stp/tactics/passive/BlockRobot.h"
+#include "stp/tactics/passive/BlockRobot.h"
 #include "stp/tactics/Intercept.h"
 
 namespace rtt::ai::stp::role {

--- a/src/stp/roles/passive/Formation.cpp
+++ b/src/stp/roles/passive/Formation.cpp
@@ -2,9 +2,9 @@
 // Created by timovdk on 3/27/20.
 //
 
-#include "include/roboteam_ai/stp/roles/passive/Formation.h"
+#include "stp/roles/passive/Formation.h"
 
-#include "include/roboteam_ai/stp/tactics/passive/Formation.h"
+#include "stp/tactics/passive/Formation.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/roles/passive/Halt.cpp
+++ b/src/stp/roles/passive/Halt.cpp
@@ -2,9 +2,9 @@
 // Created by jessevw on 24.03.20.
 //
 
-#include "include/roboteam_ai/stp/roles/passive/Halt.h"
+#include "stp/roles/passive/Halt.h"
 
-#include "include/roboteam_ai/stp/tactics/passive/Halt.h"
+#include "stp/tactics/passive/Halt.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/roles/passive/Harasser.cpp
+++ b/src/stp/roles/passive/Harasser.cpp
@@ -2,9 +2,9 @@
 // Created by timovdk on 3/27/20.
 //
 
-#include "include/roboteam_ai/stp/roles/passive/Harasser.h"
+#include "stp/roles/passive/Harasser.h"
 
-#include "include/roboteam_ai/stp/tactics/passive/BlockBall.h"
+#include "stp/tactics/passive/BlockBall.h"
 #include "stp/tactics/Intercept.h"
 
 namespace rtt::ai::stp::role {

--- a/src/stp/roles/passive/Waller.cpp
+++ b/src/stp/roles/passive/Waller.cpp
@@ -2,8 +2,8 @@
 // Created by maxl on 15-02-21.
 //
 
-#include <stp/tactics/passive/Walling.h>
-#include "include/roboteam_ai/stp/roles/passive/Waller.h"
+#include "stp/tactics/passive/Walling.h"
+#include "stp/roles/passive/Waller.h"
 
 namespace rtt::ai::stp::role {
 

--- a/src/stp/skills/GoToPos.cpp
+++ b/src/stp/skills/GoToPos.cpp
@@ -4,7 +4,7 @@
 
 #include "stp/skills/GoToPos.h"
 
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/World.hpp"
 
 namespace rtt::ai::stp::skill {
 

--- a/src/stp/tactics/active/ChipAtPos.cpp
+++ b/src/stp/tactics/active/ChipAtPos.cpp
@@ -5,7 +5,7 @@
 /// ACTIVE
 //
 
-#include "include/roboteam_ai/stp/tactics/active/ChipAtPos.h"
+#include "stp/tactics/active/ChipAtPos.h"
 
 #include "control/ControlUtils.h"
 #include "stp/skills/Chip.h"

--- a/src/stp/tactics/active/DriveWithBall.cpp
+++ b/src/stp/tactics/active/DriveWithBall.cpp
@@ -7,7 +7,7 @@
 /// ACTIVE
 //
 
-#include "include/roboteam_ai/stp/tactics/active/DriveWithBall.h"
+#include "stp/tactics/active/DriveWithBall.h"
 
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Rotate.h"

--- a/src/stp/tactics/active/GetBall.cpp
+++ b/src/stp/tactics/active/GetBall.cpp
@@ -5,7 +5,7 @@
 /// ACTIVE
 //
 
-#include "include/roboteam_ai/stp/tactics/active/GetBall.h"
+#include "stp/tactics/active/GetBall.h"
 
 #include "control/ControlUtils.h"
 #include "stp/skills/GoToPos.h"

--- a/src/stp/tactics/active/KickAtPos.cpp
+++ b/src/stp/tactics/active/KickAtPos.cpp
@@ -6,7 +6,7 @@
 /// ACTIVE
 //
 
-#include "include/roboteam_ai/stp/tactics/active/KickAtPos.h"
+#include "stp/tactics/active/KickAtPos.h"
 
 #include "control/ControlUtils.h"
 #include "stp/skills/Kick.h"

--- a/src/stp/tactics/active/Receive.cpp
+++ b/src/stp/tactics/active/Receive.cpp
@@ -5,7 +5,7 @@
 /// ACTIVE
 //
 
-#include "include/roboteam_ai/stp/tactics/active/Receive.h"
+#include "stp/tactics/active/Receive.h"
 
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Rotate.h"

--- a/src/stp/tactics/active/ShootAtPos.cpp
+++ b/src/stp/tactics/active/ShootAtPos.cpp
@@ -7,7 +7,7 @@
 //
 //
 
-#include "include/roboteam_ai/stp/tactics/active/ShootAtPos.h"
+#include "stp/tactics/active/ShootAtPos.h"
 
 #include <roboteam_utils/Print.h>
 

--- a/src/stp/tactics/passive/AvoidBall.cpp
+++ b/src/stp/tactics/passive/AvoidBall.cpp
@@ -5,7 +5,7 @@
 /// PASSIVE
 //
 
-#include "include/roboteam_ai/stp/tactics/passive/AvoidBall.h"
+#include "stp/tactics/passive/AvoidBall.h"
 
 #include <roboteam_utils/Circle.h>
 #include <roboteam_utils/Tube.h>

--- a/src/stp/tactics/passive/BlockBall.cpp
+++ b/src/stp/tactics/passive/BlockBall.cpp
@@ -5,7 +5,7 @@
 /// PASSIVE
 //
 
-#include "include/roboteam_ai/stp/tactics/passive/BlockBall.h"
+#include "stp/tactics/passive/BlockBall.h"
 
 #include <roboteam_utils/Circle.h>
 

--- a/src/stp/tactics/passive/BlockRobot.cpp
+++ b/src/stp/tactics/passive/BlockRobot.cpp
@@ -6,7 +6,7 @@
 /// PASSIVE
 //
 
-#include "include/roboteam_ai/stp/tactics/passive/BlockRobot.h"
+#include "stp/tactics/passive/BlockRobot.h"
 
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Rotate.h"

--- a/src/stp/tactics/passive/Formation.cpp
+++ b/src/stp/tactics/passive/Formation.cpp
@@ -6,7 +6,7 @@
 /// PASSIVE
 //
 
-#include "include/roboteam_ai/stp/tactics/passive/Formation.h"
+#include "stp/tactics/passive/Formation.h"
 
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Rotate.h"

--- a/src/stp/tactics/passive/Halt.cpp
+++ b/src/stp/tactics/passive/Halt.cpp
@@ -3,7 +3,7 @@
 /// ROTATES robot to face forwards
 //
 
-#include "include/roboteam_ai/stp/tactics/passive/Halt.h"
+#include "stp/tactics/passive/Halt.h"
 
 #include "stp/skills/Rotate.h"
 

--- a/src/stp/tactics/passive/Walling.cpp
+++ b/src/stp/tactics/passive/Walling.cpp
@@ -4,7 +4,7 @@
 /// PASSIVE
 //
 
-#include "include/roboteam_ai/stp/tactics/passive/Walling.h"
+#include "stp/tactics/passive/Walling.h"
 
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Rotate.h"

--- a/src/utilities/GameStateManager.cpp
+++ b/src/utilities/GameStateManager.cpp
@@ -1,8 +1,8 @@
 #include "utilities/GameStateManager.hpp"
 
-#include <include/roboteam_ai/utilities/Settings.h>
+#include "utilities/Settings.h"
 #include <roboteam_utils/Print.h>
-#include <include/roboteam_ai/world/World.hpp>
+#include "world/World.hpp"
 
 namespace rtt::ai {
 

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -1,12 +1,12 @@
-#include <utilities/IOManager.h>
-#include <utilities/Settings.h>
+#include "utilities/IOManager.h"
+#include "utilities/Settings.h"
 
-#include <include/roboteam_ai/utilities/GameStateManager.hpp>
+#include "utilities/GameStateManager.hpp"
 
 #include "interface/api/Input.h"
 #include "roboteam_utils/normalize.h"
 #include "utilities/Pause.h"
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/World.hpp"
 
 namespace rtt::ai::io {
 

--- a/src/utilities/Pause.cpp
+++ b/src/utilities/Pause.cpp
@@ -2,8 +2,8 @@
 // Created by baris on 15-2-19.
 //
 
-#include <include/roboteam_ai/world/World.hpp>
-#include "include/roboteam_ai/utilities/IOManager.h"
+#include "world/World.hpp"
+#include "utilities/IOManager.h"
 
 namespace rtt::ai {
 

--- a/src/utilities/Settings.cpp
+++ b/src/utilities/Settings.cpp
@@ -2,7 +2,7 @@
 // Created by mrlukasbos on 1-9-19.
 //
 
-#include "include/roboteam_ai/utilities/Settings.h"
+#include "utilities/Settings.h"
 
 namespace rtt {
 Settings SETTINGS;

--- a/src/world/Ball.cpp
+++ b/src/world/Ball.cpp
@@ -2,12 +2,12 @@
 // Created by john on 12/18/19.
 //
 
-#include "include/roboteam_ai/world/Ball.hpp"
+#include "world/Ball.hpp"
 
-#include <include/roboteam_ai/interface/api/Input.h>
-#include <include/roboteam_ai/utilities/Constants.h>
+#include "interface/api/Input.h"
+#include "utilities/Constants.h"
 
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/World.hpp"
 
 namespace rtt::world::ball {
 

--- a/src/world/Field.cpp
+++ b/src/world/Field.cpp
@@ -2,7 +2,8 @@
 // Created by Lukas Bos on 30/08/2019.
 //
 
-#include <include/roboteam_ai/world/Field.h>
+#include "world/Field.h"
+
 namespace rtt::world {
 
 Field::Field(proto::SSL_GeometryFieldSize sslFieldSize) {

--- a/src/world/FieldComputations.cpp
+++ b/src/world/FieldComputations.cpp
@@ -1,6 +1,6 @@
 #include <roboteam_utils/Shadow.h>
 #include "world/FieldComputations.h"
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/World.hpp"
 
 namespace rtt {
 namespace ai {

--- a/src/world/Robot.cpp
+++ b/src/world/Robot.cpp
@@ -2,10 +2,10 @@
 // Created by john on 12/16/19.
 //
 
-#include "include/roboteam_ai/world/Robot.hpp"
+#include "world/Robot.hpp"
 
 #include "utilities/Constants.h"
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/World.hpp"
 
 namespace rtt::world::robot {
 Robot::Robot(std::unordered_map<uint8_t, proto::RobotFeedback> &feedback, const proto::WorldRobot &copy, rtt::world::Team team, std::optional<view::BallView> ball,

--- a/src/world/World.cpp
+++ b/src/world/World.cpp
@@ -2,7 +2,7 @@
 // Created by john on 12/16/19.
 //
 
-#include "include/roboteam_ai/world/World.hpp"
+#include "world/World.hpp"
 
 namespace rtt::world {
     WorldData const &World::setWorld(WorldData &newWorld) noexcept {

--- a/src/world/WorldData.cpp
+++ b/src/world/WorldData.cpp
@@ -2,7 +2,7 @@
 // Created by john on 12/16/19.
 //
 
-#include "include/roboteam_ai/world/WorldData.hpp"
+#include "world/WorldData.hpp"
 
 namespace rtt::world {
     WorldData::WorldData(const World* data, proto::World &protoMsg, rtt::Settings const &settings, std::unordered_map<uint8_t, proto::RobotFeedback> &feedback) noexcept : time{protoMsg.time()} {

--- a/src/world/views/RobotView.cpp
+++ b/src/world/views/RobotView.cpp
@@ -4,7 +4,7 @@
 
 #include "world/views/RobotView.hpp"
 
-#include <include/roboteam_ai/world/World.hpp>
+#include "world/World.hpp"
 
 namespace rtt::world::view {
 RobotView::RobotView(const rtt::world::robot::Robot *const _ptr) noexcept : robotPtr{_ptr} {}

--- a/src/world/views/WorldDataView.cpp
+++ b/src/world/views/WorldDataView.cpp
@@ -3,7 +3,7 @@
 //
 
 #include "world/views/WorldDataView.hpp"
-#include "include/roboteam_ai/world/WorldData.hpp"
+#include "world/WorldData.hpp"
 
 namespace rtt::world::view {
 


### PR DESCRIPTION
This was supposed to be just a quick job of adding MacOS support, but I noticed a couple of things that could be improved with the build system.

- Refactor to use modern CMake
- Work around Qt5 issues on MacOS
- Add instructions on how to build on MacOS
- Add missing and remove redundant dependencies in README
- Add CCache install instructions to README
- Set CMake to use unity builds
- Remove unused CMake files (cotire was included but not actually used)
  - Use modern CMake features to speed up build times
- Recommend and set default build system to Ninja
- Use newer method of fetching/discovering dependencies
   - Remove unnecessary third party git submodules 
- Change structure of some roboteam repositories (e.g. where full CMake projects were nested in the `include/` directory)


Only meant to be merged together with corresponding PRs in other repos.