### PR TITLE
Check whether rotate is done for 5 ticks before actually finishing

### DIFF
--- a/include/roboteam_ai/stp/skills/Rotate.h
+++ b/include/roboteam_ai/stp/skills/Rotate.h
@@ -22,6 +22,11 @@ class Rotate : public Skill {
      * @return The name of this skill
      */
     const char* getName() override;
+
+    /**
+     * Counts how long the robot is within the rotational error margin
+     */
+    int withinMarginCount = 0;
 };
 }  // namespace rtt::ai::stp::skill
 

--- a/src/stp/skills/Rotate.cpp
+++ b/src/stp/skills/Rotate.cpp
@@ -27,9 +27,16 @@ Status Rotate::onUpdate(const StpInfo &info) noexcept {
     // forward the generated command to the ControlModule, for checking and limiting
     forwardRobotCommand(info.getCurrentWorld());
 
-    // Check if successful
+    // Check if the robot is within the error margin
     double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
     if (info.getRobot().value()->getAngle().shortestAngleDiff(targetAngle) < errorMargin) {
+        withinMarginCount += 1;
+    } else {
+        withinMarginCount = 0;
+    }
+
+    // Check whether the robot has been within the margin
+    if (withinMarginCount > 5) {
         return Status::Success;
     } else {
         return Status::Running;


### PR DESCRIPTION
#### Summary

Since the robots tend to overshoot when rotating, it can happen that the robot is within the error margin for a little bit before leaving it again due to overshoot. When this happens, we do not want rotate to terminate, since the end state is not where we want it to be. By checking whether the robot is within the error margin for 5 ticks, it will not return success when passing through the target angle while overshooting.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
