### PR TITLE
Do not touch ball before angle of robot is correct

### DIFF
--- a/src/stp/tactics/active/GetBall.cpp
+++ b/src/stp/tactics/active/GetBall.cpp
@@ -20,31 +20,37 @@ std::optional<StpInfo> GetBall::calculateInfoForSkill(StpInfo const &info) noexc
 
     if (!skillStpInfo.getRobot() || !skillStpInfo.getBall()) return std::nullopt;
 
-    Vector2 robotPosition = info.getRobot().value()->getPos();
-    Vector2 ballPosition = info.getBall().value()->getPos();
+    Vector2 robotPosition = skillStpInfo.getRobot().value()->getPos();
+    Vector2 ballPosition = skillStpInfo.getBall().value()->getPos();
+    double ballDistance = (ballPosition - robotPosition).length();
 
     // If this robot is not the keeper, don't get the ball inside a defense area
     if (info.getRobot()->get()->getId() != GameStateManager::getCurrentGameState().keeperId && FieldComputations::pointIsInDefenseArea(info.getField().value(), ballPosition)) {
         ballPosition = control::ControlUtils::projectPositionToOutsideDefenseArea(info.getField().value(), ballPosition, control_constants::AVOID_BALL_DISTANCE);
     }
 
-    // the robot will go to the position of the ball
-    double ballDistance = (ballPosition - robotPosition).length();
-    Vector2 newRobotPosition = robotPosition + (ballPosition - robotPosition).stretchToLength(ballDistance - control_constants::CENTER_TO_FRONT + 0.035);
-
-    if (ballDistance < control_constants::TURN_ON_DRIBBLER_DISTANCE) {
-        skillStpInfo.setAngle((ballPosition - robotPosition).angle());
-        skillStpInfo.setDribblerSpeed(100);
+    if (skillStpInfo.getRobot()->get()->getAngleDiffToBall() > control_constants::HAS_BALL_ANGLE_ERROR_MARGIN
+        && ballDistance < control_constants::AVOID_BALL_DISTANCE){
+        // don't move too close to the ball until the angle to the ball is (roughly) correct
+        skillStpInfo.setPositionToMoveTo(skillStpInfo.getRobot()->get()->getPos());
+    } else {
+        // the robot will go to the position of the ball
+        Vector2 newRobotPosition = robotPosition + (ballPosition - robotPosition).stretchToLength(ballDistance - control_constants::CENTER_TO_FRONT + 0.035);
+        skillStpInfo.setPositionToMoveTo(newRobotPosition);
     }
 
-    skillStpInfo.setPositionToMoveTo(newRobotPosition);
+    skillStpInfo.setAngle((ballPosition - robotPosition).angle());
+
+    if (ballDistance < control_constants::TURN_ON_DRIBBLER_DISTANCE) {
+        skillStpInfo.setDribblerSpeed(100);
+    }
 
     return skillStpInfo;
 }
 
 bool GetBall::isTacticFailing(const StpInfo &info) noexcept { return false; }
 
-bool GetBall::shouldTacticReset(const StpInfo &info) noexcept { return !info.getRobot()->hasBall(); }
+bool GetBall::shouldTacticReset(const StpInfo &info) noexcept { return info.getRobot()->get()->getAngleDiffToBall() < control_constants::HAS_BALL_ANGLE_ERROR_MARGIN * M_PI; }
 
 bool GetBall::isEndTactic() noexcept {
     // This is not an end tactic


### PR DESCRIPTION
If the ball is close to the robot but the robot is not facing towards the ball, it can happen that the robot hits the ball with its side in getBall, causing the ball to be pushed away. To avoid this, we prevent the robot from getting too close to the ball while its angle is incorrect. As long as the angle is too far off, we set the robot to go to its own position, which makes the tactic go to the next skill: rotate (since goToPos is immediately successful). The robot then rotates until it is within a margin of HAS_BALL_ANGLE_ERROR_MARGIN * M_PI, when the tactic resets and the robot is told to go to the position of the ball. This ensures that the robot always faces the right direction before actually making contact with the ball.

### Pre pull request checklist:

###### Code Quality
- [x] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
