### PR TITLE
Fix/keeper

### DIFF
--- a/src/utilities/Constants.cpp
+++ b/src/utilities/Constants.cpp
@@ -34,7 +34,8 @@ void Constants::OVERWRITE_GRSIM(bool grsim) {
     robotOutputTargetGrSim = grsim;
 }
 
-int Constants::DEFAULT_KEEPER_ID() { return 0; }
+/// Set to a valid Id to make that robot keeper. Otherwise, keeper will be first distributed based on cost.
+int Constants::DEFAULT_KEEPER_ID() { return -1; }
 
 bool Constants::FEEDBACK_ENABLED() { return true; }
 

--- a/src/utilities/Dealer.cpp
+++ b/src/utilities/Dealer.cpp
@@ -13,6 +13,7 @@
 
 #include <iterator>
 
+#include "interface/api/Output.h"
 #include "utilities/GameStateManager.hpp"
 #include "world/FieldComputations.h"
 
@@ -59,10 +60,19 @@ std::unordered_map<std::string, v::RobotView> Dealer::distribute(std::vector<v::
                         output.insert({roleNames[current.originalRolesIndex[j]], allRobots[current.originalIDsIndex.back()]});
                     }
                 }
-                if (output.size() == allRobots.size()) return output;  // case if there are less then 11 bots to distribute
+                if (output.size() == allRobots.size()) {          // case if there are less then 11 bots to distribute
+                    if (output.find("keeper") != output.end()) {
+                        interface::Output::setKeeperId(output.find("keeper")->second->getId());
+                    }
+                    return output;
+                }
                 distribute_remove(current, indexRoles, indexID, scores);
             }
         }
+    }
+    if (output.find("keeper") != output.end()) {
+        // If the keeper role is distributed, set the keeperId to this id to ensure this robot stays keeper
+        interface::Output::setKeeperId(output.find("keeper")->second->getId());
     }
     return output;
 }


### PR DESCRIPTION
The keeper id, stored in the interfaceGameState, was not updated when the keeper was distributed. This meant that whenever the robot with the default keeper id (0) was not in the field, we would now know who our keeper was in STP. This is problematic for path planning. This PR makes sure that we save the keeper id if this role is distributed. The default keeper id is also set to -1, which forces the dealer to pick a keeper based on cost, as this is the desired behavior in pretty much every scenario. If we want to force a certain robot to be keeper, the default keeper id can be set to that id.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
