### PR TITLE
Use vision to determine if enemy has ball

### DIFF
--- a/src/world/views/RobotView.cpp
+++ b/src/world/views/RobotView.cpp
@@ -17,9 +17,9 @@ robot::Robot const *RobotView::operator->() const noexcept { return get(); }
 
 // TODO: TEST whether maxDist and Angle are suitable on the field and whether ballsensor works well irl
 bool RobotView::hasBall(double maxDist, double maxAngle) const noexcept {
-    // In the simulator, return true if the ballSensorSeesBall (feedback from sim)
-    // On the field, return true if the ballsensor sees the ball or we have the ball according to the vision
-    return (SETTINGS.isSerialMode() && hasBallAccordingToVision(maxDist, maxAngle)) || get()->ballSensorSeesBall();
+    // In the sim, we only use the ball sensor to determine if the robot has the ball
+    // On the field, and for the enemies in the sim, we also use the camera to do so
+    return ((this->robotPtr->getTeam()==Team::them || SETTINGS.isSerialMode()) && hasBallAccordingToVision(maxDist, maxAngle)) || get()->ballSensorSeesBall();
 }
 
 Vector2 RobotView::getKicker() const noexcept {


### PR DESCRIPTION
Previously, we only used the ballsensors to check whether robots have the ball in the simulator, as this is highly accurate. Unfortunately though, we do not get access to this feedback from our opponents. Therefore, we must use the vision data to determine whether they have the ball.

### Comments for the reviewer
- 

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
