### PR TITLE
Implement feedback on the AI side

### DIFF
--- a/include/roboteam_ai/world/World.hpp
+++ b/include/roboteam_ai/world/World.hpp
@@ -101,7 +101,7 @@ class World {
      *
      * Undefined behavior may occur if feedback is used after being passed to this function
      */
-    void updateFeedback(std::unordered_map<uint8_t, proto::RobotFeedback> feedback);
+    void updateFeedback(google::protobuf::RepeatedPtrField<proto::RobotFeedback> feedback);
 
     /**
      * Updates the currentWorld

--- a/include/roboteam_ai/world/World.hpp
+++ b/include/roboteam_ai/world/World.hpp
@@ -95,11 +95,8 @@ class World {
     explicit World(Settings *settings);
 
     /**
-     * Updates feedback for a specific robot
-     * @param robotId Robot id of robot cache to update
-     * @param feedback Feedback to apply, do not use after passing
-     *
-     * Undefined behavior may occur if feedback is used after being passed to this function
+     * Updates feedback for all robots that received feedback
+     * @param feedback Feedback to apply
      */
     void updateFeedback(google::protobuf::RepeatedPtrField<proto::RobotFeedback> feedback);
 

--- a/include/roboteam_ai/world/views/RobotView.hpp
+++ b/include/roboteam_ai/world/views/RobotView.hpp
@@ -82,7 +82,7 @@ class RobotView {
      * Check whether the current robot has the ball
      * @param distanceErrorMargin distance error margin for ball possession
      * @param angleErrorMargin angle error margin for ball possession
-     * @return true if ballSensorSeesBall or dist(ball, robot) < maxDist else false
+     * @return true if ballSensorSeesBall (both sim or irl) or when ball is within dist/angle margin (only irl)
      */
     [[nodiscard]] bool hasBall(double distanceErrorMargin = ai::stp::control_constants::HAS_BALL_DISTANCE_ERROR_MARGIN,
                                double angleErrorMargin = ai::stp::control_constants::HAS_BALL_ANGLE_ERROR_MARGIN) const noexcept;

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -120,10 +120,14 @@ void ApplicationManager::runOneLoopCycle() {
         // Note these calls Assume the proto field exist. Otherwise, all fields and subfields are initialized as empty!!
         auto worldMessage = state.last_seen_world();
         auto fieldMessage = state.field().field();
+        auto feedbackMessage = SETTINGS.isYellow() ? state.last_seen_world().yellowfeedback() : state.last_seen_world().bluefeedback();
+
         if (!SETTINGS.isLeft()) {
             roboteam_utils::rotate(&worldMessage);
         }
+
         auto const &[_, world] = world::World::instance();
+        world->updateFeedback(feedbackMessage);
         world->updateWorld(worldMessage);
 
         if (!world->getWorld()->getUs().empty()) {
@@ -135,7 +139,6 @@ void ApplicationManager::runOneLoopCycle() {
             world->updateField(fieldMessage);
             world->updatePositionControl();
 
-            // world->updateFeedback(feedbackMap);
             decidePlay(world);
 
         } else {

--- a/src/stp/constants/ControlConstants.cpp
+++ b/src/stp/constants/ControlConstants.cpp
@@ -48,7 +48,7 @@ constexpr double MAX_VEL_WHEN_HAS_BALL = 3.0;
 // Angle margin robot to ball. Within this margin, the robot has the ball
 constexpr double HAS_BALL_ANGLE_ERROR_MARGIN = 0.10;
 // Distance margin robot to ball. Within this margin, the robot has the ball
-/// WHEN IN GRSIM, CHANGE HAS_BALL_DISTANCE_ERROR_MARGIN TO 0.12
+/// WHEN IN GRSIM, this is not used, as using feedback is a more accurate. If using this, set distance to 0.12
 /// WHEN IRL, CHANGE HAS_BALL_DISTANCE_ERROR_MARGIN TO 0.10
 constexpr double HAS_BALL_DISTANCE_ERROR_MARGIN = 0.10;
 

--- a/src/stp/constants/ControlConstants.cpp
+++ b/src/stp/constants/ControlConstants.cpp
@@ -50,7 +50,7 @@ constexpr double HAS_BALL_ANGLE_ERROR_MARGIN = 0.10;
 // Distance margin robot to ball. Within this margin, the robot has the ball
 /// WHEN IN GRSIM, CHANGE HAS_BALL_DISTANCE_ERROR_MARGIN TO 0.12
 /// WHEN IRL, CHANGE HAS_BALL_DISTANCE_ERROR_MARGIN TO 0.10
-constexpr double HAS_BALL_DISTANCE_ERROR_MARGIN = 0.12;
+constexpr double HAS_BALL_DISTANCE_ERROR_MARGIN = 0.10;
 
 /// GTP Constants
 // Distance margin for 'goToPos'. If the robot is within this margin, goToPos is successful

--- a/src/world/World.cpp
+++ b/src/world/World.cpp
@@ -75,7 +75,13 @@ void World::updateField(rtt::world::Field &protoField) { this->currentField = pr
 
 World::World(Settings *settings) : settings{settings}, currentWorld{std::nullopt}, lastTick{0} { history.reserve(HISTORY_SIZE); }
 
-void World::updateFeedback(std::unordered_map<uint8_t, proto::RobotFeedback> feedback) { updateMap = std::move(feedback); }
+void World::updateFeedback(google::protobuf::RepeatedPtrField<proto::RobotFeedback> protoFeedback) {
+    std::unordered_map<uint8_t, proto::RobotFeedback> feedbackMap;
+    for (auto &feedback : protoFeedback) {
+        feedbackMap[feedback.id()] = feedback;
+    }
+    updateMap = std::move(feedbackMap);
+}
 
 void World::updateTickTime() noexcept {
     if (!getWorld()) {  // no world currently

--- a/src/world/views/RobotView.cpp
+++ b/src/world/views/RobotView.cpp
@@ -15,9 +15,10 @@ robot::Robot const &RobotView::operator*() const noexcept { return *get(); }
 
 robot::Robot const *RobotView::operator->() const noexcept { return get(); }
 
-// TODO: TEST to see if we don't have issues using this naive approach irl
+// TODO: TEST whether maxDist and Angle are suitable on the field and whether ballsensor works well irl
 bool RobotView::hasBall(double maxDist, double maxAngle) const noexcept {
-    // If ballSensor and/or vision say we have the ball, return true else false
+    // In the simulator, return true if the ballSensorSeesBall (feedback from sim)
+    // On the field, return true if the ballsensor sees the ball or we have the ball according to the vision
     return (SETTINGS.isSerialMode() && hasBallAccordingToVision(maxDist, maxAngle)) || get()->ballSensorSeesBall();
 }
 

--- a/src/world/views/RobotView.cpp
+++ b/src/world/views/RobotView.cpp
@@ -18,7 +18,7 @@ robot::Robot const *RobotView::operator->() const noexcept { return get(); }
 // TODO: TEST to see if we don't have issues using this naive approach irl
 bool RobotView::hasBall(double maxDist, double maxAngle) const noexcept {
     // If ballSensor and/or vision say we have the ball, return true else false
-    return hasBallAccordingToVision(maxDist, maxAngle) || get()->ballSensorSeesBall();
+    return (SETTINGS.isSerialMode() && hasBallAccordingToVision(maxDist, maxAngle)) || get()->ballSensorSeesBall();
 }
 
 Vector2 RobotView::getKicker() const noexcept {


### PR DESCRIPTION
###### Summary
Feedback was passed on to AI, but it was not fully handled. This PR adds this functionality, finishing the feedback stream from robothub to world to AI.

Furthermore, a small change was made that makes sure the robot is only said to "have the ball" if the feedback from the simulator says so (when playing in the simulator). This is a useful change as the "vision" way of determining whether the robot has the ball is rather inaccurate, especially in the simulator, which led to several bugs.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
