### PR TITLE
Move grids to Field to scale with field size

### DIFF
--- a/include/roboteam_ai/stp/constants/GeneralizationConstants.h
+++ b/include/roboteam_ai/stp/constants/GeneralizationConstants.h
@@ -65,25 +65,6 @@ constexpr ScoreProfile GoalShootPosition = {0, 0.5, 1, 0};
 constexpr ScoreProfile BlockingPosition = {0, 0.5, 0, 1};
 
 /**
- * Generalized Grids to be used in plays
- * These positions are meant to be used across plays to lower computations when computing which
- * play is best by reducing the amount of unique position that need to be evaluated.
- */
-// Scaling for B-Division
-//    double scaleX = 0.75;
-//    double scaleY = 1;
-
-inline static Grid gridRightTop = Grid(3 * 1.0, 3 * 1, 2.5 * 1.0, 2.2 * 1, 3, 3);
-inline static Grid gridRightMid = Grid(3 * 1.0, 0 * 1, 2.5 * 1.0, 3 * 1, 3, 3);
-inline static Grid gridRightBot = Grid(3 * 1.0, -3 * 1, 2.5 * 1.0, 2.2 * 1, 3, 3);
-inline static Grid gridMidFieldTop = Grid(-1 * 1.0, 3 * 1, 2 * 1.0, 2.2 * 1, 3, 3);
-inline static Grid gridMidFieldMid = Grid(-1 * 1.0, -1.5 * 1, 2 * 1.0, 3 * 1, 3, 3);
-inline static Grid gridMidFieldBot = Grid(-1 * 1.0, -3 * 1, 2 * 1.0, 2.2 * 1, 3, 3);
-inline static Grid gridLeftTop = Grid(-5 * 1.0, 3 * 1, 2.5 * 1.0, 2.2 * 1, 3, 3);
-inline static Grid gridLeftMid = Grid(-5 * 1.0, -1.5 * 1, 2.5 * 1.0, 3 * 1, 3, 3);
-inline static Grid gridLeftBot = Grid(-5 * 1.0, -3 * 1, 2.5 * 1.0, 2.2 * 1, 3, 3);
-
-/**
  * Generalized Keys for passing information form the old play to the new.
  * Usage in the storePlayInfo where KeyInfo is the key for the elements in the map.
  */

--- a/include/roboteam_ai/world/Field.h
+++ b/include/roboteam_ai/world/Field.h
@@ -455,7 +455,6 @@ class Field {
      * Initialize the other field values, linesegments, arcs and vectors (this function is only called inside the constructor)
      */
     void initFieldOthers();
-
 };
 
 }  // namespace rtt::world

--- a/include/roboteam_ai/world/Field.h
+++ b/include/roboteam_ai/world/Field.h
@@ -2,6 +2,7 @@
 #define RTT_FIELD_H
 
 #include <roboteam_proto/messages_robocup_ssl_geometry.pb.h>
+#include <roboteam_utils/Grid.h>
 #include <roboteam_utils/Vector2.h>
 
 #include <optional>
@@ -261,6 +262,33 @@ class Field {
     // The bottom left corner of their defence area (note that this is not equal to the bottom of their goal side).
     std::optional<Vector2> bottomRightTheirDefenceArea;
 
+    // The left area in the back of the field (nearest side to our goal)
+    std::optional<Grid> backLeftGrid;
+
+    // The middle area in the back of the field (nearest side to our goal)
+    std::optional<Grid> backMidGrid;
+
+    // The right area in the back of the field (nearest side to our goal)
+    std::optional<Grid> backRightGrid;
+
+    // The left area in the middle of the field
+    std::optional<Grid> middleLeftGrid;
+
+    // The middle area in the middle of the field
+    std::optional<Grid> middleMidGrid;
+
+    // The right area in the middle of the field
+    std::optional<Grid> middleRightGrid;
+
+    // The left area in the front of the field (nearest side to their goal)
+    std::optional<Grid> frontLeftGrid;
+
+    // The middle area in the front of the field (nearest side to their goal)
+    std::optional<Grid> frontMidGrid;
+
+    // The right area in the front of the field (nearest side to their goal)
+    std::optional<Grid> frontRightGrid;
+
    public:
     /**
      * Constructor that creates an unitialized Field
@@ -336,6 +364,15 @@ class Field {
     const Vector2 &getTopRightTheirDefenceArea() const;
     const Vector2 &getBottomRightTheirDefenceArea() const;
     const FieldArc &getCenterCircle() const;
+    const Grid &getBackLeftGrid() const;
+    const Grid &getBackMidGrid() const;
+    const Grid &getBackRightGrid() const;
+    const Grid &getMiddleLeftGrid() const;
+    const Grid &getMiddleMidGrid() const;
+    const Grid &getMiddleRightGrid() const;
+    const Grid &getFrontLeftGrid() const;
+    const Grid &getFrontMidGrid() const;
+    const Grid &getFrontRightGrid() const;
 
     /**
      * Get all the lines of the field
@@ -379,6 +416,11 @@ class Field {
     const FieldArc &getFieldArc(const std::optional<FieldArc> &fieldArc) const;
 
     /**
+     * This method deals with getting field grids and what should happen when a field grid is missing.
+     */
+    const Grid &getFieldGrid(const std::optional<Grid> &fieldGrid) const;
+
+    /**
      * Convert a float measured in millimeters to meters (is needed, because proto message contains values measured in
      * millimeters).
      */
@@ -405,9 +447,15 @@ class Field {
     void initFieldArcs(const proto::SSL_GeometryFieldSize &sslFieldSize);
 
     /**
+     * Initialize the field grids (this function is only called inse the contructor)
+     */
+    void initFieldGrids();
+
+    /**
      * Initialize the other field values, linesegments, arcs and vectors (this function is only called inside the constructor)
      */
     void initFieldOthers();
+
 };
 
 }  // namespace rtt::world

--- a/include/roboteam_ai/world/Field.h
+++ b/include/roboteam_ai/world/Field.h
@@ -105,10 +105,10 @@ class Field {
 
    private:
     // The number of points generated in a grid in the x-direction
-    const int numSegmentsX = 3;
+    static constexpr int numSegmentsX = 3;
 
     // The number of points generated in a grid in the y-direction
-    const int numSegmentsY = 3;
+    static constexpr int numSegmentsY = 3;
 
     std::vector<FieldLineSegment> allFieldLines;
 

--- a/include/roboteam_ai/world/Field.h
+++ b/include/roboteam_ai/world/Field.h
@@ -104,6 +104,12 @@ class Field {
     };
 
    private:
+    // The number of points generated in a grid in the x-direction
+    const int numSegmentsX = 3;
+
+    // The number of points generated in a grid in the y-direction
+    const int numSegmentsY = 3;
+
     std::vector<FieldLineSegment> allFieldLines;
 
     /* The width of the field (measured in meters), which is the difference in y-coordinate between the upper part of

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -80,11 +80,11 @@ void GetBallPossession::calculateInfoForRoles() noexcept {
     stpInfos["defender_2"].setBlockDistance(BlockDistance::CLOSE);
 
     stpInfos["midfielder_0"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["midfielder_0"].getPositionToMoveTo(), gen::gridMidFieldBot, gen::SafePosition, field, world));
+        PositionComputations::getPosition(stpInfos["midfielder_0"].getPositionToMoveTo(), field.getMiddleLeftGrid(), gen::SafePosition, field, world));
     stpInfos["midfielder_1"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(), gen::gridMidFieldMid, gen::SafePosition, field, world));
+        PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(), field.getMiddleMidGrid(), gen::SafePosition, field, world));
     stpInfos["midfielder_2"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["midfielder_2"].getPositionToMoveTo(), gen::gridMidFieldTop, gen::SafePosition, field, world));
+        PositionComputations::getPosition(stpInfos["midfielder_2"].getPositionToMoveTo(), field.getMiddleRightGrid(), gen::SafePosition, field, world));
 
     stpInfos["waller_0"].setPositionToMoveTo(PositionComputations::getWallPosition(0, 3, field, world));
     stpInfos["waller_1"].setPositionToMoveTo(PositionComputations::getWallPosition(1, 3, field, world));

--- a/src/stp/plays/contested/GetBallRisky.cpp
+++ b/src/stp/plays/contested/GetBallRisky.cpp
@@ -60,11 +60,11 @@ void GetBallRisky::calculateInfoForRoles() noexcept {
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
 
     stpInfos["receiver_0"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["receiver_2"].getPositionToMoveTo(), gen::gridRightTop, gen::OffensivePosition, field, world));
+        PositionComputations::getPosition(stpInfos["receiver_2"].getPositionToMoveTo(), field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
     stpInfos["receiver_1"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["receiver_1"].getPositionToMoveTo(), gen::gridRightBot, gen::OffensivePosition, field, world));
+        PositionComputations::getPosition(stpInfos["receiver_1"].getPositionToMoveTo(), field.getFrontRightGrid(), gen::OffensivePosition, field, world));
     stpInfos["receiver_2"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["receiver_2"].getPositionToMoveTo(), gen::gridRightMid, gen::OffensivePosition, field, world));
+        PositionComputations::getPosition(stpInfos["receiver_2"].getPositionToMoveTo(), field.getFrontMidGrid(), gen::OffensivePosition, field, world));
 
     stpInfos["defender_0"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["defender_0"].setEnemyRobot(enemyAttacker);

--- a/src/stp/plays/defensive/DefendShot.cpp
+++ b/src/stp/plays/defensive/DefendShot.cpp
@@ -127,15 +127,15 @@ void DefendShot::calculateInfoForKeeper() noexcept {
 
 void DefendShot::calculateInfoForMidfielders() noexcept {
     stpInfos["midfielder_1"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(), gen::gridMidFieldBot, gen::SafePosition, field, world));
+        PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(), field.getMiddleRightGrid(), gen::SafePosition, field, world));
 
     stpInfos["midfielder_2"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["midfielder_2"].getPositionToMoveTo(), gen::gridMidFieldTop, gen::SafePosition, field, world));
+        PositionComputations::getPosition(stpInfos["midfielder_2"].getPositionToMoveTo(), field.getMiddleMidGrid(), gen::SafePosition, field, world));
 }
 
 void DefendShot::calculateInfoForOffenders() noexcept {
-    stpInfos["offender_1"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["offender_1"].getPositionToMoveTo(), gen::gridRightBot, gen::SafePosition, field, world));
-    stpInfos["offender_2"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["offender_2"].getPositionToMoveTo(), gen::gridRightTop, gen::SafePosition, field, world));
+    stpInfos["offender_1"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["offender_1"].getPositionToMoveTo(), field.getFrontLeftGrid(), gen::SafePosition, field, world));
+    stpInfos["offender_2"].setPositionToMoveTo(PositionComputations::getPosition(stpInfos["offender_2"].getPositionToMoveTo(), field.getFrontRightGrid(), gen::SafePosition, field, world));
 }
 
 const char *DefendShot::getName() { return "Defend Shot"; }

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -85,9 +85,9 @@ void AttackingPass::calculateInfoForScoredRoles(world::World *world) noexcept {
 
     // Receiver
     stpInfos["receiver_left"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["receiver_left"].getPositionToMoveTo(), gen::gridRightBot, gen::GoalShootPosition, field, world));
+        PositionComputations::getPosition(stpInfos["receiver_left"].getPositionToMoveTo(), field.getFrontLeftGrid(), gen::GoalShootPosition, field, world));
     stpInfos["receiver_right"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["receiver_right"].getPositionToMoveTo(), gen::gridRightTop, gen::GoalShootPosition, field, world));
+        PositionComputations::getPosition(stpInfos["receiver_right"].getPositionToMoveTo(), field.getFrontRightGrid(), gen::GoalShootPosition, field, world));
 }
 
 void AttackingPass::calculateInfoForRoles() noexcept {
@@ -120,11 +120,11 @@ void AttackingPass::calculateInfoForRoles() noexcept {
 
     /// Slightly aggressive midfielders
     stpInfos["midfielder_0"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["midfielder_0"].getPositionToMoveTo(), gen::gridMidFieldMid, gen::OffensivePosition, field, world));
+        PositionComputations::getPosition(stpInfos["midfielder_0"].getPositionToMoveTo(), field.getMiddleMidGrid(), gen::OffensivePosition, field, world));
     stpInfos["midfielder_1"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(), gen::gridMidFieldBot, gen::OffensivePosition, field, world));
+        PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(), field.getMiddleLeftGrid(), gen::OffensivePosition, field, world));
     stpInfos["midfielder_2"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["midfielder_2"].getPositionToMoveTo(), gen::gridMidFieldTop, gen::OffensivePosition, field, world));
+        PositionComputations::getPosition(stpInfos["midfielder_2"].getPositionToMoveTo(), field.getMiddleRightGrid(), gen::OffensivePosition, field, world));
 }
 
 std::vector<Vector2> AttackingPass::calculateDefensivePositions(int numberOfDefenders, std::vector<world::view::RobotView> enemyRobots) {
@@ -144,8 +144,8 @@ void AttackingPass::calculateInfoForPass(const world::ball::Ball *ball) noexcept
     /// Recalculate pass positions if we did not shoot yet
     /// For the receive locations, divide the field up into grids where the passers should stand,
     /// and find the best locations in those grids
-    auto receiverPositionRight = PositionComputations::getPosition(stpInfos["receiver_right"].getPositionToMoveTo(), gen::gridRightBot, gen::GoalShootPosition, field, world);
-    auto receiverPositionLeft = PositionComputations::getPosition(stpInfos["receiver_left"].getPositionToMoveTo(), gen::gridRightTop, gen::GoalShootPosition, field, world);
+    auto receiverPositionRight = PositionComputations::getPosition(stpInfos["receiver_right"].getPositionToMoveTo(), field.getFrontRightGrid(), gen::GoalShootPosition, field, world);
+    auto receiverPositionLeft = PositionComputations::getPosition(stpInfos["receiver_left"].getPositionToMoveTo(), field.getFrontLeftGrid(), gen::GoalShootPosition, field, world);
 
     stpInfos["passer"].setPositionToMoveTo(world->getWorld()->getBall()->get()->getPos());
 

--- a/src/stp/plays/offensive/GenericPass.cpp
+++ b/src/stp/plays/offensive/GenericPass.cpp
@@ -22,8 +22,8 @@ void GenericPass::onInitialize() noexcept {
     passerShot = false;
 
     // Make sure we calculate pass positions at least once
-    receiverPositionLeft = PositionComputations::getPosition(stpInfos["receiver_left"].getPositionToMoveTo(), gen::gridLeftTop, gen::GoalShootPosition, field, world);
-    receiverPositionRight = PositionComputations::getPosition(stpInfos["receiver_right"].getPositionToMoveTo(), gen::gridRightTop, gen::GoalShootPosition, field, world);
+    receiverPositionLeft = PositionComputations::getPosition(stpInfos["receiver_left"].getPositionToMoveTo(), field.getFrontLeftGrid(), gen::GoalShootPosition, field, world);
+    receiverPositionRight = PositionComputations::getPosition(stpInfos["receiver_right"].getPositionToMoveTo(), field.getFrontRightGrid(), gen::GoalShootPosition, field, world);
     passingPosition = receiverPositionRight.position;
 }
 
@@ -77,7 +77,7 @@ void GenericPass::calculateInfoForRoles() noexcept {
     auto searchGrid = Grid(-0.15 * fieldWidth, -2, 0.10 * fieldWidth, 4, 4, 4);
     // TODO: check if SafePosition is the right profile to use
     stpInfos["midfielder_1"].setPositionToMoveTo(
-        PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(), gen::gridMidFieldMid, gen::SafePosition, field, world));
+        PositionComputations::getPosition(stpInfos["midfielder_1"].getPositionToMoveTo(), field.getMiddleMidGrid(), gen::SafePosition, field, world));
 }
 
 Dealer::FlagMap GenericPass::decideRoleFlags() const noexcept {
@@ -115,8 +115,8 @@ void GenericPass::calculateInfoForPass(const world::ball::Ball* ball) noexcept {
     if (!passerShot) {
         /// For the receive locations, divide the field up into grids where the passers should stand,
         /// and find the best locations in those grids
-        receiverPositionLeft = PositionComputations::getPosition(stpInfos["receiver_left"].getPositionToMoveTo(), gen::gridLeftTop, gen::GoalShootPosition, field, world);
-        receiverPositionRight = PositionComputations::getPosition(stpInfos["receiver_right"].getPositionToMoveTo(), gen::gridRightTop, gen::GoalShootPosition, field, world);
+        receiverPositionLeft = PositionComputations::getPosition(stpInfos["receiver_left"].getPositionToMoveTo(), field.getFrontLeftGrid(), gen::GoalShootPosition, field, world);
+        receiverPositionRight = PositionComputations::getPosition(stpInfos["receiver_right"].getPositionToMoveTo(), field.getFrontRightGrid(), gen::GoalShootPosition, field, world);
 
         /// From the available receivers, select the best
         if (receiverPositionLeft.score > receiverPositionRight.score) {

--- a/src/world/Field.cpp
+++ b/src/world/Field.cpp
@@ -60,31 +60,30 @@ void Field::initFieldGrids() {
 
     // Grid- length/width is negative when playing as right/left respectively to as we need to add/substract from
     // starting point (when calculating middle and top X and middle and right Y) depending on which side we are
-    auto gridLength = SETTINGS.isLeft() ? getFieldLength()/3 : -getFieldLength()/3;
-    auto gridWidth = SETTINGS.isLeft() ? -getFieldWidth()/3 : getFieldWidth()/3;
+    auto gridLength = SETTINGS.isLeft() ? getFieldLength() / 3 : -getFieldLength() / 3;
+    auto gridWidth = SETTINGS.isLeft() ? -getFieldWidth() / 3 : getFieldWidth() / 3;
 
     // Calculate back and left side depending on which side we are
-    auto backmostX = SETTINGS.isLeft() ? leftmostX.value() : rightmostX.value() - getFieldLength()/3;
-    auto leftmostY = SETTINGS.isLeft() ? topmostY.value() - getFieldWidth()/3 : bottommostY.value();
+    auto backmostX = SETTINGS.isLeft() ? leftmostX.value() : rightmostX.value() - getFieldLength() / 3;
+    auto leftmostY = SETTINGS.isLeft() ? topmostY.value() - getFieldWidth() / 3 : bottommostY.value();
 
     auto bottomX = backmostX;
     auto middleX = backmostX + gridLength;
-    auto topX = backmostX + gridLength*2;
+    auto topX = backmostX + gridLength * 2;
 
     auto leftY = leftmostY;
     auto middleY = leftmostY + gridWidth;
-    auto rightY = leftmostY + gridWidth*2;
+    auto rightY = leftmostY + gridWidth * 2;
 
-    backLeftGrid = Grid(bottomX, leftY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
-    backMidGrid =  Grid(bottomX, middleY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
-    backRightGrid = Grid(bottomX, rightY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
-    middleLeftGrid = Grid(middleX, leftY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
-    middleMidGrid = Grid(middleX, middleY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
-    middleRightGrid = Grid(middleX, rightY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
-    frontLeftGrid = Grid(topX, leftY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
-    frontMidGrid = Grid(topX, middleY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
-    frontRightGrid = Grid(topX, rightY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
-
+    backLeftGrid = Grid(bottomX, leftY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
+    backMidGrid = Grid(bottomX, middleY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
+    backRightGrid = Grid(bottomX, rightY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
+    middleLeftGrid = Grid(middleX, leftY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
+    middleMidGrid = Grid(middleX, middleY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
+    middleRightGrid = Grid(middleX, rightY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
+    frontLeftGrid = Grid(topX, leftY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
+    frontMidGrid = Grid(topX, middleY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
+    frontRightGrid = Grid(topX, rightY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
 }
 
 void Field::initFieldOthers() {
@@ -100,11 +99,10 @@ void Field::initFieldOthers() {
     // Initialize some additional field vectors
 
     // Location of our/their goal is right or left depending which side we are playing as
-    if (SETTINGS.isLeft()){
+    if (SETTINGS.isLeft()) {
         ourGoalCenter = Vector2(leftmostX.value(), centerY.value());
         theirGoalCenter = Vector2(rightmostX.value(), centerY.value());
-    }
-    else{
+    } else {
         ourGoalCenter = Vector2(rightmostX.value(), centerY.value());
         theirGoalCenter = Vector2(leftmostX.value(), centerY.value());
     }
@@ -139,8 +137,7 @@ void Field::initFieldOthers() {
         bottomLeftOurDefenceArea = bottomLeftPenaltyStretch->begin;
         topRightTheirDefenceArea = topRightPenaltyStretch->begin;
         bottomRightTheirDefenceArea = bottomRightPenaltyStretch->begin;
-    }
-    else{
+    } else {
         topLeftOurDefenceArea = topRightPenaltyStretch->begin;
         bottomLeftOurDefenceArea = bottomRightPenaltyStretch->begin;
         topRightTheirDefenceArea = topLeftPenaltyStretch->begin;
@@ -264,7 +261,6 @@ const Grid &Field::getFrontMidGrid() const { return getFieldGrid(frontMidGrid); 
 
 const Grid &Field::getFrontRightGrid() const { return getFieldGrid(frontRightGrid); }
 
-
 double Field::getFieldValue(const std::optional<double> &fieldValue) const {
     if (fieldValue) {
         return fieldValue.value();
@@ -316,17 +312,16 @@ const FieldArc &Field::getFieldArc(const std::optional<FieldArc> &fieldArc) cons
 }
 
 const Grid &Field::getFieldGrid(const std::optional<Grid> &fieldGrid) const {
-    if (fieldGrid){
+    if (fieldGrid) {
         return fieldGrid.value();
     } else {
         /* This clause is needed, because the default constructor could have been called. In which case the variables
         have not been assigned a value. */
         std::cout << "Warning: access undefined grid in the Field class (world might not be turned on?)." << std::endl;
 
-        static Grid standard = Grid(0,0,0,0,0,0);
+        static Grid standard = Grid(0, 0, 0, 0, 0, 0);
         return standard;
     }
-
 }
 
 const std::vector<FieldLineSegment> &Field::getFieldLines() const { return allFieldLines; }

--- a/src/world/Field.cpp
+++ b/src/world/Field.cpp
@@ -55,9 +55,6 @@ void Field::initFieldArcs(const proto::SSL_GeometryFieldSize &sslFieldSize) {
 }
 
 void Field::initFieldGrids() {
-    auto numSegmentsX = 3;
-    auto numSegmentsY = 3;
-
     auto gridLength = getFieldLength() / numSegmentsX;
     auto gridWidth = getFieldWidth() / numSegmentsY;
 

--- a/src/world/Field.cpp
+++ b/src/world/Field.cpp
@@ -58,22 +58,16 @@ void Field::initFieldGrids() {
     auto numSegmentsX = 3;
     auto numSegmentsY = 3;
 
-    // Grid- length/width is negative when playing as right/left respectively to as we need to add/substract from
-    // starting point (when calculating middle and top X and middle and right Y) depending on which side we are
-    auto gridLength = SETTINGS.isLeft() ? getFieldLength() / 3 : -getFieldLength() / 3;
-    auto gridWidth = SETTINGS.isLeft() ? -getFieldWidth() / 3 : getFieldWidth() / 3;
+    auto gridLength = getFieldLength() / numSegmentsX;
+    auto gridWidth = getFieldWidth() / numSegmentsY;
 
-    // Calculate back and left side depending on which side we are
-    auto backmostX = SETTINGS.isLeft() ? leftmostX.value() : rightmostX.value() - getFieldLength() / 3;
-    auto leftmostY = SETTINGS.isLeft() ? topmostY.value() - getFieldWidth() / 3 : bottommostY.value();
+    auto bottomX = getLeftmostX();
+    auto middleX = getLeftmostX() + gridLength;
+    auto topX = getLeftmostX() + gridLength * 2;
 
-    auto bottomX = backmostX;
-    auto middleX = backmostX + gridLength;
-    auto topX = backmostX + gridLength * 2;
-
-    auto leftY = leftmostY;
-    auto middleY = leftmostY + gridWidth;
-    auto rightY = leftmostY + gridWidth * 2;
+    auto leftY = getBottommostY() + gridWidth * 2;
+    auto middleY = getBottommostY() + gridWidth;
+    auto rightY = getBottommostY();
 
     backLeftGrid = Grid(bottomX, leftY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
     backMidGrid = Grid(bottomX, middleY, gridWidth, gridLength, numSegmentsX, numSegmentsY);
@@ -97,15 +91,8 @@ void Field::initFieldOthers() {
     rightPenaltyX = rightPenaltyLine.value().begin.x;
 
     // Initialize some additional field vectors
-
-    // Location of our/their goal is right or left depending which side we are playing as
-    if (SETTINGS.isLeft()) {
-        ourGoalCenter = Vector2(leftmostX.value(), centerY.value());
-        theirGoalCenter = Vector2(rightmostX.value(), centerY.value());
-    } else {
-        ourGoalCenter = Vector2(rightmostX.value(), centerY.value());
-        theirGoalCenter = Vector2(leftmostX.value(), centerY.value());
-    }
+    ourGoalCenter = Vector2(leftmostX.value(), centerY.value());
+    theirGoalCenter = Vector2(rightmostX.value(), centerY.value());
 
     Vector2 goalWidthAdjust = Vector2(0, goalWidth.value() / 2);
     ourBottomGoalSide = ourGoalCenter.value() - goalWidthAdjust;
@@ -131,18 +118,11 @@ void Field::initFieldOthers() {
     bottomRightCorner = Vector2(rightmostX.value(), bottommostY.value());
     topRightCorner = Vector2(rightmostX.value(), topmostY.value());
 
-    // Calculate defense area based on which side we are
-    if (SETTINGS.isLeft()) {
-        topLeftOurDefenceArea = topLeftPenaltyStretch->begin;
-        bottomLeftOurDefenceArea = bottomLeftPenaltyStretch->begin;
-        topRightTheirDefenceArea = topRightPenaltyStretch->begin;
-        bottomRightTheirDefenceArea = bottomRightPenaltyStretch->begin;
-    } else {
-        topLeftOurDefenceArea = topRightPenaltyStretch->begin;
-        bottomLeftOurDefenceArea = bottomRightPenaltyStretch->begin;
-        topRightTheirDefenceArea = topLeftPenaltyStretch->begin;
-        bottomRightTheirDefenceArea = bottomLeftPenaltyStretch->begin;
-    }
+    topLeftOurDefenceArea = topLeftPenaltyStretch->begin;
+    bottomLeftOurDefenceArea = bottomLeftPenaltyStretch->begin;
+    topRightTheirDefenceArea = topRightPenaltyStretch->begin;
+    bottomRightTheirDefenceArea = bottomRightPenaltyStretch->begin;
+
 }
 
 float Field::mm_to_m(float scalar) { return scalar / 1000; }

--- a/src/world/Field.cpp
+++ b/src/world/Field.cpp
@@ -4,6 +4,8 @@
 
 #include "world/Field.h"
 
+#include "utilities/Settings.h"
+
 namespace rtt::world {
 
 Field::Field(proto::SSL_GeometryFieldSize sslFieldSize) {
@@ -11,6 +13,7 @@ Field::Field(proto::SSL_GeometryFieldSize sslFieldSize) {
     initFieldArcs(sslFieldSize);
     initFieldValues(sslFieldSize);
     initFieldOthers();
+    initFieldGrids();
 }
 
 void Field::initFieldValues(const proto::SSL_GeometryFieldSize &sslFieldSize) {
@@ -51,6 +54,39 @@ void Field::initFieldArcs(const proto::SSL_GeometryFieldSize &sslFieldSize) {
     }
 }
 
+void Field::initFieldGrids() {
+    auto numSegmentsX = 3;
+    auto numSegmentsY = 3;
+
+    // Grid- length/width is negative when playing as right/left respectively to as we need to add/substract from
+    // starting point (when calculating middle and top X and middle and right Y) depending on which side we are
+    auto gridLength = SETTINGS.isLeft() ? getFieldLength()/3 : -getFieldLength()/3;
+    auto gridWidth = SETTINGS.isLeft() ? -getFieldWidth()/3 : getFieldWidth()/3;
+
+    // Calculate back and left side depending on which side we are
+    auto backmostX = SETTINGS.isLeft() ? leftmostX.value() : rightmostX.value() - getFieldLength()/3;
+    auto leftmostY = SETTINGS.isLeft() ? topmostY.value() - getFieldWidth()/3 : bottommostY.value();
+
+    auto bottomX = backmostX;
+    auto middleX = backmostX + gridLength;
+    auto topX = backmostX + gridLength*2;
+
+    auto leftY = leftmostY;
+    auto middleY = leftmostY + gridWidth;
+    auto rightY = leftmostY + gridWidth*2;
+
+    backLeftGrid = Grid(bottomX, leftY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
+    backMidGrid =  Grid(bottomX, middleY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
+    backRightGrid = Grid(bottomX, rightY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
+    middleLeftGrid = Grid(middleX, leftY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
+    middleMidGrid = Grid(middleX, middleY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
+    middleRightGrid = Grid(middleX, rightY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
+    frontLeftGrid = Grid(topX, leftY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
+    frontMidGrid = Grid(topX, middleY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
+    frontRightGrid = Grid(topX, rightY, gridWidth, gridLength, numSegmentsX ,numSegmentsY);
+
+}
+
 void Field::initFieldOthers() {
     // Initialize some additional field values
     leftmostX = -0.5 * fieldLength.value();
@@ -62,8 +98,16 @@ void Field::initFieldOthers() {
     rightPenaltyX = rightPenaltyLine.value().begin.x;
 
     // Initialize some additional field vectors
-    ourGoalCenter = Vector2(leftmostX.value(), centerY.value());
-    theirGoalCenter = Vector2(rightmostX.value(), centerY.value());
+
+    // Location of our/their goal is right or left depending which side we are playing as
+    if (SETTINGS.isLeft()){
+        ourGoalCenter = Vector2(leftmostX.value(), centerY.value());
+        theirGoalCenter = Vector2(rightmostX.value(), centerY.value());
+    }
+    else{
+        ourGoalCenter = Vector2(rightmostX.value(), centerY.value());
+        theirGoalCenter = Vector2(leftmostX.value(), centerY.value());
+    }
 
     Vector2 goalWidthAdjust = Vector2(0, goalWidth.value() / 2);
     ourBottomGoalSide = ourGoalCenter.value() - goalWidthAdjust;
@@ -89,10 +133,19 @@ void Field::initFieldOthers() {
     bottomRightCorner = Vector2(rightmostX.value(), bottommostY.value());
     topRightCorner = Vector2(rightmostX.value(), topmostY.value());
 
-    topLeftOurDefenceArea = topLeftPenaltyStretch->begin;
-    bottomLeftOurDefenceArea = bottomLeftPenaltyStretch->begin;
-    topRightTheirDefenceArea = topRightPenaltyStretch->begin;
-    bottomRightTheirDefenceArea = bottomRightPenaltyStretch->begin;
+    // Calculate defense area based on which side we are
+    if (SETTINGS.isLeft()) {
+        topLeftOurDefenceArea = topLeftPenaltyStretch->begin;
+        bottomLeftOurDefenceArea = bottomLeftPenaltyStretch->begin;
+        topRightTheirDefenceArea = topRightPenaltyStretch->begin;
+        bottomRightTheirDefenceArea = bottomRightPenaltyStretch->begin;
+    }
+    else{
+        topLeftOurDefenceArea = topRightPenaltyStretch->begin;
+        bottomLeftOurDefenceArea = bottomRightPenaltyStretch->begin;
+        topRightTheirDefenceArea = topLeftPenaltyStretch->begin;
+        bottomRightTheirDefenceArea = bottomLeftPenaltyStretch->begin;
+    }
 }
 
 float Field::mm_to_m(float scalar) { return scalar / 1000; }
@@ -193,6 +246,25 @@ const Vector2 &Field::getTopRightTheirDefenceArea() const { return getFieldVecto
 
 const Vector2 &Field::getBottomRightTheirDefenceArea() const { return getFieldVector(bottomRightTheirDefenceArea); }
 
+const Grid &Field::getBackLeftGrid() const { return getFieldGrid(backLeftGrid); }
+
+const Grid &Field::getBackMidGrid() const { return getFieldGrid(backMidGrid); }
+
+const Grid &Field::getBackRightGrid() const { return getFieldGrid(backRightGrid); }
+
+const Grid &Field::getMiddleLeftGrid() const { return getFieldGrid(middleLeftGrid); }
+
+const Grid &Field::getMiddleMidGrid() const { return getFieldGrid(middleMidGrid); }
+
+const Grid &Field::getMiddleRightGrid() const { return getFieldGrid(middleRightGrid); }
+
+const Grid &Field::getFrontLeftGrid() const { return getFieldGrid(frontLeftGrid); }
+
+const Grid &Field::getFrontMidGrid() const { return getFieldGrid(frontMidGrid); }
+
+const Grid &Field::getFrontRightGrid() const { return getFieldGrid(frontRightGrid); }
+
+
 double Field::getFieldValue(const std::optional<double> &fieldValue) const {
     if (fieldValue) {
         return fieldValue.value();
@@ -241,6 +313,20 @@ const FieldArc &Field::getFieldArc(const std::optional<FieldArc> &fieldArc) cons
         static FieldArc standard = {};
         return standard;
     }
+}
+
+const Grid &Field::getFieldGrid(const std::optional<Grid> &fieldGrid) const {
+    if (fieldGrid){
+        return fieldGrid.value();
+    } else {
+        /* This clause is needed, because the default constructor could have been called. In which case the variables
+        have not been assigned a value. */
+        std::cout << "Warning: access undefined grid in the Field class (world might not be turned on?)." << std::endl;
+
+        static Grid standard = Grid(0,0,0,0,0,0);
+        return standard;
+    }
+
 }
 
 const std::vector<FieldLineSegment> &Field::getFieldLines() const { return allFieldLines; }
@@ -358,7 +444,15 @@ Field &Field::operator=(const Field &old) noexcept {
     bottomLeftOurDefenceArea = old.bottomLeftOurDefenceArea;
     topRightTheirDefenceArea = old.topRightTheirDefenceArea;
     bottomRightTheirDefenceArea = old.bottomRightTheirDefenceArea;
-
+    backLeftGrid = old.backLeftGrid;
+    backMidGrid = old.backMidGrid;
+    backRightGrid = old.backRightGrid;
+    middleLeftGrid = old.middleLeftGrid;
+    middleMidGrid = old.middleMidGrid;
+    middleRightGrid = old.middleRightGrid;
+    frontLeftGrid = old.frontLeftGrid;
+    frontMidGrid = old.frontMidGrid;
+    frontRightGrid = old.frontRightGrid;
     return *this;
 }
 

--- a/src/world/Field.cpp
+++ b/src/world/Field.cpp
@@ -122,7 +122,6 @@ void Field::initFieldOthers() {
     bottomLeftOurDefenceArea = bottomLeftPenaltyStretch->begin;
     topRightTheirDefenceArea = topRightPenaltyStretch->begin;
     bottomRightTheirDefenceArea = bottomRightPenaltyStretch->begin;
-
 }
 
 float Field::mm_to_m(float scalar) { return scalar / 1000; }


### PR DESCRIPTION
Grids were hardcoded and did not take into account the size of the field. To do this more easily, the grids are moved to Field to reduce dependency and keep similar computations in one place.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
