### PR TITLE
Improve movement computations and completion check in orbit

### DIFF
--- a/include/roboteam_ai/stp/skills/Orbit.h
+++ b/include/roboteam_ai/stp/skills/Orbit.h
@@ -5,6 +5,7 @@
 #ifndef RTT_ORBIT_H
 #define RTT_ORBIT_H
 
+#include "roboteam_utils/pid.h"
 #include "stp/Skill.h"
 
 namespace rtt::ai::stp::skill {
@@ -22,6 +23,16 @@ class Orbit : public Skill {
      * @return The name of this skill
      */
     const char* getName() override;
+
+    /**
+     * Counter for how many ticks the robot is within the error margin
+     */
+    int counter = 0;
+
+    /**
+     * PID controller to determine velocity multiplier
+     */
+    PID velPid = PID(0.75, 0, 0);
 };
 }  // namespace rtt::ai::stp::skill
 

--- a/src/stp/skills/Orbit.cpp
+++ b/src/stp/skills/Orbit.cpp
@@ -4,36 +4,37 @@
 
 #include "stp/skills/Orbit.h"
 
-#include <ApplicationManager.h>
-
-#include "control/ControlUtils.h"
-
 namespace rtt::ai::stp::skill {
 
 Status Orbit::onUpdate(const StpInfo &info) noexcept {
     Vector2 directionVector = (info.getBall()->get()->getPos() - info.getRobot()->get()->getPos());
-    Angle normalAngle = directionVector.rotate(M_PI).rotate(M_PI_2).toAngle();
+    double normalAngle = directionVector.rotate(M_PI).rotate(M_PI_2).angle();
+    Angle targetAngle = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).toAngle();
 
-    Vector2 initialVelocity = info.getRobot()->get()->getVel();
-    double initX = cos(initialVelocity.toAngle()) * initialVelocity.length();
-    double initY = sin(initialVelocity.toAngle()) * initialVelocity.length();
+    double margin = control_constants::ROBOT_RADIUS + 1.5 * stp::control_constants::BALL_RADIUS;
+    double adjustDistance = (info.getRobot()->get()->getDistanceToBall() - margin);
 
-    double margin = stp::control_constants::ROBOT_RADIUS + 2 * stp::control_constants::BALL_RADIUS;
-    Vector2 adjustDistance = directionVector.normalize().scale(info.getRobot()->get()->getDistanceToBall() - margin);
+    // Get the direction of movement, counterclockwise or clockwise
+    auto direction = Angle(directionVector).rotateDirection(targetAngle) ? -1.0 : 1.0;
 
-    double multiplier = -sin(0.5 * (directionVector - info.getAngle()).toAngle());
+    double error = targetAngle.shortestAngleDiff(directionVector.angle());
+    error = error * direction;
 
-    double x = cos(normalAngle) * multiplier + cos(adjustDistance.toAngle()) * adjustDistance.length();  //- initX adjustment for initial velocity?;
-    double y = sin(normalAngle) * multiplier + sin(adjustDistance.toAngle()) * adjustDistance.length();  //- initY adjustment for initial velocity?;
+    // Use PID controller to determine desired velocity multiplier
+    auto multiplier = velPid.getOutput(error, 0);
 
-    double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
-    command.set_w(info.getAngle());
+    // Velocity consists of a part to create the circular movement, and an adjustment for distance to the ball
+    Vector2 targetVelocity;
+    targetVelocity.x = cos(normalAngle) * multiplier + 3 * cos(directionVector.toAngle()) * adjustDistance;
+    targetVelocity.y = sin(normalAngle) * multiplier + 3 * sin(directionVector.toAngle()) * adjustDistance;
 
-    // Don't rotate and move at the same time
-    if (info.getRobot().value()->getAngle().shortestAngleDiff(info.getAngle()) < M_PI_4) {
-        command.mutable_vel()->set_x(static_cast<float>(x));
-        command.mutable_vel()->set_y(static_cast<float>(y));
-    }
+    auto maxVel = 0.65;
+    if (targetVelocity.length() > maxVel) targetVelocity = targetVelocity.stretchToLength(maxVel);
+
+    command.mutable_vel()->set_x(static_cast<float>(targetVelocity.x));
+    command.mutable_vel()->set_y(static_cast<float>(targetVelocity.y));
+
+    command.set_w(targetAngle);
 
     // set command ID
     command.set_id(info.getRobot().value()->getId());
@@ -42,11 +43,18 @@ Status Orbit::onUpdate(const StpInfo &info) noexcept {
     forwardRobotCommand(info.getCurrentWorld());
 
     // Check if successful
-    if (directionVector.rotate(M_PI).toAngle().shortestAngleDiff(info.getAngle()) < errorMargin) {
-        return Status::Success;
+    double errorMargin = stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
+    if (directionVector.toAngle().shortestAngleDiff(targetAngle) < errorMargin) {
+        counter++;
+    } else {
+        counter = 0;
     }
 
-    return Status::Running;
+    // If the robot is within the error margin for 5 consecutive ticks, return success
+    if (counter > 5)
+        return Status::Success;
+    else
+        return Status::Running;
 }
 
 const char *Orbit::getName() { return "Orbit"; }

--- a/src/stp/skills/Orbit.cpp
+++ b/src/stp/skills/Orbit.cpp
@@ -9,7 +9,7 @@ namespace rtt::ai::stp::skill {
 Status Orbit::onUpdate(const StpInfo &info) noexcept {
     Vector2 directionVector = (info.getBall()->get()->getPos() - info.getRobot()->get()->getPos());
     double normalAngle = directionVector.rotate(M_PI).rotate(M_PI_2).angle();
-    Angle targetAngle = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).toAngle();
+    Angle targetAngle = (info.getPositionToShootAt().value() - info.getBall()->get()->getPos()).toAngle();
 
     double margin = control_constants::ROBOT_RADIUS + 1.5 * stp::control_constants::BALL_RADIUS;
     double adjustDistance = (info.getRobot()->get()->getDistanceToBall() - margin);

--- a/src/stp/skills/Orbit.cpp
+++ b/src/stp/skills/Orbit.cpp
@@ -28,7 +28,8 @@ Status Orbit::onUpdate(const StpInfo &info) noexcept {
     targetVelocity.x = cos(normalAngle) * multiplier + 3 * cos(directionVector.toAngle()) * adjustDistance;
     targetVelocity.y = sin(normalAngle) * multiplier + 3 * sin(directionVector.toAngle()) * adjustDistance;
 
-    auto maxVel = 0.65;
+    auto maxVel = directionVector.length() * 4;
+    if (maxVel < 0.65) maxVel = 0.65;
     if (targetVelocity.length() > maxVel) targetVelocity = targetVelocity.stretchToLength(maxVel);
 
     command.mutable_vel()->set_x(static_cast<float>(targetVelocity.x));


### PR DESCRIPTION
This PR changes orbit to be more consistent and effective by changing several things.
1) using PID control to calculate the multiplier
2) Setting a max vel to avoid moving faster than is feasible while making a circle
3) Checking if orbit is within the error for 5 ticks instead of 1 before returning success

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
