### PR TITLE
Change kick to be success if kicker no longer has ball

### DIFF
--- a/src/stp/skills/Kick.cpp
+++ b/src/stp/skills/Kick.cpp
@@ -35,7 +35,7 @@ Status Kick::onUpdate(const StpInfo &info) noexcept {
     // forward the generated command to the ControlModule, for checking and limiting
     forwardRobotCommand(info.getCurrentWorld());
 
-    if (info.getBall()->get()->getVelocity().length() > stp::control_constants::HAS_KICKED_ERROR_MARGIN) {
+    if (!info.getRobot()->hasBall()) {
         kickAttempts = 0;
         return Status::Success;
     }


### PR DESCRIPTION
### Summary

Previously, kick would return success if the ball had a velocity greater than a certain constant. This is less than ideal for two main reasons:
1) It is relatively slow to react after shooting the ball, as it takes some time for the velocity to reach the determined level
2) Other parts of the code, mainly the kickAtPos tactic, require the robot to have the ball in order to execute. If the robot kicks the ball, but does not immediately recognize it has done so, the kickAtPos tactic will fail since it cannot be ran without having the ball. This will lead to undesired behaviour as the robot role will go back to the previous tactic (for example, getBall) and then run after the ball after having kicked it.

By changing kick to be a success when the robot does not have the ball, it is ensured that this skill is finished as soon as possible after kicking.
This method is not perfect. Mainly, it can be an issue that the robot will think it has successfully kicked the ball even if it just loses the ball for a few milliseconds due to, for example, inconsistencies while rotating or imperfections on the field. However, this is not a big issue since the AI will then simply pick a new play (presumably trying to kick again) and correct this.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
