### PR TITLE
Fix segfault and small issue in defendShot/Pass

### DIFF
--- a/src/stp/plays/defensive/DefendPass.cpp
+++ b/src/stp/plays/defensive/DefendPass.cpp
@@ -69,10 +69,10 @@ void DefendPass::calculateInfoForDefenders() noexcept {
 
     auto remainingEnemy = world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), enemyRobots);
 
-    stpInfos["defender_1"].setPositionToDefend(remainingEnemy->get()->getPos());
+    stpInfos["defender_1"].setPositionToDefend(enemyClosestToOurGoal->get()->getPos());
     stpInfos["defender_1"].setBlockDistance(BlockDistance::HALFWAY);
 
-    stpInfos["defender_2"].setPositionToDefend(enemyClosestToOurGoal->get()->getPos());
+    stpInfos["defender_2"].setPositionToDefend(remainingEnemy->get()->getPos());
     stpInfos["defender_2"].setBlockDistance(BlockDistance::HALFWAY);
 }
 

--- a/src/stp/plays/defensive/DefendPass.cpp
+++ b/src/stp/plays/defensive/DefendPass.cpp
@@ -25,6 +25,8 @@ DefendPass::DefendPass() : Play() {
 }
 
 uint8_t DefendPass::score(PlayEvaluator &playEvaluator) noexcept {
+    auto world = playEvaluator.getWorld();
+    auto field = world->getField().value();
     auto enemyRobot = world->getWorld()->getRobotClosestToBall(world::them);
     auto position = distanceFromPointToLine(field.getBottomLeftCorner(), field.getTopLeftCorner(), enemyRobot->get()->getPos());
     return 255 * (position / field.getFieldLength());

--- a/src/stp/plays/defensive/DefendShot.cpp
+++ b/src/stp/plays/defensive/DefendShot.cpp
@@ -28,6 +28,8 @@ DefendShot::DefendShot() : Play() {
 }
 
 uint8_t DefendShot::score(PlayEvaluator &playEvaluator) noexcept {
+    auto world = playEvaluator.getWorld();
+    auto field = world->getField().value();
     auto enemyRobot = world->getWorld()->getRobotClosestToBall(world::them);
     auto position = distanceFromPointToLine(field.getBottomLeftCorner(), field.getTopLeftCorner(), enemyRobot->get()->getPos());
     return 255 * (field.getFieldLength() - position) / field.getFieldLength();


### PR DESCRIPTION
World and field are only set in the play after it has been selected. When scoring each play, this has not been done yet. Therefore, the internal world and field of each play should not be accessed in the score function, as this could cause a segfault if these are not set yet. To avoid this, we use the world as set in the playEvaluator, which is updated before scoring.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
