### PR TITLE
Check if role is actually initialised before trying to access it

### DIFF
--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -49,6 +49,7 @@ void Play::update() noexcept {
 
     // Loop through roles and update them if they are assigned to a robot
     for (auto &role : roles) {
+        if (role == nullptr) continue;
         auto stpInfo = stpInfos.find(role->getName());
         if (stpInfo != stpInfos.end() && stpInfo->second.getRobot()) {
             // Update and store the returned status
@@ -78,6 +79,7 @@ void Play::refreshData() noexcept {
 
     // Loop through all roles, if an stpInfo exists and has an assigned robot, refresh the data
     for (auto &role : roles) {
+        if (role == nullptr) continue;
         auto stpInfo = stpInfos.find(role->getName());
         if (stpInfo != stpInfos.end() && stpInfo->second.getRobot().has_value()) {
             // Get a new RobotView from world using the old robot id
@@ -104,6 +106,7 @@ void Play::distributeRoles() noexcept {
     // TODO-Max if role exists in oldStpInfos then copy those.
     // Clear the stpInfos for the new role assignment
     for (auto &role : roles) {
+        if (role == nullptr) continue;
         role->reset();
         auto roleName{role->getName()};
         if (distribution.find(roleName) != distribution.end()) {


### PR DESCRIPTION
#### Summary
Roles is an array of size 11, for 11 roles. Some plays now use 4 roles (for spain). Thus, there will be several nullptrs in this array that we need to check for.

Note: for flexibility, we could also use a vector instead of an array to avoid needing to check for nullptr. If we move back to all plays having 11 roles though, the 11-sized array is good.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
