### PR TITLE
Changed MAX_CHIP_POWER from 8 to 6.5

### DIFF
--- a/src/stp/constants/ControlConstants.cpp
+++ b/src/stp/constants/ControlConstants.cpp
@@ -12,7 +12,7 @@ constexpr double MAX_KICK_POWER = 6.5;
 constexpr double MIN_KICK_POWER = 0.123;
 constexpr double MAX_POWER_KICK_DISTANCE = 8;
 constexpr double MAX_POWER_CHIP_DISTANCE = 9;
-constexpr double MAX_CHIP_POWER = 8;
+constexpr double MAX_CHIP_POWER = 6.5;
 constexpr double MIN_CHIP_POWER = 1.01;
 // Max attempts before the force_kick_chip is set to true
 constexpr double MAX_KICK_ATTEMPTS = 25;


### PR DESCRIPTION
The MAX_CHIP_POWER should be the same as the MAX_KICK_POWER, which should both be 6.5. This is namely the upper boundry that control uses for this value. Setting it to 8 wouldn't make sense.

### Comments for the reviewer
- 

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
