### PR TITLE
Update uses of dribbler to comply with new range of [0,1]

### DIFF
--- a/include/roboteam_ai/control/RobotCommand.h
+++ b/include/roboteam_ai/control/RobotCommand.h
@@ -18,7 +18,7 @@ class RobotCommand {
     Vector2 pos = Vector2();
     Vector2 vel = Vector2();
     Angle angle = Angle();
-    int dribbler = 0;
+    float dribbler = 0;
     bool kicker = false;
     double kickerVel = 0;
     bool kickerForced = false;

--- a/include/roboteam_ai/manual/JoystickHandler.h
+++ b/include/roboteam_ai/manual/JoystickHandler.h
@@ -19,7 +19,7 @@ class JoystickHandler {
     JoystickState joystickState;
     float robotAngle = 0.0;
     int robotId = -1;
-    int dribbler_vel = 0;
+    float dribbler_vel = 0;
     std::chrono::steady_clock::time_point id_switched_timestamp;
 
    public:

--- a/include/roboteam_ai/stp/skills/Rotate.h
+++ b/include/roboteam_ai/stp/skills/Rotate.h
@@ -22,6 +22,11 @@ class Rotate : public Skill {
      * @return The name of this skill
      */
     const char* getName() override;
+
+    /**
+     * Counts how long the robot is within the rotational error margin
+     */
+    int withinMarginCount = 0;
 };
 }  // namespace rtt::ai::stp::skill
 

--- a/src/manual/JoystickHandler.cpp
+++ b/src/manual/JoystickHandler.cpp
@@ -108,7 +108,7 @@ void JoystickHandler::toggleDribbler() {
         if (0 < command.dribbler()) {
             command.set_dribbler(0);
         } else {
-            command.set_dribbler(10);
+            command.set_dribbler(1);
         }
     }
 }
@@ -219,12 +219,12 @@ void JoystickHandler::handleJoystickHat(SDL_Event &event) {
 
 /* Sets dribber speed */
 void JoystickHandler::tuneDribbler() {
-    if (joystickState.triggerLeft > 32766) dribbler_vel -= 1;
+    if (joystickState.triggerLeft > 32766) dribbler_vel -= 0.03;
 
-    if (joystickState.triggerRight > 32766) dribbler_vel += 1;
+    if (joystickState.triggerRight > 32766) dribbler_vel += 0.03;
 
     if (dribbler_vel < 0) dribbler_vel = 0;
-    if (31 < dribbler_vel) dribbler_vel = 31;
+    if (1 < dribbler_vel) dribbler_vel = 1;
 
     command.set_dribbler(dribbler_vel);
 }

--- a/src/stp/skills/Chip.cpp
+++ b/src/stp/skills/Chip.cpp
@@ -16,7 +16,7 @@ Status Chip::onUpdate(const StpInfo &info) noexcept {
 
     // Clamp and set dribbler speed
     int targetDribblerPercentage = std::clamp(info.getDribblerSpeed(), 0, 10);
-    int targetDribblerSpeed = static_cast<int>(targetDribblerPercentage / 100.0 * stp::control_constants::MAX_DRIBBLER_CMD);
+    double targetDribblerSpeed = targetDribblerPercentage / 100.0 * stp::control_constants::MAX_DRIBBLER_CMD;
 
     // Set dribbler speed command
     command.set_dribbler(targetDribblerSpeed);

--- a/src/stp/skills/GoToPos.cpp
+++ b/src/stp/skills/GoToPos.cpp
@@ -52,7 +52,7 @@ Status GoToPos::onUpdate(const StpInfo &info) noexcept {
 
     // Clamp and set dribbler speed
     int targetDribblerPercentage = std::clamp(info.getDribblerSpeed(), 0, 100);
-    int targetDribblerSpeed = static_cast<int>(targetDribblerPercentage / 100.0 * stp::control_constants::MAX_DRIBBLER_CMD);
+    double targetDribblerSpeed = targetDribblerPercentage / 100.0 * stp::control_constants::MAX_DRIBBLER_CMD;
 
     // Set dribbler speed command
     command.set_dribbler(targetDribblerSpeed);

--- a/src/stp/skills/Kick.cpp
+++ b/src/stp/skills/Kick.cpp
@@ -16,7 +16,7 @@ Status Kick::onUpdate(const StpInfo &info) noexcept {
 
     // Clamp and set dribbler speed
     int targetDribblerPercentage = std::clamp(info.getDribblerSpeed(), 0, 10);
-    int targetDribblerSpeed = static_cast<int>(targetDribblerPercentage / 100.0 * stp::control_constants::MAX_DRIBBLER_CMD);
+    double targetDribblerSpeed = targetDribblerPercentage / 100.0 * stp::control_constants::MAX_DRIBBLER_CMD;
 
     // Set dribbler speed command
     command.set_dribbler(targetDribblerSpeed);

--- a/src/stp/skills/Rotate.cpp
+++ b/src/stp/skills/Rotate.cpp
@@ -27,9 +27,16 @@ Status Rotate::onUpdate(const StpInfo &info) noexcept {
     // forward the generated command to the ControlModule, for checking and limiting
     forwardRobotCommand(info.getCurrentWorld());
 
-    // Check if successful
+    // Check if the robot is within the error margin
     double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
     if (info.getRobot().value()->getAngle().shortestAngleDiff(targetAngle) < errorMargin) {
+        withinMarginCount += 1;
+    } else {
+        withinMarginCount = 0;
+    }
+
+    // Check whether the robot has been within the margin
+    if (withinMarginCount > 5) {
         return Status::Success;
     } else {
         return Status::Running;

--- a/src/stp/skills/Rotate.cpp
+++ b/src/stp/skills/Rotate.cpp
@@ -16,7 +16,7 @@ Status Rotate::onUpdate(const StpInfo &info) noexcept {
 
     // Clamp and set dribbler speed
     int targetDribblerPercentage = std::clamp(info.getDribblerSpeed(), 0, 30);
-    int targetDribblerSpeed = static_cast<int>(targetDribblerPercentage / 100.0 * stp::control_constants::MAX_DRIBBLER_CMD);
+    double targetDribblerSpeed = targetDribblerPercentage / 100.0 * stp::control_constants::MAX_DRIBBLER_CMD;
 
     // Set dribbler speed command
     command.set_dribbler(targetDribblerSpeed);

--- a/src/stp/skills/Shoot.cpp
+++ b/src/stp/skills/Shoot.cpp
@@ -29,7 +29,7 @@ Status Shoot::onUpdateKick(const StpInfo &info) noexcept {
 
     // Clamp and set dribbler speed
     int targetDribblerPercentage = std::clamp(info.getDribblerSpeed(), 0, 10);
-    int targetDribblerSpeed = static_cast<int>(targetDribblerPercentage / 100.0 * stp::control_constants::MAX_DRIBBLER_CMD);
+    double targetDribblerSpeed = targetDribblerPercentage / 100.0 * stp::control_constants::MAX_DRIBBLER_CMD;
 
     // Set dribbler speed command
     command.set_dribbler(targetDribblerSpeed);

--- a/src/utilities/Constants.cpp
+++ b/src/utilities/Constants.cpp
@@ -66,7 +66,7 @@ double Constants::MIN_ANGLE() { return -M_PI; }
 
 double Constants::MAX_ANGLE() { return M_PI; }
 
-int Constants::MAX_DRIBBLER_CMD() { return 31; }
+int Constants::MAX_DRIBBLER_CMD() { return 1; }
 
 double Constants::MIN_VEL() { return 0.2; }
 


### PR DESCRIPTION
The expected value of the dribbler command is [0,1]. The old maximum was 31. There were still some uses of the old range. This PR updates those to be compliant with the [0,1] range.

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
