### PR TITLE
Penalty fix 

### DIFF
--- a/include/roboteam_ai/stp/roles/Keeper.h
+++ b/include/roboteam_ai/stp/roles/Keeper.h
@@ -24,6 +24,7 @@ class Keeper : public Role {
      * @return The status that the current tactic returns
      */
     [[nodiscard]] Status update(StpInfo const& info) noexcept override;
+
    protected:
     /**
      * Checks if ball is in our defense area and still
@@ -34,6 +35,7 @@ class Keeper : public Role {
      */
 
     [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
+    
    private:
     /**
      * Resets state machine when ball is in our defense area and still and current tactic is not KeeperBlockBall

--- a/include/roboteam_ai/stp/roles/Keeper.h
+++ b/include/roboteam_ai/stp/roles/Keeper.h
@@ -24,6 +24,20 @@ class Keeper : public Role {
      * @return The status that the current tactic returns
      */
     [[nodiscard]] Status update(StpInfo const& info) noexcept override;
+
+
+   private:
+
+
+
+
+   protected:
+
+    //
+    //These functions are changed from private to protected, since they need to be used by inherited classes
+    // like PenaltyKeeper
+    //
+
     /**
      * Checks if ball is in our defense area and still
      * @param field Field
@@ -32,18 +46,13 @@ class Keeper : public Role {
      * @return True if ball is in our defense area and still
      */
 
-   private:
-
-
-
-   protected:
+    [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
 
     /**
      * Resets state machine when ball is in our defense area and still and current tactic is not KeeperBlockBall
      * @param isBallInOurDefenseAreaAndStill True if ball is in our defense area and still
      * @return True if isBallInOurDefenseAreaAndStill and current tactic is not KeeperBlockBall
      */
-    [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
     [[nodiscard]] bool shouldRoleReset(bool isBallInOurDefenseAreaAndStill) noexcept;
 };
 }  // namespace rtt::ai::stp::role

--- a/include/roboteam_ai/stp/roles/Keeper.h
+++ b/include/roboteam_ai/stp/roles/Keeper.h
@@ -34,7 +34,7 @@ class Keeper : public Role {
      */
 
     [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
-
+   private:
     /**
      * Resets state machine when ball is in our defense area and still and current tactic is not KeeperBlockBall
      * @param isBallInOurDefenseAreaAndStill True if ball is in our defense area and still

--- a/include/roboteam_ai/stp/roles/Keeper.h
+++ b/include/roboteam_ai/stp/roles/Keeper.h
@@ -24,8 +24,6 @@ class Keeper : public Role {
      * @return The status that the current tactic returns
      */
     [[nodiscard]] Status update(StpInfo const& info) noexcept override;
-
-   private:
     /**
      * Checks if ball is in our defense area and still
      * @param field Field
@@ -33,13 +31,19 @@ class Keeper : public Role {
      * @param ballVel Ball velocity
      * @return True if ball is in our defense area and still
      */
-    [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
+
+   private:
+
+
+
+   protected:
 
     /**
      * Resets state machine when ball is in our defense area and still and current tactic is not KeeperBlockBall
      * @param isBallInOurDefenseAreaAndStill True if ball is in our defense area and still
      * @return True if isBallInOurDefenseAreaAndStill and current tactic is not KeeperBlockBall
      */
+    [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
     [[nodiscard]] bool shouldRoleReset(bool isBallInOurDefenseAreaAndStill) noexcept;
 };
 }  // namespace rtt::ai::stp::role

--- a/include/roboteam_ai/stp/roles/Keeper.h
+++ b/include/roboteam_ai/stp/roles/Keeper.h
@@ -25,7 +25,6 @@ class Keeper : public Role {
      */
     [[nodiscard]] Status update(StpInfo const& info) noexcept override;
 
-   private:
     /**
      * Checks if ball is in our defense area and still
      * @param field Field
@@ -33,6 +32,7 @@ class Keeper : public Role {
      * @param ballVel Ball velocity
      * @return True if ball is in our defense area and still
      */
+
     [[nodiscard]] static bool isBallInOurDefenseAreaAndStill(const world::Field& field, const Vector2& ballPos, const Vector2& ballVel) noexcept;
 
     /**

--- a/include/roboteam_ai/stp/roles/Keeper.h
+++ b/include/roboteam_ai/stp/roles/Keeper.h
@@ -25,19 +25,6 @@ class Keeper : public Role {
      */
     [[nodiscard]] Status update(StpInfo const& info) noexcept override;
 
-
-   private:
-
-
-
-
-   protected:
-
-    //
-    //These functions are changed from private to protected, since they need to be used by inherited classes
-    // like PenaltyKeeper
-    //
-
     /**
      * Checks if ball is in our defense area and still
      * @param field Field

--- a/include/roboteam_ai/stp/roles/Keeper.h
+++ b/include/roboteam_ai/stp/roles/Keeper.h
@@ -24,7 +24,7 @@ class Keeper : public Role {
      * @return The status that the current tactic returns
      */
     [[nodiscard]] Status update(StpInfo const& info) noexcept override;
-
+   protected:
     /**
      * Checks if ball is in our defense area and still
      * @param field Field

--- a/include/roboteam_ai/stp/roles/PenaltyKeeper.h
+++ b/include/roboteam_ai/stp/roles/PenaltyKeeper.h
@@ -12,6 +12,10 @@
 
 namespace rtt::ai::stp::role {
 
+//
+//Role inherited from the Keeper
+//
+
 class PenaltyKeeper : public Keeper {
    public:
     /**

--- a/include/roboteam_ai/stp/roles/PenaltyKeeper.h
+++ b/include/roboteam_ai/stp/roles/PenaltyKeeper.h
@@ -6,12 +6,17 @@
 #ifndef RTT_PENALTYKEEPER_H
 #define RTT_PENALTYKEEPER_H
 
+#include "Keeper.h"
 #include "stp/Role.hpp"
 #include "world/Field.h"
 
 namespace rtt::ai::stp::role {
 
-class PenaltyKeeper : public Role {
+//
+//Role inherited from the Keeper
+//
+
+class PenaltyKeeper : public Keeper {
    public:
     /**
      * Ctor that sets the name of the role and creates a state machine of tactics

--- a/include/roboteam_ai/stp/roles/PenaltyKeeper.h
+++ b/include/roboteam_ai/stp/roles/PenaltyKeeper.h
@@ -30,7 +30,6 @@ class PenaltyKeeper : public Keeper {
      * @return The status that the current tactic returns
      */
     [[nodiscard]] Status update(StpInfo const& info) noexcept override;
-
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/roles/PenaltyKeeper.h
+++ b/include/roboteam_ai/stp/roles/PenaltyKeeper.h
@@ -6,12 +6,13 @@
 #ifndef RTT_PENALTYKEEPER_H
 #define RTT_PENALTYKEEPER_H
 
+#include "Keeper.h"
 #include "stp/Role.hpp"
 #include "world/Field.h"
 
 namespace rtt::ai::stp::role {
 
-class PenaltyKeeper : public Role {
+class PenaltyKeeper : public Keeper {
    public:
     /**
      * Ctor that sets the name of the role and creates a state machine of tactics
@@ -25,6 +26,7 @@ class PenaltyKeeper : public Role {
      * @return The status that the current tactic returns
      */
     [[nodiscard]] Status update(StpInfo const& info) noexcept override;
+
 };
 }  // namespace rtt::ai::stp::role
 

--- a/src/stp/plays/referee_specific/PenaltyThem.cpp
+++ b/src/stp/plays/referee_specific/PenaltyThem.cpp
@@ -17,7 +17,7 @@ namespace rtt::ai::stp::play {
         keepPlayEvaluation.emplace_back(GlobalEvaluation::PenaltyThemGameState);
 
         roles = std::array<std::unique_ptr<Role>, stp::control_constants::MAX_ROBOT_COUNT>{
-                std::make_unique<role::Keeper>(role::Keeper("keeper")),
+                std::make_unique<role::PenaltyKeeper>(role::PenaltyKeeper("keeper")),
                 std::make_unique<role::Halt>(role::Halt("halt_0")),
                 std::make_unique<role::Halt>(role::Halt("halt_1")),
                 std::make_unique<role::Halt>(role::Halt("halt_2")),

--- a/src/stp/plays/referee_specific/PenaltyThem.cpp
+++ b/src/stp/plays/referee_specific/PenaltyThem.cpp
@@ -55,10 +55,11 @@ namespace rtt::ai::stp::play {
     }
 
     void PenaltyThem::calculateInfoForRoles() noexcept {
-        stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x,world->getWorld()->getBall()->get()->getPos().y));
+        stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + 0.2, 0));
         stpInfos["keeper"].setPositionToShootAt(
                 world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), world::us).value()->getPos());
         stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
+        stpInfos["keeper"].setPidType(stp::PIDType::DEFAULT);
     }
 
     const char *PenaltyThem::getName() { return "Penalty Them"; }

--- a/src/stp/plays/referee_specific/PenaltyThem.cpp
+++ b/src/stp/plays/referee_specific/PenaltyThem.cpp
@@ -55,7 +55,7 @@ namespace rtt::ai::stp::play {
     }
 
     void PenaltyThem::calculateInfoForRoles() noexcept {
-        stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + 0.2, 0));
+        stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + Constants::KEEPER_CENTREGOAL_MARGIN(), 0));
         stpInfos["keeper"].setPositionToShootAt(
                 world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), world::us).value()->getPos());
         stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));

--- a/src/stp/plays/referee_specific/PenaltyThemPrepare.cpp
+++ b/src/stp/plays/referee_specific/PenaltyThemPrepare.cpp
@@ -40,7 +40,7 @@ namespace rtt::ai::stp::play {
         const double yPosition = Constants::STD_TIMEOUT_TO_TOP() ? distanceToCenterLine : -distanceToCenterLine;
 
         // Keeper
-        stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x,world->getWorld()->getBall()->get()->getPos().y));
+        stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x+ Constants::KEEPER_CENTREGOAL_MARGIN(),world->getWorld()->getBall()->get()->getPos().y));
 
         // regular bots
         const std::string formation = "formation_";

--- a/src/stp/roles/PenaltyKeeper.cpp
+++ b/src/stp/roles/PenaltyKeeper.cpp
@@ -16,7 +16,7 @@
 
 namespace rtt::ai::stp::role {
 
-PenaltyKeeper::PenaltyKeeper(std::string name) : Role(std::move(name)) {
+PenaltyKeeper::PenaltyKeeper(std::string name) : Keeper(std::move(name)) {
     // create state machine and initializes the first state
     robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::Formation(), tactic::KeeperBlockBall(), tactic::GetBall(), tactic::ChipAtPos()};
 }

--- a/src/stp/roles/PenaltyKeeper.cpp
+++ b/src/stp/roles/PenaltyKeeper.cpp
@@ -28,10 +28,17 @@ Status PenaltyKeeper::update(StpInfo const& info) noexcept {
         return Status::Failure;
     }
 
-    // Stop Formation tactic when ball is moving, start getting the ball and pass
-    if (info.getBall().value()->getVelocity().length() > control_constants::BALL_STILL_VEL) {
-        forceNextTactic();
-    }
+    bool stopBlockBall = isBallInOurDefenseAreaAndStill(info.getField().value(), info.getBall().value()->getPos(), info.getBall().value()->getVelocity());
+
+    // Stop Formation tactic when ball is moving, start blocking, getting the ball and pass
+    if (robotTactics.current_num() == 0 && info.getBall().value()->getVelocity().length() > control_constants::BALL_STILL_VEL )  forceNextTactic();
+
+    //stop block tactic when the ball is still in our defense area, then get ball and pass
+    if (robotTactics.current_num() == 1 && stopBlockBall) forceNextTactic();
+
+    //when the robot has the ball, blocking has stopped, go pass the ball
+    if (robotTactics.current_num() == 2 && info.getRobot().value().hasBall(0.09,0.2) && stopBlockBall) forceNextTactic();
+
 
     currentRobot = info.getRobot();
     // Update the current tactic with the new tacticInfo
@@ -66,4 +73,6 @@ Status PenaltyKeeper::update(StpInfo const& info) noexcept {
     // Return running by default
     return Status::Running;
 }
+
+
 }  // namespace rtt::ai::stp::role

--- a/src/stp/roles/PenaltyKeeper.cpp
+++ b/src/stp/roles/PenaltyKeeper.cpp
@@ -83,6 +83,4 @@ Status PenaltyKeeper::update(StpInfo const& info) noexcept {
     // Return running by default
     return Status::Running;
 }
-
-
 }  // namespace rtt::ai::stp::role

--- a/src/stp/roles/PenaltyKeeper.cpp
+++ b/src/stp/roles/PenaltyKeeper.cpp
@@ -16,6 +16,16 @@
 
 namespace rtt::ai::stp::role {
 
+//
+// PenaltyKeeper is a subclass of Keeper and therefore inherit all its functions
+// The difference between a normal Keeper and PenaltyKeeper is that the PenaltyKeeper
+// has to stay on the goal line until the ball has moved 0.05 meters, afterwards it
+// can move freely.
+// Since calculating exactly when the ball has moved 0.05 meters takes too long, we
+// let the PenaltyKeeper move after the ball has moved. If this requirement is fullfilled
+// the keeper will behave as a normal keeper
+//
+
 PenaltyKeeper::PenaltyKeeper(std::string name) : Keeper(std::move(name)) {
     // create state machine and initializes the first state
     robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::Formation(), tactic::KeeperBlockBall(), tactic::GetBall(), tactic::ChipAtPos()};
@@ -30,7 +40,7 @@ Status PenaltyKeeper::update(StpInfo const& info) noexcept {
 
     bool stopBlockBall = isBallInOurDefenseAreaAndStill(info.getField().value(), info.getBall().value()->getPos(), info.getBall().value()->getVelocity());
 
-    // Stop Formation tactic when ball is moving, start blocking, getting the ball and pass
+    // Stop Formation tactic when ball is moving, start blocking, getting the ball and pass (normal keeper behavior)
     if (robotTactics.current_num() == 0 && info.getBall().value()->getVelocity().length() > control_constants::BALL_STILL_VEL )  forceNextTactic();
 
     //stop block tactic when the ball is still in our defense area, then get ball and pass

--- a/src/stp/skills/GoToPos.cpp
+++ b/src/stp/skills/GoToPos.cpp
@@ -33,8 +33,16 @@ Status GoToPos::onUpdate(const StpInfo &info) noexcept {
     if (commandCollision.collisionData.has_value()) {
         return Status::Failure;
     }
+
+    double targetVelocityLength;
+    if (info.getPidType() == stp::PIDType::KEEPER && (info.getRobot()->get()->getPos() - info.getBall()->get()->getPos()).length() > control_constants::ROBOT_RADIUS/2){
+        RTT_DEBUG("Setting max vel");
+        targetVelocityLength = stp::control_constants::MAX_VEL_CMD;
+    }
+    else{
+        targetVelocityLength = std::clamp(commandCollision.robotCommand.vel.length(), 0.0, stp::control_constants::MAX_VEL_CMD);
+    }
     // Clamp and set velocity
-    double targetVelocityLength = std::clamp(commandCollision.robotCommand.vel.length(), 0.0, stp::control_constants::MAX_VEL_CMD);
     Vector2 targetVelocity = commandCollision.robotCommand.vel.stretchToLength(targetVelocityLength);
 
     // Set velocity and angle commands

--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -56,7 +56,7 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
         // Intercept ball when it is moving towards the goal
         if (ball->getVelocity().length() > control_constants::BALL_STILL_VEL) {
             auto start = ball->getPos();
-            auto end = start + ball->getVelocity().stretchToLength(field.getFieldLength() * 0.2);
+            auto end = start + ball->getVelocity().stretchToLength(field.getFieldLength());
             auto startGoal = field.getOurTopGoalSide() + Vector2(control_constants::DISTANCE_FROM_GOAL_CLOSE, 0);
             auto endGoal = field.getOurBottomGoalSide() + Vector2(control_constants::DISTANCE_FROM_GOAL_CLOSE, 0);
 
@@ -70,8 +70,8 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
         // Block the ball by staying on the shot line of the opponent
         if (enemyRobot->getDistanceToBall() < control_constants::ENEMY_CLOSE_TO_BALL_DISTANCE) {
             auto start = enemyRobot->getPos();
-            auto enemyToBall = ball->getPos() - start;
-            auto end = start + enemyToBall.stretchToLength(field.getFieldLength() * 0.5);
+            auto robotAngle = enemyRobot->getAngle();
+            auto end = start + robotAngle.toVector2().stretchToLength(field.getFieldLength());
             const auto &startGoal = field.getOurTopGoalSide();
             const auto &endGoal = field.getOurBottomGoalSide();
 

--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -29,6 +29,7 @@ std::optional<StpInfo> KeeperBlockBall::calculateInfoForSkill(StpInfo const &inf
 
     auto targetPosition = calculateTargetPosition(ball, field, enemyRobot);
 
+    skillStpInfo.setPidType(targetPosition.second);
     skillStpInfo.setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + 0.2,targetPosition.first.y));
     return skillStpInfo;
 }

--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -10,7 +10,7 @@
 
 namespace rtt::ai::stp::tactic {
 
-KeeperBlockBall::KeeperBlockBall() { skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos(), skill::Rotate()}; }
+KeeperBlockBall::KeeperBlockBall() { skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos()}; }
 
 std::optional<StpInfo> KeeperBlockBall::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
@@ -19,18 +19,13 @@ std::optional<StpInfo> KeeperBlockBall::calculateInfoForSkill(StpInfo const &inf
 
     auto field = info.getField().value();
     auto ball = info.getBall().value();
-    auto keeper = info.getRobot().value();
     auto enemyRobot = info.getEnemyRobot().value();
 
-    auto keeperToBall = ball->getPos() - keeper->getPos();
 
     auto targetPosition = calculateTargetPosition(ball, field, enemyRobot);
 
-    auto targetAngle = keeperToBall.angle();
-    skillStpInfo.setPositionToMoveTo(Vector2(field.getOurGoalCenter().x,targetPosition.first.y));
-    skillStpInfo.setPidType(targetPosition.second);
-    skillStpInfo.setAngle(targetAngle);
 
+    skillStpInfo.setPositionToMoveTo(Vector2(field.getOurGoalCenter().x,targetPosition.first.y));
     return skillStpInfo;
 }
 

--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -29,8 +29,7 @@ std::optional<StpInfo> KeeperBlockBall::calculateInfoForSkill(StpInfo const &inf
 
     auto targetPosition = calculateTargetPosition(ball, field, enemyRobot);
 
-
-    skillStpInfo.setPositionToMoveTo(Vector2(field.getOurGoalCenter().x,targetPosition.first.y));
+    skillStpInfo.setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + 0.2,targetPosition.first.y));
     return skillStpInfo;
 }
 
@@ -88,18 +87,10 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
             }
         }
 
-        // Stay between the ball and the center of the goal
-        auto targetPositions = keeperArc.intersectionWithLine(ball->getPos(), field.getOurGoalCenter());
-
-        if (targetPositions.first) {
-            return std::make_pair(targetPositions.first.value(), PIDType::DEFAULT);
-        } else if (targetPositions.second) {
-            return std::make_pair(targetPositions.second.value(), PIDType::DEFAULT);
-        }
+        auto targetPosition = Vector2(field.getOurGoalCenter().x,
+                                      std::clamp(ball->getPos().y, field.getOurGoalCenter().y - field.getGoalWidth() / 2, field.getOurGoalCenter().y + field.getGoalWidth() / 2));
+        return std::make_pair(targetPosition, PIDType::DEFAULT);
     }
-
-    // Default position
-    return std::make_pair(field.getOurGoalCenter() + Vector2(DISTANCE_FROM_GOAL_FAR, 0), PIDType::DEFAULT);
 }
 
 }  // namespace rtt::ai::stp::tactic

--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -63,7 +63,7 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
 
             auto intersection = LineSegment(start, end).intersects(LineSegment(startGoal, endGoal));
             if (intersection) {
-                return std::make_pair(intersection.value(), PIDType::DEFAULT);
+                return std::make_pair(intersection.value(), PIDType::KEEPER);
             }
         }
 

--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -20,7 +20,7 @@ std::optional<StpInfo> KeeperBlockBall::calculateInfoForSkill(StpInfo const &inf
     auto field = info.getField().value();
     auto ball = info.getBall().value();
     if (!skillStpInfo.getEnemyRobot()){
-        skillStpInfo.setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + 0.2, 0));
+        skillStpInfo.setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + Constants::KEEPER_CENTREGOAL_MARGIN(), 0));
         return skillStpInfo;
     }
 

--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -15,10 +15,15 @@ KeeperBlockBall::KeeperBlockBall() { skills = rtt::collections::state_machine<Sk
 std::optional<StpInfo> KeeperBlockBall::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 
-    if (!skillStpInfo.getField() || !skillStpInfo.getBall() || !skillStpInfo.getRobot() || !skillStpInfo.getEnemyRobot()) return std::nullopt;
+    if (!skillStpInfo.getField() || !skillStpInfo.getBall() || !skillStpInfo.getRobot()) return std::nullopt;
 
     auto field = info.getField().value();
     auto ball = info.getBall().value();
+    if (!skillStpInfo.getEnemyRobot()){
+        skillStpInfo.setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + 0.2, 0));
+        return skillStpInfo;
+    }
+
     auto enemyRobot = info.getEnemyRobot().value();
 
 

--- a/src/utilities/Constants.cpp
+++ b/src/utilities/Constants.cpp
@@ -125,7 +125,7 @@ double Constants::DEFAULT_BALLCOLLISION_RADIUS() { return 0.27; }
 
 double Constants::KEEPER_POST_MARGIN() { return 0.08; }
 
-double Constants::KEEPER_CENTREGOAL_MARGIN() { return 0.5; }
+double Constants::KEEPER_CENTREGOAL_MARGIN() { return 0.2; }
 
 double Constants::KEEPER_PENALTY_LINE_MARGIN() { return 0.06; }
 


### PR DESCRIPTION
- [ X ] The tests are passing

### Summary
The PenaltyKeeper should do exactly the same thing as a normal Keeper except that the PenaltyKeeper should stay at the goal line untill the ball moves. 
The original PenaltyKeeper didn't do this, it always stayed on the goal line and thus not stopping the ball. 
The PenaltyKeeper now inherits from the Keeper class. The PenaltyKeeper stays in the Formation tactic (on the goal line) until the ball has moved. Then it does the same as a normal Keeper. 
The keeper exhibited some additional strange behaviour, namely deflecting the ball into its own goal. This was due to an out dated piece of code that makes the robot rotate after it has gone it its correct position. (See Trello issue or discord for more information). This piece of code is deleted as well. 

### Related issues
No related issues

### Comments for the reviewer
No comments for the reviewer

### Checklist for the reviewer
This acts as a guide to help you and/or the reviewer to analyze the code. 

**functionality**  
- Is the code is properly tested?
- Is the code working as expected
- Is the code is understandable and easy to read
- Are proper abstractions made? (no duplicate code, nice use of functions/objects)

**style**  
- Variables/objects/classes have proper names
- Proper use of variables: nu unused vars, no magic numbers
- No possible memory leaks. Mutexes properly used when multithreading? possible pointer issues?
- Are smart pointers used?
- unused variables?
- magic numbers?
- well documented?
- No unused imports?
- No leftover code / unused comments
- Proper indentation
- Proper use of namespaces
