### PR TITLE
Fix issues regarding dealing the keeper role.

### DIFF
--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -100,6 +100,14 @@ void Play::refreshData() noexcept {
 
 void Play::distributeRoles() noexcept {
     Dealer dealer{world->getWorld().value(), &field};
+
+    // Set role names for each stpInfo
+    for (auto &role : roles) {
+        if (role == nullptr) continue;
+        auto roleName{role->getName()};
+        stpInfos[roleName].setRoleName(roleName);
+    }
+
     auto flagMap = decideRoleFlags();
     auto distribution = dealer.distribute(world->getWorld()->getUs(), flagMap, stpInfos);
 
@@ -112,7 +120,6 @@ void Play::distributeRoles() noexcept {
         if (distribution.find(roleName) != distribution.end()) {
             auto robot = distribution.find(role->getName())->second;
             stpInfos[roleName].setRobot(robot);
-            stpInfos[roleName].setRoleName(roleName);
         }
     }
     std::for_each(stpInfos.begin(), stpInfos.end(), [this](auto &each) { each.second.setCurrentWorld(world); });

--- a/src/utilities/Dealer.cpp
+++ b/src/utilities/Dealer.cpp
@@ -192,6 +192,8 @@ double Dealer::getWeightForPriority(const DealerFlagPriority &flagPriority) {
             return 5;
         case DealerFlagPriority::REQUIRED:
             return 100;
+        case DealerFlagPriority::KEEPER:
+            return 1000;
         default:
             RTT_WARNING("Unhandled dealerflag!")
             return 0;


### PR DESCRIPTION
### Summary

Some fixes to ensure the keeper role is divided properly. See commit messages for more info.

Note that in order for the keeper role to be given correctly at the very start of the game (when no keeper has been assigned previously), the keeper's position to move to should be set! (setting this position to be our goal center would be the obvious choice).

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
