### PR TITLE
Switch to normal play gamestate after kickoff is done

### DIFF
--- a/include/roboteam_ai/stp/Play.hpp
+++ b/include/roboteam_ai/stp/Play.hpp
@@ -174,6 +174,12 @@ class Play {
     // virtual bool shouldRoleSkipEndTactic() = 0;
 
     /**
+     * Optional function to force end plays
+     * @return True if play should end this tick
+     */
+    virtual bool shouldEndPlay() noexcept;
+
+    /**
      * Map that holds info from the previous play
      */
     std::optional<gen::PlayInfos> previousPlayInfos;
@@ -201,12 +207,6 @@ class Play {
      * This is used to check if we need to re-deal (if a robot disappears for example)
      */
     int previousRobotNum{};
-
-    /**
-     * Optional function to force end plays
-     * @return True if play should end this tick
-     */
-    bool shouldEndPlay() noexcept;
 };
 }  // namespace rtt::ai::stp
 

--- a/include/roboteam_ai/stp/plays/referee_specific/KickOffThem.h
+++ b/include/roboteam_ai/stp/plays/referee_specific/KickOffThem.h
@@ -43,6 +43,11 @@ class KickOffThem : public Play {
     void calculateInfoForScoredRoles(world::World*) noexcept override{};
 
     /**
+     * Check if the play should end. True after kickoff
+     */
+    bool shouldEndPlay() noexcept override;
+
+    /**
      * Gets the play name
      */
     const char* getName() override;

--- a/include/roboteam_ai/stp/plays/referee_specific/KickOffUs.h
+++ b/include/roboteam_ai/stp/plays/referee_specific/KickOffUs.h
@@ -43,6 +43,11 @@ class KickOffUs : public Play {
     void calculateInfoForScoredRoles(world::World*) noexcept override{};
 
     /**
+     * Check if the play should end. True after kickoff
+     */
+    bool shouldEndPlay() noexcept override;
+
+    /**
      * Gets the play name
      */
     const char* getName() override;

--- a/src/stp/plays/referee_specific/KickOffThem.cpp
+++ b/src/stp/plays/referee_specific/KickOffThem.cpp
@@ -6,6 +6,7 @@
 
 #include "stp/roles/Keeper.h"
 #include "stp/roles/passive/Halt.h"
+#include "utilities/GameStateManager.hpp"
 
 namespace rtt::ai::stp::play {
 
@@ -52,6 +53,15 @@ Dealer::FlagMap KickOffThem::decideRoleFlags() const noexcept {
     flagMap.insert({"halt_9", {DealerFlagPriority::LOW_PRIORITY, {}}});
 
     return flagMap;
+}
+
+bool KickOffThem::shouldEndPlay() noexcept {
+    if (world->getWorld()->getBall()->get()->getFilteredVelocity().length() > control_constants::BALL_GOT_SHOT_LIMIT) {
+        // Return to normal play after kickoff is done
+        GameStateManager::forceNewGameState(RefCommand::NORMAL_START, std::nullopt);
+        return true;
+    }
+    return false;
 }
 
 const char *KickOffThem::getName() { return "Kick Off Them"; }

--- a/src/stp/plays/referee_specific/KickOffUs.cpp
+++ b/src/stp/plays/referee_specific/KickOffUs.cpp
@@ -9,6 +9,7 @@
 #include "stp/roles/active/Passer.h"
 #include "stp/roles/passive/Formation.h"
 #include "stp/roles/passive/Halt.h"
+#include "utilities/GameStateManager.hpp"
 
 namespace rtt::ai::stp::play {
 
@@ -68,6 +69,14 @@ Dealer::FlagMap KickOffUs::decideRoleFlags() const noexcept {
     return flagMap;
 }
 
-const char *KickOffUs::getName() { return "Kick Off Us"; }
+bool KickOffUs::shouldEndPlay() noexcept {
+    if (world->getWorld()->getBall()->get()->getFilteredVelocity().length() > control_constants::BALL_GOT_SHOT_LIMIT) {
+        // Return to normal play after kickoff is done
+        GameStateManager::forceNewGameState(RefCommand::NORMAL_START, std::nullopt);
+        return true;
+    }
+    return false;
+}
 
+const char *KickOffUs::getName() { return "Kick Off Us"; }
 }  // namespace rtt::ai::stp::play


### PR DESCRIPTION
### Summary
When the referee issues the "normal_start" command after a kickoff_prepare command, we go into kickoff_us/them gamestate to ensure the relevant play is selected. After the kickoff has happened, this play should end and the gamestate should return to normal_play. To do this, the shouldEndPlay function is implemented to end the play when the ball has been kicked. When this is true, the gamestate is also changed to normal start through the gamestatemanager.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
