### PR TITLE
Revert "Changed call to Hungarian in Dealer.cpp"

### DIFF
--- a/src/utilities/Dealer.cpp
+++ b/src/utilities/Dealer.cpp
@@ -51,8 +51,7 @@ std::unordered_map<std::string, v::RobotView> Dealer::distribute(std::vector<v::
         }
         if (!current.currentRoles.empty()) {
             // Return best assignment for those roles (column)
-            auto linearAssignment = Hungarian();
-            current.newAssignments = linearAssignment.Solve(current.currentScores);
+            rtt::Hungarian::Solve(current.currentScores, current.newAssignments);
             if (!current.newAssignments.empty()) {
                 for (std::size_t j = 0; j < current.newAssignments.size(); j++) {
                     if (current.newAssignments[j] >= 0) {


### PR DESCRIPTION
Reverts RoboTeamTwente/roboteam_ai#1275

The hungarian function contained an error which resulted in a function not terminating. This then snowballed into more problems, of which a freezing GUI was one.
Alex and Floris decided to roll back this PR, in order to give Max some time to fix it and give others the possibility to work on other stuff in the meantime