### PR TITLE
Fix logic in isValidPlayToKeep to return false when shouldEndPlay is true

### DIFF
--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -114,10 +114,10 @@ namespace rtt::ai::stp {
     std::unordered_map<Role *, Status> const &Play::getRoleStatuses() const { return roleStatuses; }
 
     bool Play::isValidPlayToKeep(PlayEvaluator &playEvaluator) noexcept {
-        return (interface::MainControlsWidget::ignoreInvariants || shouldEndPlay() ||
+        return (interface::MainControlsWidget::ignoreInvariants || (!shouldEndPlay() &&
                 std::all_of(keepPlayEvaluation.begin(), keepPlayEvaluation.end(), [&playEvaluator](auto &x) {
                     return playEvaluator.checkEvaluation(x);
-                }));
+                })));
     }
 
     bool Play::isValidPlayToStart(PlayEvaluator &playEvaluator) const noexcept {


### PR DESCRIPTION
There were two issues with this function:
1) shouldEndPlay was not negated (!), which meant that is shouldEndPlay was true, isValidPlayToKeep was also true, which is the opposite of the desired behaviour. Fixed by adding !.
2) isValidPlayToKeep returned true if shouldEndPlay OR all of the playEvaluations were true. However, we need to make sure that BOTH conditions are fullfilled. Hence, the OR was changed into AND.

Without these changes, this function would return the wrong value if shouldEndPlay() is true, as the function would return true when it should be false, as the play should end. Furthermore, this function used OR where AND should be used, as both shouldEndPlay needs to be false AND all evaluations must be true in order to be a valid play to keep.

- [ X] The tests are passing

### Summary
Negated shouldEndPlay and changed shouldEndPlay OR [all evaluations are true] to  ... AND ...

### Checklist for the reviewer
This acts as a guide to help you and/or the reviewer to analyze the code. 

**functionality**  
- Is the code is properly tested?
- Is the code working as expected
- Is the code is understandable and easy to read
- Are proper abstractions made? (no duplicate code, nice use of functions/objects)

**style**  
- Variables/objects/classes have proper names
- Proper use of variables: nu unused vars, no magic numbers
- No possible memory leaks. Mutexes properly used when multithreading? possible pointer issues?
- Are smart pointers used?
- unused variables?
- magic numbers?
- well documented?
- No unused imports?
- No leftover code / unused comments
- Proper indentation
- Proper use of namespaces
