### PR TITLE
Fix small mistakes in scoring and evaluations

### DIFF
--- a/src/stp/plays/defensive/DefendPass.cpp
+++ b/src/stp/plays/defensive/DefendPass.cpp
@@ -17,7 +17,7 @@ DefendPass::DefendPass() : Play() {
 
     keepPlayEvaluation.clear();
     keepPlayEvaluation.emplace_back(eval::NormalPlayGameState);
-    startPlayEvaluation.emplace_back(eval::TheyHaveBall);
+    keepPlayEvaluation.emplace_back(eval::TheyHaveBall);
 
     roles = std::array<std::unique_ptr<Role>, stp::control_constants::MAX_ROBOT_COUNT>{
         std::make_unique<role::Keeper>(role::Keeper("keeper")), std::make_unique<role::Defender>(role::Defender("defender_1")),

--- a/src/stp/plays/defensive/DefendShot.cpp
+++ b/src/stp/plays/defensive/DefendShot.cpp
@@ -17,7 +17,7 @@ DefendShot::DefendShot() : Play() {
 
     keepPlayEvaluation.clear();
     keepPlayEvaluation.emplace_back(eval::NormalPlayGameState);
-    startPlayEvaluation.emplace_back(eval::TheyHaveBall);
+    keepPlayEvaluation.emplace_back(eval::TheyHaveBall);
 
     roles = std::array<std::unique_ptr<Role>, stp::control_constants::MAX_ROBOT_COUNT>{
         std::make_unique<role::Keeper>(role::Keeper("keeper")),

--- a/src/stp/plays/offensive/Attack.cpp
+++ b/src/stp/plays/offensive/Attack.cpp
@@ -32,7 +32,7 @@ uint8_t Attack::score(PlayEvaluator& playEvaluator) noexcept {
     auto field = world->getField().value();
 
     // Score the position of the ball based on the odds of scoring
-    return PositionScoring::scorePosition(playEvaluator.getWorld()->getWorld()->getBall().value()->getPos(), gen::GoalShootPosition, field, world).score;
+    return PositionScoring::scorePosition(world->getWorld()->getBall().value()->getPos(), gen::GoalShootPosition, field, world).score;
 }
 
 Dealer::FlagMap Attack::decideRoleFlags() const noexcept {

--- a/src/stp/plays/offensive/Attack.cpp
+++ b/src/stp/plays/offensive/Attack.cpp
@@ -28,8 +28,11 @@ Attack::Attack() : Play() {
 }
 
 uint8_t Attack::score(PlayEvaluator& playEvaluator) noexcept {
+    auto world = playEvaluator.getWorld();
+    auto field = world->getField().value();
+
     // Score the position of the ball based on the odds of scoring
-    return PositionScoring::scorePosition(playEvaluator.getWorld()->getWorld()->getBall().value()->getPos(), gen::GoalShootPosition, field, playEvaluator.getWorld()).score;
+    return PositionScoring::scorePosition(playEvaluator.getWorld()->getWorld()->getBall().value()->getPos(), gen::GoalShootPosition, field, world).score;
 }
 
 Dealer::FlagMap Attack::decideRoleFlags() const noexcept {


### PR DESCRIPTION
Similar to other plays, the world/field from the playEvaluator should be used when scoring, as the internal world/field have not been set yet. Furthermore, this PR fixes a small mistake in defendShot/Pass where the wrong variable name was used.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
