### PR TITLE
Reorganize position computations and scoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ set(COMPUTATION_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/computations/PositionComputations.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/computations/GoalComputations.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/computations/PassComputations.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/computations/PositionScoring.cpp
         )
 
 set(CONTROL_SOURCES

--- a/include/roboteam_ai/stp/computations/ComputationManager.h
+++ b/include/roboteam_ai/stp/computations/ComputationManager.h
@@ -1,0 +1,38 @@
+//
+// Created by alexander on 02-12-21.
+//
+
+#ifndef RTT_COMPUTATIONMANAGER_H
+#define RTT_COMPUTATIONMANAGER_H
+
+#include "roboteam_utils/Vector2.h"
+#include "stp/constants/GeneralizationConstants.h"
+
+namespace rtt::ai::stp {
+
+/**
+ * Class that stores computation results that can be re-used in the same tick to prevent identical computations happening within a tick
+ */
+class ComputationManager {
+   public:
+    /**
+     * Clear computation results that are used to avoid computing the same thing more than once in a tick. This function should be called after every tick
+     */
+    static void clearStoredComputations() {
+        calculatedScores.clear();
+        calculatedWallPositions.clear();
+    }
+
+    /**
+     * vector of calculated position scores
+     */
+    inline static std::unordered_map<Vector2, gen::PositionScores> calculatedScores{};
+
+    /**
+     * vector of determined wall positions
+     */
+    inline static std::vector<Vector2> calculatedWallPositions{};
+};
+}  // namespace rtt::ai::stp
+
+#endif  // RTT_COMPUTATIONMANAGER_H

--- a/include/roboteam_ai/stp/computations/PositionComputations.h
+++ b/include/roboteam_ai/stp/computations/PositionComputations.h
@@ -24,11 +24,6 @@ namespace rtt::ai::stp {
 class PositionComputations {
    public:
     /**
-     * vector of determined wall positions
-     */
-    inline static std::vector<Vector2> calculatedWallPositions{};
-
-    /**
      * Determines the location for defenders around the defense area
      * Uses the defence area boundaries and the path from ball to center of goal to find the intersects of circles to
      * find the various positions.

--- a/include/roboteam_ai/stp/computations/PositionComputations.h
+++ b/include/roboteam_ai/stp/computations/PositionComputations.h
@@ -22,75 +22,7 @@
 namespace rtt::ai::stp {
 
 class PositionComputations {
-   private:
-    /**
-     * Determine score for the Open at given position
-     * @param point Position to calculate from
-     * @param world
-     * @param scores ref to struct linked to that pos
-     * @return score value
-     */
-    static double determineOpenScore(Vector2 &point, const world::World *world, gen::PositionScores &scores);
-
-    /**
-     * Determine score for the Line of Sight to the ball at given position
-     * @param point Position to calculate from
-     * @param world
-     * @param scores ref to struct linked to that pos
-     * @return score value
-     */
-    static double determineLineOfSightScore(Vector2 &point, const world::World *world, gen::PositionScores &scores);
-
-    /**
-     * Determine score for the Visibility of the goal at given position
-     * @param point Position to calculate from
-     * @param field
-     * @param world
-     * @param scores ref to struct linked to that pos
-     * @return score value
-     */
-    static double determineGoalShotScore(Vector2 &point, const world::Field &field, const world::World *world, gen::PositionScores &scores);
-
-    /**
-     * Determine score for blocking potential of a position
-     * @param point Position to calculate from
-     * @param world
-     * @param scores ref to struct linked to that pos
-     * @return score value
-     */
-    static double determineBlockingScore(Vector2 &point, const world::World *world, gen::PositionScores &scores);
-
-    /**
-     * Get score of a position, used in getPosition
-     * @param position Vector2 that needs to be scored
-     * @param profile combination of weights for different factors that should be scored
-     * @param field
-     * @param world
-     * @param bias value added to score
-     * @return Position with score
-     */
-    static gen::ScoredPosition scorePosition(const Vector2 &position, gen::ScoreProfile &profile, const world::Field &field, const world::World *world, uint8_t bias = 0);
-
    public:
-    /**
-     * Score a position using the given weights weights for a profile.
-     * Will check if the position already has a pre-calculated score (from this tick) then throws the weight over it
-     * and sums the scores, resulting in a position scored a particular set of weights.
-     * @param profile set of weights of the different factors that determine the score
-     * @param position x,y coordinates
-     * @param scores reference to scores of said position in map
-     * @param world
-     * @param field
-     * @return score of position including the weights
-     */
-    static uint8_t getScoreOfPosition(gen::ScoreProfile &profile, Vector2 position, gen::PositionScores &scores, const world::Field &field, const world::World *world);
-
-    /**
-     * unordered map of calculated scores of this tick.
-     * must be cleared at start of tick
-     */
-    inline static std::unordered_map<Vector2, gen::PositionScores> calculatedScores{};
-
     /**
      * vector of determined wall positions
      */

--- a/include/roboteam_ai/stp/computations/PositionScoring.h
+++ b/include/roboteam_ai/stp/computations/PositionScoring.h
@@ -73,12 +73,6 @@ class PositionScoring {
      * @return Position with score
      */
     static gen::ScoredPosition scorePosition(const Vector2 &position, gen::ScoreProfile &profile, const world::Field &field, const world::World *world, uint8_t bias = 0);
-
-    /**
-     * unordered map of calculated scores of this tick.
-     * must be cleared at start of tick
-     */
-    inline static std::unordered_map<Vector2, gen::PositionScores> calculatedScores{};
 };
 }  // namespace rtt::ai::stp
 #endif  // RTT_POSITIONSCORING_H

--- a/include/roboteam_ai/stp/computations/PositionScoring.h
+++ b/include/roboteam_ai/stp/computations/PositionScoring.h
@@ -1,0 +1,84 @@
+//
+// Created by alexander on 02-12-21.
+//
+
+#ifndef RTT_POSITIONSCORING_H
+#define RTT_POSITIONSCORING_H
+
+#include "stp/constants/GeneralizationConstants.h"
+#include "world/Field.h"
+#include "world/World.hpp"
+
+namespace rtt::ai::stp {
+class PositionScoring {
+   private:
+    /**
+     * Determine score for the Open at given position
+     * @param point Position to calculate from
+     * @param world
+     * @param scores ref to struct linked to that pos
+     * @return score value
+     */
+    static double determineOpenScore(Vector2 &point, const world::World *world, gen::PositionScores &scores);
+
+    /**
+     * Determine score for the Line of Sight to the ball at given position
+     * @param point Position to calculate from
+     * @param world
+     * @param scores ref to struct linked to that pos
+     * @return score value
+     */
+    static double determineLineOfSightScore(Vector2 &point, const world::World *world, gen::PositionScores &scores);
+
+    /**
+     * Determine score for the Visibility of the goal at given position
+     * @param point Position to calculate from
+     * @param field
+     * @param world
+     * @param scores ref to struct linked to that pos
+     * @return score value
+     */
+    static double determineGoalShotScore(Vector2 &point, const world::Field &field, const world::World *world, gen::PositionScores &scores);
+
+    /**
+     * Determine score for blocking potential of a position
+     * @param point Position to calculate from
+     * @param world
+     * @param scores ref to struct linked to that pos
+     * @return score value
+     */
+    static double determineBlockingScore(Vector2 &point, const world::World *world, gen::PositionScores &scores);
+
+    /**
+     * Score a position using the given weights weights for a profile.
+     * Will check if the position already has a pre-calculated score (from this tick) then throws the weight over it
+     * and sums the scores, resulting in a position scored a particular set of weights.
+     * @param profile set of weights of the different factors that determine the score
+     * @param position x,y coordinates
+     * @param scores reference to scores of said position in map
+     * @param world
+     * @param field
+     * @return score of position including the weights
+     */
+    static uint8_t getScoreOfPosition(gen::ScoreProfile &profile, Vector2 position, gen::PositionScores &scores, const world::Field &field, const world::World *world);
+
+   public:
+    /**
+     * Get score of a position, used in getPosition
+     * @param position Vector2 that needs to be scored
+     * @param profile combination of weights for different factors that should be scored
+     * @param field
+     * @param world
+     * @param bias value added to score
+     * @return Position with score
+     */
+    static gen::ScoredPosition scorePosition(const Vector2 &position, gen::ScoreProfile &profile, const world::Field &field, const world::World *world, uint8_t bias = 0);
+
+    /**
+     * unordered map of calculated scores of this tick.
+     * must be cleared at start of tick
+     */
+    inline static std::unordered_map<Vector2, gen::PositionScores> calculatedScores{};
+};
+}  // namespace rtt::ai::stp
+#endif  // RTT_POSITIONSCORING_H

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -9,8 +9,7 @@
 #include "control/ControlModule.h"
 #include "utilities/GameStateManager.hpp"
 #include "utilities/IOManager.h"
-#include "stp/computations/PositionScoring.h"
-#include "stp/computations/PositionComputations.h"
+#include "stp/computations/ComputationManager.h"
 
 /**
  * Plays are included here
@@ -164,8 +163,7 @@ void ApplicationManager::runOneLoopCycle() {
 void ApplicationManager::decidePlay(world::World *_world) {
     // TODO make a clear function
     playEvaluator.clearGlobalScores();  // reset all evaluations
-    ai::stp::PositionScoring::calculatedScores.clear();
-    ai::stp::PositionComputations::calculatedWallPositions.clear();
+    ai::stp::ComputationManager::clearStoredComputations();
 
     playEvaluator.update(_world);
     playChecker.update(playEvaluator);

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -9,6 +9,8 @@
 #include "control/ControlModule.h"
 #include "utilities/GameStateManager.hpp"
 #include "utilities/IOManager.h"
+#include "stp/computations/PositionScoring.h"
+#include "stp/computations/PositionComputations.h"
 
 /**
  * Plays are included here
@@ -162,7 +164,7 @@ void ApplicationManager::runOneLoopCycle() {
 void ApplicationManager::decidePlay(world::World *_world) {
     // TODO make a clear function
     playEvaluator.clearGlobalScores();  // reset all evaluations
-    ai::stp::PositionComputations::calculatedScores.clear();
+    ai::stp::PositionScoring::calculatedScores.clear();
     ai::stp::PositionComputations::calculatedWallPositions.clear();
 
     playEvaluator.update(_world);

--- a/src/stp/computations/PositionComputations.cpp
+++ b/src/stp/computations/PositionComputations.cpp
@@ -5,7 +5,9 @@
 #include "stp/computations/PositionComputations.h"
 
 #include <roboteam_utils/Grid.h>
+
 #include "stp/StpInfo.h"
+#include "stp/computations/ComputationManager.h"
 #include "stp/computations/PositionScoring.h"
 #include "world/Field.h"
 #include "world/World.hpp"
@@ -27,10 +29,10 @@ gen::ScoredPosition PositionComputations::getPosition(std::optional<rtt::Vector2
 }
 
 Vector2 PositionComputations::getWallPosition(int index, int amountDefenders, const rtt::world::Field &field, rtt::world::World *world) {
-    if (calculatedWallPositions.empty()) {
-        calculatedWallPositions = determineWallPositions(field, world, amountDefenders);
+    if (ComputationManager::calculatedWallPositions.empty()) {
+        ComputationManager::calculatedWallPositions = determineWallPositions(field, world, amountDefenders);
     }
-    return calculatedWallPositions[index];
+    return ComputationManager::calculatedWallPositions[index];
 }
 
 std::vector<Vector2> PositionComputations::determineWallPositions(const rtt::world::Field &field, const rtt::world::World *world, int amountDefenders) {

--- a/src/stp/computations/PositionComputations.cpp
+++ b/src/stp/computations/PositionComputations.cpp
@@ -5,12 +5,8 @@
 #include "stp/computations/PositionComputations.h"
 
 #include <roboteam_utils/Grid.h>
-
 #include "stp/StpInfo.h"
-#include "stp/evaluations/position/BlockingEvaluation.h"
-#include "stp/evaluations/position/GoalShotEvaluation.h"
-#include "stp/evaluations/position/LineOfSightEvaluation.h"
-#include "stp/evaluations/position/OpennessEvaluation.h"
+#include "stp/computations/PositionScoring.h"
 #include "world/Field.h"
 #include "world/World.hpp"
 
@@ -19,94 +15,15 @@ namespace rtt::ai::stp {
 gen::ScoredPosition PositionComputations::getPosition(std::optional<rtt::Vector2> currentPosition, const Grid &searchGrid, gen::ScoreProfile profile, const world::Field &field,
                                                       world::World *world) {
     gen::ScoredPosition bestPosition;
-    (currentPosition.has_value()) ? bestPosition = scorePosition(currentPosition.value(), profile, field, world, 2) : bestPosition = {{0, 0}, 0};
+    (currentPosition.has_value()) ? bestPosition = PositionScoring::scorePosition(currentPosition.value(), profile, field, world, 2) : bestPosition = {{0, 0}, 0};
     for (const auto &nestedPoints : searchGrid.getPoints()) {
         for (const Vector2 &position : nestedPoints) {
             if (!FieldComputations::pointIsValidPosition(field, position)) continue;
-            gen::ScoredPosition consideredPosition = scorePosition(position, profile, field, world);
+            gen::ScoredPosition consideredPosition = PositionScoring::scorePosition(position, profile, field, world);
             if (consideredPosition.score > bestPosition.score) bestPosition = consideredPosition;
         }
     }
     return bestPosition;
-}
-
-gen::ScoredPosition PositionComputations::scorePosition(const Vector2 &position, gen::ScoreProfile &profile, const world::Field &field, const world::World *world, uint8_t bias) {
-    gen::PositionScores &scores = calculatedScores[position];
-    uint8_t positionScore = getScoreOfPosition(profile, position, scores, field, world);
-    if (bias) positionScore = (positionScore + bias > bias) ? positionScore + bias : std::numeric_limits<uint8_t>::max();  // stop overflow of uint8_t (254+2 = 1)
-    return {position, positionScore};
-}
-
-uint8_t PositionComputations::getScoreOfPosition(gen::ScoreProfile &profile, Vector2 position, gen::PositionScores &scores, const rtt::world::Field &field,
-                                                 const rtt::world::World *world) {
-    double scoreTotal = 0;
-    double weightTotal = 0;
-    if (profile.weightGoalShot > 0) {
-        scoreTotal += scores.scoreGoalShot.value_or(determineGoalShotScore(position, field, world, scores)) * profile.weightGoalShot;
-        weightTotal += profile.weightGoalShot;
-    }
-    if (profile.weightLineOfSight > 0) {
-        scoreTotal += scores.scoreLineOfSight.value_or(determineLineOfSightScore(position, world, scores)) * profile.weightLineOfSight;
-        weightTotal += profile.weightLineOfSight;
-    }
-    if (profile.weightOpen > 0) {
-        scoreTotal += scores.scoreOpen.value_or(determineOpenScore(position, world, scores)) * profile.weightOpen;
-        weightTotal += profile.weightOpen;
-    }
-    if (profile.weightBlocking) {
-        scoreTotal += scores.scoreBlocking.value_or(determineBlockingScore(position, world, scores)) * profile.weightBlocking;
-        weightTotal += profile.weightBlocking;
-    }
-    return static_cast<uint8_t>(scoreTotal / weightTotal);
-}
-
-double PositionComputations::determineOpenScore(Vector2 &point, const rtt::world::World *world, gen::PositionScores &scores) {
-    std::vector<double> enemyDistances;
-    auto &them = world->getWorld()->getThem();
-    enemyDistances.reserve(them.size());
-    for (auto &enemyRobot : them) {
-        enemyDistances.push_back(point.dist(enemyRobot->getPos()));
-    }
-    return (scores.scoreOpen = stp::evaluation::OpennessEvaluation().metricCheck(enemyDistances)).value();
-}
-
-double PositionComputations::determineLineOfSightScore(Vector2 &point, const rtt::world::World *world, gen::PositionScores &scores) {
-    Vector2 ballPos = world->getWorld().value()->getBall()->get()->getPos();
-    double pointDistance = ballPos.dist(point);
-    double pointAngle = (ballPos - point).angle();
-    std::vector<double> enemyDistancesToBall;
-    std::vector<double> enemyAnglesToBallvsPoint;
-    auto &them = world->getWorld()->getThem();
-    enemyDistancesToBall.reserve(them.size());
-    enemyAnglesToBallvsPoint.reserve(them.size());
-    for (auto &enemyRobot : them) {
-        enemyDistancesToBall.push_back(ballPos.dist(enemyRobot->getPos()));
-        enemyAnglesToBallvsPoint.push_back((ballPos - enemyRobot->getPos()).angle() - pointAngle);
-    }
-    return (scores.scoreLineOfSight = stp::evaluation::LineOfSightEvaluation().metricCheck(pointDistance, enemyDistancesToBall, enemyAnglesToBallvsPoint)).value();
-}
-
-double PositionComputations::determineGoalShotScore(Vector2 &point, const rtt::world::Field &field, const rtt::world::World *world, gen::PositionScores &scores) {
-    double visibility = FieldComputations::getPercentageOfGoalVisibleFromPoint(field, false, point, world) / 100;
-    double goalDistance = FieldComputations::getDistanceToGoal(field, false, point);
-    double trialToGoalAngle = fabs((field.getTheirGoalCenter() - point).angle());
-    return (scores.scoreGoalShot = stp::evaluation::GoalShotEvaluation().metricCheck(visibility, goalDistance, trialToGoalAngle)).value();
-}
-
-double PositionComputations::determineBlockingScore(Vector2 &point, const rtt::world::World *world, gen::PositionScores &scores) {
-    Vector2 ballPos = world->getWorld().value()->getBall()->get()->getPos();
-    double pointDistance = ballPos.dist(point);
-    double pointAngle = (point - ballPos).angle();
-    std::vector<double> enemyDistances;
-    std::vector<double> enemyAnglesToBallvsPoint;
-    auto &them = world->getWorld()->getThem();
-    enemyDistances.reserve(them.size());
-    enemyAnglesToBallvsPoint.reserve(them.size());
-    for (auto &enemyRobot : them) {
-        enemyDistances.push_back(point.dist(enemyRobot->getPos()));
-        enemyAnglesToBallvsPoint.push_back((enemyRobot->getPos() - ballPos).angle() - pointAngle);
-    }
-    return (scores.scoreBlocking = stp::evaluation::BlockingEvaluation().metricCheck(pointDistance, enemyDistances, enemyAnglesToBallvsPoint)).value();
 }
 
 Vector2 PositionComputations::getWallPosition(int index, int amountDefenders, const rtt::world::Field &field, rtt::world::World *world) {

--- a/src/stp/computations/PositionScoring.cpp
+++ b/src/stp/computations/PositionScoring.cpp
@@ -1,0 +1,93 @@
+//
+// Created by alexander on 02-12-21.
+//
+
+#include "stp/computations/PositionScoring.h"
+
+#include <optional>
+
+#include "stp/evaluations/position/BlockingEvaluation.h"
+#include "stp/evaluations/position/GoalShotEvaluation.h"
+#include "stp/evaluations/position/LineOfSightEvaluation.h"
+#include "stp/evaluations/position/OpennessEvaluation.h"
+
+namespace rtt::ai::stp {
+gen::ScoredPosition PositionScoring::scorePosition(const Vector2 &position, gen::ScoreProfile &profile, const world::Field &field, const world::World *world, uint8_t bias) {
+    gen::PositionScores &scores = calculatedScores[position];
+    uint8_t positionScore = getScoreOfPosition(profile, position, scores, field, world);
+    if (bias) positionScore = (positionScore + bias > bias) ? positionScore + bias : std::numeric_limits<uint8_t>::max();  // stop overflow of uint8_t (254+2 = 1)
+    return {position, positionScore};
+}
+
+uint8_t PositionScoring::getScoreOfPosition(gen::ScoreProfile &profile, Vector2 position, gen::PositionScores &scores, const rtt::world::Field &field,
+                                            const rtt::world::World *world) {
+    double scoreTotal = 0;
+    double weightTotal = 0;
+    if (profile.weightGoalShot > 0) {
+        scoreTotal += scores.scoreGoalShot.value_or(determineGoalShotScore(position, field, world, scores)) * profile.weightGoalShot;
+        weightTotal += profile.weightGoalShot;
+    }
+    if (profile.weightLineOfSight > 0) {
+        scoreTotal += scores.scoreLineOfSight.value_or(determineLineOfSightScore(position, world, scores)) * profile.weightLineOfSight;
+        weightTotal += profile.weightLineOfSight;
+    }
+    if (profile.weightOpen > 0) {
+        scoreTotal += scores.scoreOpen.value_or(determineOpenScore(position, world, scores)) * profile.weightOpen;
+        weightTotal += profile.weightOpen;
+    }
+    if (profile.weightBlocking) {
+        scoreTotal += scores.scoreBlocking.value_or(determineBlockingScore(position, world, scores)) * profile.weightBlocking;
+        weightTotal += profile.weightBlocking;
+    }
+    return static_cast<uint8_t>(scoreTotal / weightTotal);
+}
+
+double PositionScoring::determineOpenScore(Vector2 &point, const rtt::world::World *world, gen::PositionScores &scores) {
+    std::vector<double> enemyDistances;
+    auto &them = world->getWorld()->getThem();
+    enemyDistances.reserve(them.size());
+    for (auto &enemyRobot : them) {
+        enemyDistances.push_back(point.dist(enemyRobot->getPos()));
+    }
+    return (scores.scoreOpen = stp::evaluation::OpennessEvaluation().metricCheck(enemyDistances)).value();
+}
+
+double PositionScoring::determineLineOfSightScore(Vector2 &point, const rtt::world::World *world, gen::PositionScores &scores) {
+    Vector2 ballPos = world->getWorld().value()->getBall()->get()->getPos();
+    double pointDistance = ballPos.dist(point);
+    double pointAngle = (ballPos - point).angle();
+    std::vector<double> enemyDistancesToBall;
+    std::vector<double> enemyAnglesToBallvsPoint;
+    auto &them = world->getWorld()->getThem();
+    enemyDistancesToBall.reserve(them.size());
+    enemyAnglesToBallvsPoint.reserve(them.size());
+    for (auto &enemyRobot : them) {
+        enemyDistancesToBall.push_back(ballPos.dist(enemyRobot->getPos()));
+        enemyAnglesToBallvsPoint.push_back((ballPos - enemyRobot->getPos()).angle() - pointAngle);
+    }
+    return (scores.scoreLineOfSight = stp::evaluation::LineOfSightEvaluation().metricCheck(pointDistance, enemyDistancesToBall, enemyAnglesToBallvsPoint)).value();
+}
+
+double PositionScoring::determineGoalShotScore(Vector2 &point, const rtt::world::Field &field, const rtt::world::World *world, gen::PositionScores &scores) {
+    double visibility = FieldComputations::getPercentageOfGoalVisibleFromPoint(field, false, point, world) / 100;
+    double goalDistance = FieldComputations::getDistanceToGoal(field, false, point);
+    double trialToGoalAngle = fabs((field.getTheirGoalCenter() - point).angle());
+    return (scores.scoreGoalShot = stp::evaluation::GoalShotEvaluation().metricCheck(visibility, goalDistance, trialToGoalAngle)).value();
+}
+
+double PositionScoring::determineBlockingScore(Vector2 &point, const rtt::world::World *world, gen::PositionScores &scores) {
+    Vector2 ballPos = world->getWorld().value()->getBall()->get()->getPos();
+    double pointDistance = ballPos.dist(point);
+    double pointAngle = (point - ballPos).angle();
+    std::vector<double> enemyDistances;
+    std::vector<double> enemyAnglesToBallvsPoint;
+    auto &them = world->getWorld()->getThem();
+    enemyDistances.reserve(them.size());
+    enemyAnglesToBallvsPoint.reserve(them.size());
+    for (auto &enemyRobot : them) {
+        enemyDistances.push_back(point.dist(enemyRobot->getPos()));
+        enemyAnglesToBallvsPoint.push_back((enemyRobot->getPos() - ballPos).angle() - pointAngle);
+    }
+    return (scores.scoreBlocking = stp::evaluation::BlockingEvaluation().metricCheck(pointDistance, enemyDistances, enemyAnglesToBallvsPoint)).value();
+}
+}  // namespace rtt::ai::stp

--- a/src/stp/computations/PositionScoring.cpp
+++ b/src/stp/computations/PositionScoring.cpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 
+#include "stp/computations/ComputationManager.h"
 #include "stp/evaluations/position/BlockingEvaluation.h"
 #include "stp/evaluations/position/GoalShotEvaluation.h"
 #include "stp/evaluations/position/LineOfSightEvaluation.h"
@@ -13,7 +14,7 @@
 
 namespace rtt::ai::stp {
 gen::ScoredPosition PositionScoring::scorePosition(const Vector2 &position, gen::ScoreProfile &profile, const world::Field &field, const world::World *world, uint8_t bias) {
-    gen::PositionScores &scores = calculatedScores[position];
+    gen::PositionScores &scores = ComputationManager::calculatedScores[position];
     uint8_t positionScore = getScoreOfPosition(profile, position, scores, field, world);
     if (bias) positionScore = (positionScore + bias > bias) ? positionScore + bias : std::numeric_limits<uint8_t>::max();  // stop overflow of uint8_t (254+2 = 1)
     return {position, positionScore};


### PR DESCRIPTION
### Summary

This PR changes two things:
1) PositionComputations is split up in PositionComputations and PositionScoring, as the former had functions that served two clearly distinct purposes in one file, which is not ideal.
2) Store computation results that can be reused in a central ComputationManager instead of in other classes. This allows all stored computations to be easily cleared in the application manager by calling a function in the ComputationManager class.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
