### PR TITLE
Add missing include <optional>

### DIFF
--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -5,6 +5,7 @@
 #ifndef RTT_STPINFO_H
 #define RTT_STPINFO_H
 
+#include <optional>
 #include "world/Field.h"
 #include "world/views/BallView.hpp"
 #include "world/views/RobotView.hpp"

--- a/include/roboteam_ai/stp/constants/GeneralizationConstants.h
+++ b/include/roboteam_ai/stp/constants/GeneralizationConstants.h
@@ -5,6 +5,7 @@
 #ifndef RTT_GENERALIZATIONCONSTANTS_H
 #define RTT_GENERALIZATIONCONSTANTS_H
 
+#include <optional>
 #include <roboteam_utils/Grid.h>
 
 namespace rtt::ai::stp::gen {

--- a/include/roboteam_ai/world/Field.h
+++ b/include/roboteam_ai/world/Field.h
@@ -1,6 +1,7 @@
 #ifndef RTT_FIELD_H
 #define RTT_FIELD_H
 
+#include <optional>
 #include <roboteam_utils/Vector2.h>
 #include "gtest/gtest_prod.h"
 #include <roboteam_proto/messages_robocup_ssl_geometry.pb.h>

--- a/include/roboteam_ai/world/Robot.hpp
+++ b/include/roboteam_ai/world/Robot.hpp
@@ -5,6 +5,8 @@
 #ifndef RTT_ROBOT_HPP
 #define RTT_ROBOT_HPP
 
+#include <optional>
+
 #include <roboteam_proto/RobotFeedback.pb.h>
 #include <roboteam_proto/WorldRobot.pb.h>
 

--- a/include/roboteam_ai/world/Robot.hpp
+++ b/include/roboteam_ai/world/Robot.hpp
@@ -6,7 +6,6 @@
 #define RTT_ROBOT_HPP
 
 #include <optional>
-
 #include <roboteam_proto/RobotFeedback.pb.h>
 #include <roboteam_proto/WorldRobot.pb.h>
 

--- a/include/roboteam_ai/world/WorldData.hpp
+++ b/include/roboteam_ai/world/WorldData.hpp
@@ -5,6 +5,7 @@
 #ifndef RTT_WORLD_DATA_HPP
 #define RTT_WORLD_DATA_HPP
 
+#include <optional>
 #include <vector>
 #include "world/views/RobotView.hpp"
 


### PR DESCRIPTION
### Summary
A few files use the standard library <optional> but do not include it. Some compilers allow for it, as other classes do import it into the namespace, but more strict compilers will deny a build. I added the include statements in these files in this branch.