### PR TITLE
Remove plays that are not needed for minimum viable product

### DIFF
--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -55,29 +55,29 @@ void ApplicationManager::start() {
     /// This play is only used for testing purposes, when needed uncomment this play!
     // plays.emplace_back(std::make_unique<rtt::ai::stp::TestPlay>());
 
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::AttackingPass>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::AttackingPass>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::Attack>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::Halt>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::DefendShot>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::DefendPass>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::DefendPass>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::DefensiveStopFormation>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::AggressiveStopFormation>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::BallPlacementUs>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::BallPlacementThem>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::TimeOut>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::PenaltyThemPrepare>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::PenaltyUsPrepare>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::PenaltyThem>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::PenaltyUs>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::TimeOut>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::PenaltyThemPrepare>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::PenaltyUsPrepare>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::PenaltyThem>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::PenaltyUs>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::KickOffUsPrepare>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::KickOffThemPrepare>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::FreeKickThem>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::FreeKickThem>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::KickOffUs>());
     plays.emplace_back(std::make_unique<rtt::ai::stp::play::KickOffThem>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::GetBallPossession>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::GetBallRisky>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::ReflectKick>());
-    plays.emplace_back(std::make_unique<rtt::ai::stp::play::GenericPass>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::GetBallPossession>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::GetBallRisky>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::ReflectKick>());
+    //plays.emplace_back(std::make_unique<rtt::ai::stp::play::GenericPass>());
     playChecker.setPlays(plays);
 
     int amountOfCycles = 0;


### PR DESCRIPTION
As discussed with the AI team (see AI plan of attack presentation in drive>software>ai>presentations), we will focus on creating a minimum viable product only containing the plays absolutely necessary to play a game. This PR comments out the other plays, so that they will not be picked by the playDecider.

These plays will be added back later on, after being tested carefully.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
