### PR TITLE
Remove check to see if ball is on our side

### DIFF
--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -53,61 +53,58 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
                                                                           const world::view::RobotView &enemyRobot) noexcept {
     const double DISTANCE_FROM_GOAL_FAR = field.getGoalWidth() / 1.5;
 
-    // Ball is on our side
-    if (ball->getPos().x < 0) {
-        auto keeperArc = Arc(field.getOurGoalCenter(), DISTANCE_FROM_GOAL_FAR, -M_PI / 2, M_PI / 2);
+    auto keeperArc = Arc(field.getOurGoalCenter(), DISTANCE_FROM_GOAL_FAR, -M_PI / 2, M_PI / 2);
 
-        // Keeper should not move too far to the side, it is not great if the keeper is halfway out of the goal
-        auto minKeeperY = field.getOurBottomGoalSide().y + control_constants::DISTANCE_TO_ROBOT_CLOSE;
-        auto maxKeeperY = field.getOurTopGoalSide().y - control_constants::DISTANCE_TO_ROBOT_CLOSE;
+    // Keeper should not move too far to the side, it is not great if the keeper is halfway out of the goal
+    auto minKeeperY = field.getOurBottomGoalSide().y + control_constants::DISTANCE_TO_ROBOT_CLOSE;
+    auto maxKeeperY = field.getOurTopGoalSide().y - control_constants::DISTANCE_TO_ROBOT_CLOSE;
 
-        // Intercept ball when it is moving towards the goal
-        if (ball->getVelocity().length() > control_constants::BALL_STILL_VEL) {
-            auto start = ball->getPos();
-            auto end = start + ball->getVelocity().stretchToLength(field.getFieldLength());
-            // Goal is made a bit "bigger" to ensure robot still moves towards ball trajectory
-            // even when it thinks the ball will just miss, as this can be error prone
-            auto startGoal = field.getOurTopGoalSide() + Vector2(0, control_constants::DISTANCE_TO_ROBOT_CLOSE);
-            auto endGoal = field.getOurBottomGoalSide() - Vector2(0, control_constants::DISTANCE_TO_ROBOT_CLOSE);
+    // Intercept ball when it is moving towards the goal
+    if (ball->getVelocity().length() > control_constants::BALL_STILL_VEL) {
+        auto start = ball->getPos();
+        auto end = start + ball->getVelocity().stretchToLength(field.getFieldLength());
+        // Goal is made a bit "bigger" to ensure robot still moves towards ball trajectory
+        // even when it thinks the ball will just miss, as this can be error prone
+        auto startGoal = field.getOurTopGoalSide() + Vector2(0, control_constants::DISTANCE_TO_ROBOT_CLOSE);
+        auto endGoal = field.getOurBottomGoalSide() - Vector2(0, control_constants::DISTANCE_TO_ROBOT_CLOSE);
 
-            auto intersection = LineSegment(start, end).intersects(LineSegment(startGoal, endGoal));
-            if (intersection) {
-                // Clamp y between goal to ensure robot does not move out of goal
-                intersection.value().y = std::clamp(intersection.value().y, field.getOurBottomGoalSide().y, field.getOurTopGoalSide().y);
-                return std::make_pair(intersection.value(), PIDType::KEEPER);
-            }
+        auto intersection = LineSegment(start, end).intersects(LineSegment(startGoal, endGoal));
+        if (intersection) {
+            // Clamp y between goal to ensure robot does not move out of goal
+            intersection.value().y = std::clamp(intersection.value().y, field.getOurBottomGoalSide().y, field.getOurTopGoalSide().y);
+            return std::make_pair(intersection.value(), PIDType::KEEPER);
         }
-
-        // Opponent is close to ball and aiming towards the goal
-        // Block the ball by staying on the shot line of the opponent
-        if (enemyRobot->getDistanceToBall() < control_constants::ENEMY_CLOSE_TO_BALL_DISTANCE) {
-            auto start = enemyRobot->getPos();
-            auto robotAngle = enemyRobot->getAngle();
-            auto end = start + robotAngle.toVector2().stretchToLength(field.getFieldLength());
-            // Goal is made a bit "bigger" to ensure robot still moves towards expected target position
-            // even when it thinks the ball will just miss, as this can be error prone
-            auto startGoal = field.getOurTopGoalSide() + Vector2(0, control_constants::DISTANCE_TO_ROBOT_CLOSE);
-            auto endGoal = field.getOurBottomGoalSide() - Vector2(0, control_constants::DISTANCE_TO_ROBOT_CLOSE);
-
-            auto intersection = LineSegment(start, end).intersects(LineSegment(startGoal, endGoal));
-            if (intersection) {
-                // Clamp y between goal to ensure robot does not move out of goal
-                intersection.value().y = std::clamp(intersection.value().y, minKeeperY, maxKeeperY);
-
-                auto targetPositions = keeperArc.intersectionWithLine(start, intersection.value());
-
-                if (targetPositions.first) {
-                    return std::make_pair(targetPositions.first.value(), PIDType::DEFAULT);
-                } else if (targetPositions.second) {
-                    return std::make_pair(targetPositions.second.value(), PIDType::DEFAULT);
-                }
-            }
-        }
-
-        // Default positioning, stand at same y as the ball is currently located, clamped between the goal
-        auto targetPosition = Vector2(field.getOurGoalCenter().x + control_constants::ROBOT_CLOSE_TO_POINT, std::clamp(ball->getPos().y, minKeeperY, maxKeeperY));
-        return std::make_pair(targetPosition, PIDType::DEFAULT);
     }
+
+    // Opponent is close to ball and aiming towards the goal
+    // Block the ball by staying on the shot line of the opponent
+    if (enemyRobot->getDistanceToBall() < control_constants::ENEMY_CLOSE_TO_BALL_DISTANCE) {
+        auto start = enemyRobot->getPos();
+        auto robotAngle = enemyRobot->getAngle();
+        auto end = start + robotAngle.toVector2().stretchToLength(field.getFieldLength());
+        // Goal is made a bit "bigger" to ensure robot still moves towards expected target position
+        // even when it thinks the ball will just miss, as this can be error prone
+        auto startGoal = field.getOurTopGoalSide() + Vector2(0, control_constants::DISTANCE_TO_ROBOT_CLOSE);
+        auto endGoal = field.getOurBottomGoalSide() - Vector2(0, control_constants::DISTANCE_TO_ROBOT_CLOSE);
+
+        auto intersection = LineSegment(start, end).intersects(LineSegment(startGoal, endGoal));
+        if (intersection) {
+            // Clamp y between goal to ensure robot does not move out of goal
+            intersection.value().y = std::clamp(intersection.value().y, minKeeperY, maxKeeperY);
+
+            auto targetPositions = keeperArc.intersectionWithLine(start, intersection.value());
+
+            if (targetPositions.first) {
+                return std::make_pair(targetPositions.first.value(), PIDType::DEFAULT);
+            } else if (targetPositions.second) {
+                return std::make_pair(targetPositions.second.value(), PIDType::DEFAULT);
+            }
+        }
+    }
+
+    // Default positioning, stand at same y as the ball is currently located, clamped between the goal
+    auto targetPosition = Vector2(field.getOurGoalCenter().x + control_constants::ROBOT_CLOSE_TO_POINT, std::clamp(ball->getPos().y, minKeeperY, maxKeeperY));
+    return std::make_pair(targetPosition, PIDType::DEFAULT);
 }
 
 }  // namespace rtt::ai::stp::tactic


### PR DESCRIPTION
#### Summary

Remove the check to see if the ball is on our side. This check is undesirable, as our keeper should still do the same even when the ball is on their half. With this check, the keeper just stands still when the ball is on their half.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
