### PR TITLE
Delete central server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,14 +19,14 @@ if (APPLE)
 else (NOT APPLE)
     set(CMAKE_AUTOMOC ON)
     set(GTEST_LIB
-            PRIVATE gtest
-            PRIVATE gmock)
+            PUBLIC gtest
+            PUBLIC gmock)
 endif ()
 
-find_package(Qt5 COMPONENTS Core Widgets Gui Charts REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Charts REQUIRED)
 
-
-set(UTILS_SOURCES
+###### UTILS #######
+add_library(roboteam_ai_utils
         ${PROJECT_SOURCE_DIR}/src/utilities/GameStateManager.cpp
         ${PROJECT_SOURCE_DIR}/src/utilities/Constants.cpp
         ${PROJECT_SOURCE_DIR}/src/utilities/Pause.cpp
@@ -36,14 +36,33 @@ set(UTILS_SOURCES
         ${PROJECT_SOURCE_DIR}/src/utilities/Settings.cpp
         ${PROJECT_SOURCE_DIR}/src/utilities/StrategyManager.cpp
         ${PROJECT_SOURCE_DIR}/src/utilities/normalize.cpp
-        )
+)
+target_link_libraries(roboteam_ai_utils
+        PRIVATE roboteam_networking
+        PRIVATE roboteam_utils
+        PRIVATE Qt5::Widgets
+)
+target_include_directories(roboteam_ai_utils
+        PRIVATE include/roboteam_ai
+)
 
-set(MANUAL_SOURCES
+###### MANUAL #######
+add_library(roboteam_ai_manual
         ${PROJECT_SOURCE_DIR}/src/manual/JoystickManager.cpp
         ${PROJECT_SOURCE_DIR}/src/manual/JoystickHandler.cpp
-        )
+)
+target_include_directories(roboteam_ai_manual
+        PRIVATE include/roboteam_ai
+)
+target_link_libraries(roboteam_ai_manual
+        PRIVATE roboteam_networking
+        PRIVATE roboteam_utils
+        PRIVATE SDL2
+        PRIVATE Qt5::Widgets
+)
 
-set(SKILLS_SOURCES
+###### SKILLS #######
+add_library(roboteam_ai_skills
         ${PROJECT_SOURCE_DIR}/src/stp/Skill.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/skills/Kick.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/skills/Chip.cpp
@@ -52,9 +71,18 @@ set(SKILLS_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/skills/Shoot.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/skills/Orbit.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/skills/TestSkill.cpp
-        )
+)
+target_include_directories(roboteam_ai_skills
+        PRIVATE include/roboteam_ai
+)
+target_link_libraries(roboteam_ai_skills
+        PRIVATE roboteam_networking
+        PRIVATE roboteam_utils
+        PRIVATE Qt5::Widgets
+)
 
-set(TACTICS_SOURCES
+###### TACTICS #######
+add_library(roboteam_ai_tactics
         ${PROJECT_SOURCE_DIR}/src/stp/Tactic.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/constants/ControlConstants.cpp
         # /
@@ -76,9 +104,19 @@ set(TACTICS_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/tactics/passive/BlockRobot.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/tactics/passive/Formation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/tactics/passive/Halt.cpp
-        ${PROJECT_SOURCE_DIR}/src/stp/tactics/passive/Walling.cpp)
+        ${PROJECT_SOURCE_DIR}/src/stp/tactics/passive/Walling.cpp
+)
+target_include_directories(roboteam_ai_tactics
+        PRIVATE include/roboteam_ai
+)
+target_link_libraries(roboteam_ai_tactics
+        PRIVATE roboteam_utils
+        PRIVATE roboteam_networking
+        PRIVATE Qt5::Widgets
+)
 
-set(ROLES_SOURCES
+###### ROLES #######
+add_library(roboteam_ai_roles
         ${PROJECT_SOURCE_DIR}/src/stp/Role.cpp
         # /
         ${PROJECT_SOURCE_DIR}/src/stp/roles/TestRole.cpp
@@ -97,9 +135,19 @@ set(ROLES_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/roles/passive/Formation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/roles/passive/Halt.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/roles/passive/Harasser.cpp
-        ${PROJECT_SOURCE_DIR}/src/stp/roles/passive/Waller.cpp)
+        ${PROJECT_SOURCE_DIR}/src/stp/roles/passive/Waller.cpp
+)
+target_include_directories(roboteam_ai_roles
+        PRIVATE include/roboteam_ai
+)
+target_link_libraries(roboteam_ai_roles
+        PRIVATE roboteam_utils
+        PRIVATE roboteam_networking
+        PRIVATE Qt5::Widgets
+)
 
-set(PLAYS_SOURCES
+###### PLAYS #######
+add_library(roboteam_ai_plays
         ${PROJECT_SOURCE_DIR}/src/stp/Play.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/PlayChecker.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/PlayDecider.cpp
@@ -134,9 +182,20 @@ set(PLAYS_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/plays/referee_specific/PenaltyUs.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/plays/referee_specific/PenaltyUsPrepare.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/plays/referee_specific/TimeOut.cpp
-        )
+)
+target_include_directories(roboteam_ai_plays
+        PRIVATE include/roboteam_ai
+)
+target_link_libraries(roboteam_ai_plays
+        PRIVATE roboteam_networking
+        PRIVATE roboteam_utils
+        PRIVATE Qt5::Widgets
+        PRIVATE SDL2
+        PRIVATE NFParam
+)
 
-set(EVALUATION_SOURCES
+###### EVALUATION #######
+add_library(roboteam_ai_evaluation
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/global/WeHaveBallGlobalEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/global/BallGotShotGlobalEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/global/BallMovesSlowGlobalEvaluation.cpp
@@ -150,6 +209,8 @@ set(EVALUATION_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/global/GoalVisionGlobalEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/global/GoalVisionFromBallGlobalEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/global/BallIsFreeGlobalEvaluation.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/evaluations/global/TheyHaveBallGlobalEvaluation.cpp
+        ${PROJECT_SOURCE_DIR}/src/stp/evaluations/global/TheyDoNotHaveBallGlobalEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/global/NoGoalVisionFromBallGlobalEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/global/BallClosestToUsGlobalEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/game_states/BallPlacementUsGameStateEvaluation.cpp
@@ -174,16 +235,36 @@ set(EVALUATION_SOURCES
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/position/GoalShotEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/position/TimeToPositionEvaluation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/evaluations/position/BlockingEvaluation.cpp
-        )
+)
+target_include_directories(roboteam_ai_evaluation
+        PRIVATE include/roboteam_ai
+)
+target_link_libraries(roboteam_ai_evaluation
+        PRIVATE roboteam_networking
+        PRIVATE roboteam_utils
+        PRIVATE Qt5::Widgets
+        PRIVATE NFParam
+)
 
-set(COMPUTATION_SOURCES
+###### COMPUTATION #######
+add_library(roboteam_ai_computation
         ${PROJECT_SOURCE_DIR}/src/stp/computations/PositionComputations.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/computations/GoalComputations.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/computations/PassComputations.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/computations/PositionScoring.cpp
-        )
+)
+target_include_directories(roboteam_ai_computation
+        PRIVATE include/roboteam_ai
+)
+target_link_libraries(roboteam_ai_computation
+        PRIVATE roboteam_utils
+        PRIVATE Qt5::Widgets
+        PRIVATE roboteam_networking
+        PRIVATE NFParam
+)
 
-set(CONTROL_SOURCES
+###### CONTROL #######
+add_library(roboteam_ai_control
         ${PROJECT_SOURCE_DIR}/src/control/ControlModule.cpp
         ${PROJECT_SOURCE_DIR}/src/control/ControlUtils.cpp
         ${PROJECT_SOURCE_DIR}/src/control/positionControl/pathPlanning/NumTreesPlanning.cpp
@@ -202,29 +283,18 @@ set(CONTROL_SOURCES
         ${PROJECT_SOURCE_DIR}/src/control/positionControl/BBTrajectories/WorldObjects.cpp
         ${PROJECT_SOURCE_DIR}/src/control/positionControl/BBTrajectories/WorldObjects.cpp
         ${PROJECT_SOURCE_DIR}/src/control/positionControl/BBTrajectories/WorldObjects.cpp
-        src/control/AnglePID.cpp
-        )
+        ${PROJECT_SOURCE_DIR}/src/control/AnglePID.cpp
+)
+target_include_directories(roboteam_ai_control
+        PRIVATE include/roboteam_ai
+)
+target_link_libraries(roboteam_ai_control
+        PRIVATE roboteam_networking
+        PRIVATE roboteam_utils
+        PRIVATE Qt5::Widgets
+)
 
-set(TEST_SOURCES
-        ${PROJECT_SOURCE_DIR}/test/main.cpp
-        ${PROJECT_SOURCE_DIR}/test/ControlTests/ControlUtilsTest.cpp
-        ${PROJECT_SOURCE_DIR}/test/UtilTests/RefereeTest.cpp
-        ${PROJECT_SOURCE_DIR}/test/helpers/WorldHelper.h
-        ${PROJECT_SOURCE_DIR}/test/helpers/WorldHelper.cpp
-        ${PROJECT_SOURCE_DIR}/test/helpers/FieldHelper.h
-        ${PROJECT_SOURCE_DIR}/test/helpers/FieldHelper.cpp
-        ${PROJECT_SOURCE_DIR}/test/WorldTests/BallTests.cpp
-        ${PROJECT_SOURCE_DIR}/test/WorldTests/RobotTests.cpp
-        ${PROJECT_SOURCE_DIR}/test/WorldTests/FieldComputationTest.cpp
-        ${PROJECT_SOURCE_DIR}/test/WorldTests/HistorySizeTest.cpp
-        ${PROJECT_SOURCE_DIR}/test/WorldTests/HistoryRetrievalTest.cpp
-        ${PROJECT_SOURCE_DIR}/test/WorldTests/WhichRobotHasBallTest.cpp
-        ${PROJECT_SOURCE_DIR}/test/WorldTests/WorldResetTests.cpp
-        ${PROJECT_SOURCE_DIR}/test/StpTests/PlayCheckerTests.cpp
-        ${PROJECT_SOURCE_DIR}/test/StpTests/PlayDeciderTests.cpp
-        ${PROJECT_SOURCE_DIR}/test/StpTests/TacticTests.cpp
-        test/ControlTests/BBTrajectory/BBTrajectory1DTest.cpp)
-
+###### INTERFACE *HEADERS* #######
 set(INTERFACE_HEADERS
         #QT wants to know about these headers
         ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/PidBox.h
@@ -239,9 +309,12 @@ set(INTERFACE_HEADERS
         ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/SettingsWidget.h
         ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/ManualControlWidget.h
         ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/PlaysWidget.hpp
-        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/GraphWidget.h)
+        ${PROJECT_SOURCE_DIR}/include/roboteam_ai/interface/widgets/GraphWidget.h
+)
 
-set(INTERFACE_SOURCES
+###### INTERFACE #######
+add_library(roboteam_ai_interface
+        ${INTERFACE_HEADERS}
         ${PROJECT_SOURCE_DIR}/src/interface/widgets/mainWindow.cpp
         ${PROJECT_SOURCE_DIR}/src/interface/widgets/widget.cpp
         ${PROJECT_SOURCE_DIR}/src/interface/api/Input.cpp
@@ -258,9 +331,19 @@ set(INTERFACE_SOURCES
         ${PROJECT_SOURCE_DIR}/src/interface/widgets/SettingsWidget.cpp
         ${PROJECT_SOURCE_DIR}/src/interface/widgets/ManualControlWidget.cpp
         ${PROJECT_SOURCE_DIR}/src/interface/widgets/PlaysWidget.cpp
-        )
+)
+target_include_directories(roboteam_ai_interface
+        PRIVATE include/roboteam_ai
+)
+target_link_libraries(roboteam_ai_interface
+        PRIVATE Qt5::Widgets
+        PRIVATE roboteam_networking
+        PRIVATE roboteam_utils
+        PRIVATE SDL2
+)
 
-set(WORLD_SOURCES
+###### WORLD #######
+add_library(roboteam_ai_world
         ${PROJECT_SOURCE_DIR}/src/world/FieldComputations.cpp
         ${PROJECT_SOURCE_DIR}/src/world/Field.cpp
         ${PROJECT_SOURCE_DIR}/src/world/Ball.cpp
@@ -270,65 +353,85 @@ set(WORLD_SOURCES
         ${PROJECT_SOURCE_DIR}/src/world/views/WorldDataView.cpp
         ${PROJECT_SOURCE_DIR}/src/world/views/RobotView.cpp
         ${PROJECT_SOURCE_DIR}/src/world/views/BallView.cpp
-        )
-
-# Putting it all together so we can use it in both the main executable and the test executable
-set(AI_SOURCES
-        ${PROJECT_SOURCE_DIR}/src/ApplicationManager.cpp
-        ${UTILS_SOURCES}
-        ${SKILLS_SOURCES}
-        ${TACTICS_SOURCES}
-        ${ROLES_SOURCES}
-        ${PLAYS_SOURCES}
-        ${EVALUATION_SOURCES}
-        ${CONTROL_SOURCES}
-        ${INTERFACE_SOURCES}
-        ${WORLD_SOURCES}
-        ${MANUAL_SOURCES}
-        ${COMPUTATION_SOURCES}
-        )
-
-set(AI_LIBS
-        PRIVATE Qt5::Core
-        PRIVATE Qt5::Widgets
-        PRIVATE Qt5::Gui
-        PRIVATE Qt5::Charts
-        PRIVATE roboteam_utils
-        PRIVATE NFParam
-        PRIVATE SDL2
-        PRIVATE roboteam_networking
-        )
-
-set(AI_INCLUDES
-        INTERFACE include
+)
+target_include_directories(roboteam_ai_world
         PRIVATE include/roboteam_ai
-        )
+)
+target_link_libraries(roboteam_ai_world
+        PRIVATE roboteam_networking
+        PRIVATE roboteam_utils
+        PRIVATE Qt5::Widgets
+)
 
-# Apple-specific fixes and separate out old interface for performance
-if(APPLE)
-    # AUTOMOC is borked on CMAKE 3.21.0 + moc 5.15.2 + libprotoc 3.17.3
-    # AUTOMOC tries to moc *.pb.h and fails because ./moc dislikes strange enums?
-    QT5_WRAP_CPP(ai_iface_moc ${INTERFACE_HEADERS})
-    add_library(ai_iface ${ai_iface_moc})
-else()
-    add_library(ai_iface ${INTERFACE_HEADERS})
-endif()
+###### MAIN #######
+add_executable(roboteam_ai
+        ${PROJECT_SOURCE_DIR}/src/ApplicationManager.cpp
+        ${PROJECT_SOURCE_DIR}/src/roboteam_ai.cpp
+)
+target_include_directories(roboteam_ai
+        PRIVATE include/roboteam_ai
+)
+target_link_libraries(roboteam_ai
+        PRIVATE roboteam_utils
+        PRIVATE Qt5::Widgets
+        PRIVATE roboteam_networking
+        PRIVATE SDL2
+        # Watch out! The order of these libraries apparently matters!
+        PRIVATE roboteam_ai_interface
+        PRIVATE roboteam_ai_plays
+        PRIVATE roboteam_ai_world
+        PRIVATE roboteam_ai_control
+        PRIVATE roboteam_ai_roles
+        PRIVATE Qt5::Charts
+        PRIVATE roboteam_ai_manual
+        PRIVATE roboteam_ai_utils
+        PRIVATE roboteam_ai_computation
+        PRIVATE roboteam_ai_tactics
+        PRIVATE roboteam_ai_evaluation
+        PRIVATE roboteam_ai_skills
+)
 
-target_link_libraries(ai_iface ${AI_LIBS})
-target_include_directories(ai_iface ${AI_INCLUDES})
-
-add_library(ai_lib ${AI_SOURCES})
-target_link_libraries(ai_lib ${AI_LIBS})
-target_include_directories(ai_lib ${AI_INCLUDES})
-
-# Main Executable
-add_executable(roboteam_ai src/roboteam_ai.cpp)
-target_link_libraries(roboteam_ai ${AI_LIBS} ai_lib ai_iface)
-target_include_directories(roboteam_ai ${AI_INCLUDES})
-
-# Testing #
-#add_executable(ai_tests ${TEST_SOURCES})
-
-#target_link_libraries(ai_tests ${AI_LIBS} ${GTEST_LIB} ai_lib)
-#target_include_directories(ai_tests ${AI_INCLUDES} test)
-
+# ###### TEST #######
+# add_executable(roboteam_ai_test
+#         ${PROJECT_SOURCE_DIR}/test/main.cpp
+#         ${PROJECT_SOURCE_DIR}/test/ControlTests/ControlUtilsTest.cpp
+#         ${PROJECT_SOURCE_DIR}/test/UtilTests/RefereeTest.cpp
+#         ${PROJECT_SOURCE_DIR}/test/helpers/WorldHelper.h
+#         ${PROJECT_SOURCE_DIR}/test/helpers/WorldHelper.cpp
+#         ${PROJECT_SOURCE_DIR}/test/helpers/FieldHelper.h
+#         ${PROJECT_SOURCE_DIR}/test/helpers/FieldHelper.cpp
+#         ${PROJECT_SOURCE_DIR}/test/WorldTests/BallTests.cpp
+#         ${PROJECT_SOURCE_DIR}/test/WorldTests/RobotTests.cpp
+#         ${PROJECT_SOURCE_DIR}/test/WorldTests/FieldComputationTest.cpp
+#         ${PROJECT_SOURCE_DIR}/test/WorldTests/HistorySizeTest.cpp
+#         ${PROJECT_SOURCE_DIR}/test/WorldTests/HistoryRetrievalTest.cpp
+#         ${PROJECT_SOURCE_DIR}/test/WorldTests/WhichRobotHasBallTest.cpp
+#         ${PROJECT_SOURCE_DIR}/test/WorldTests/WorldResetTests.cpp
+#         ${PROJECT_SOURCE_DIR}/test/StpTests/PlayCheckerTests.cpp
+#         ${PROJECT_SOURCE_DIR}/test/StpTests/PlayDeciderTests.cpp
+#         ${PROJECT_SOURCE_DIR}/test/StpTests/TacticTests.cpp
+#         ${PROJECT_SOURCE_DIR}/test/ControlTests/BBTrajectory/BBTrajectory1DTest.cpp
+# )
+# target_include_directories(roboteam_ai_test
+#         PRIVATE include/roboteam_ai
+#         PRIVATE test
+# )
+# target_link_libraries(roboteam_ai_test
+#         PRIVATE roboteam_utils
+#         PRIVATE Qt5::Widgets
+#         PRIVATE roboteam_networking
+#         PRIVATE SDL2
+#         # Watch out! The order of these libraries apparently matters!
+#         PRIVATE roboteam_ai_interface
+#         PRIVATE roboteam_ai_plays
+#         PRIVATE roboteam_ai_world
+#         PRIVATE roboteam_ai_control
+#         PRIVATE roboteam_ai_roles
+#         PRIVATE Qt5::Charts
+#         PRIVATE roboteam_ai_manual
+#         PRIVATE roboteam_ai_utils
+#         PRIVATE roboteam_ai_computation
+#         PRIVATE roboteam_ai_tactics
+#         PRIVATE roboteam_ai_evaluation
+#         PRIVATE roboteam_ai_skills
+# )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,6 @@ set(AI_LIBS
         PRIVATE NFParam
         PRIVATE SDL2
         PRIVATE roboteam_networking
-        PRIVATE stx
         )
 
 set(AI_INCLUDES

--- a/include/roboteam_ai/utilities/IOManager.h
+++ b/include/roboteam_ai/utilities/IOManager.h
@@ -6,7 +6,6 @@
 #include <WorldNetworker.hpp>
 #include <iostream>
 #include <mutex>
-#include <utils/Pair.hpp>
 
 #include "utilities/Constants.h"
 #include "world/Field.h"
@@ -33,14 +32,11 @@ class IOManager {
 
     rtt::ai::Pause *pause;
 
-    std::unique_ptr<rtt::net::utils::PairReceiver<16970>> centralServerConnection;
-
     bool publishRobotCommands(const proto::AICommand &aiCommand, bool forTeamYellow);
 
    public:
     void publishAllRobotCommands(const std::vector<proto::RobotCommand> &vector);
     void publishSettings(proto::Setting setting);
-    void handleCentralServerConnection();
     bool init(bool isPrimaryAI);
     proto::State getState();
 

--- a/src/ApplicationManager.cpp
+++ b/src/ApplicationManager.cpp
@@ -154,7 +154,6 @@ void ApplicationManager::runOneLoopCycle() {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     rtt::ai::control::ControlModule::sendAllCommands();
-    io::io.handleCentralServerConnection();
 }
 
 void ApplicationManager::decidePlay(world::World *_world) {


### PR DESCRIPTION
### Comments for the reviewer
This repository contained files that connect to the central server. This required the use of STX, a library that is causing some trouble.
Because central server is unused, we can get rid of central server and the STX library dependency. This PR removes the code that connects to the central server, removes the STX dependency and cleans up the CMakeLists.

This PR goes together with the PR of [suite](https://github.com/RoboTeamTwente/roboteam_suite/pull/30) and [networking](https://github.com/RoboTeamTwente/roboteam_networking/pull/2)

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
