### PR TITLE
Stp info collision settings

### DIFF
--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -81,8 +81,16 @@ struct StpInfo {
     std::string getRoleName() const { return roleName; }
     void setRoleName(std::string name) { roleName = name; }
 
-    AvoidObjects getObjectsToAvoid() const { return avoidObjects; }
-    void setObjectsToAvoid(AvoidObjects objectsToAvoid) { avoidObjects = objectsToAvoid; }
+    bool getShouldAvoidDefenseArea() const {return objectsToAvoid.shouldAvoidDefenseArea;}
+    void setShouldAvoidDefenseArea(bool shouldAvoidDefenseArea) {objectsToAvoid.shouldAvoidDefenseArea = shouldAvoidDefenseArea;}
+
+    bool getShouldAvoidBall() const {return objectsToAvoid.shouldAvoidBall;}
+    void setShouldAvoidBall(bool shouldAvoidBall) {objectsToAvoid.shouldAvoidBall = shouldAvoidBall;}
+
+    bool getShouldAvoidOutOfField() const {return objectsToAvoid.shouldAvoidOutOfField;}
+    void setShouldAvoidOutOfField(bool shouldAvoidOutOfField) {objectsToAvoid.shouldAvoidOutOfField = shouldAvoidOutOfField;}
+
+
 
    private:
     /**
@@ -178,7 +186,8 @@ struct StpInfo {
     /**
      * Specify what objects the robot should avoid
      */
-    AvoidObjects avoidObjects;
+    AvoidObjects objectsToAvoid;
+
 };
 
 /**

--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -90,6 +90,9 @@ struct StpInfo {
     bool getShouldAvoidOutOfField() const {return objectsToAvoid.shouldAvoidOutOfField;}
     void setShouldAvoidOutOfField(bool shouldAvoidOutOfField) {objectsToAvoid.shouldAvoidOutOfField = shouldAvoidOutOfField;}
 
+    AvoidObjects getObjectsToAvoid() const { return objectsToAvoid; }
+    void setObjectsToAvoid(AvoidObjects avoidObjects) { objectsToAvoid = avoidObjects; }
+
 
 
    private:

--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -84,14 +84,14 @@ struct StpInfo {
     AvoidObjects getObjectsToAvoid() const { return avoidObjects; }
     void setObjectsToAvoid(AvoidObjects objectsToAvoid) { avoidObjects = objectsToAvoid; }
 
-    bool getShouldAvoidDefenseArea() const {return avoidObjects.shouldAvoidDefenseArea;}
-    void setShouldAvoidDefenseArea(bool shouldAvoidDefenseArea) {avoidObjects.shouldAvoidDefenseArea = shouldAvoidDefenseArea;}
+    bool getShouldAvoidDefenseArea() const { return avoidObjects.shouldAvoidDefenseArea; }
+    void setShouldAvoidDefenseArea(bool shouldAvoidDefenseArea) { avoidObjects.shouldAvoidDefenseArea = shouldAvoidDefenseArea; }
 
-    bool getShouldAvoidBall() const {return avoidObjects.shouldAvoidBall;}
-    void setShouldAvoidBall(bool shouldAvoidBall) {avoidObjects.shouldAvoidBall = shouldAvoidBall;}
+    bool getShouldAvoidBall() const { return avoidObjects.shouldAvoidBall; }
+    void setShouldAvoidBall(bool shouldAvoidBall) { avoidObjects.shouldAvoidBall = shouldAvoidBall; }
 
-    bool getShouldAvoidOutOfField() const {return avoidObjects.shouldAvoidOutOfField;}
-    void setShouldAvoidOutOfField(bool shouldAvoidOutOfField) {avoidObjects.shouldAvoidOutOfField = shouldAvoidOutOfField;}
+    bool getShouldAvoidOutOfField() const { return avoidObjects.shouldAvoidOutOfField; }
+    void setShouldAvoidOutOfField(bool shouldAvoidOutOfField) { avoidObjects.shouldAvoidOutOfField = shouldAvoidOutOfField; }
 
    private:
     /**
@@ -188,7 +188,6 @@ struct StpInfo {
      * Specify what objects the robot should avoid
      */
     AvoidObjects avoidObjects;
-
 };
 
 /**

--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -81,19 +81,17 @@ struct StpInfo {
     std::string getRoleName() const { return roleName; }
     void setRoleName(std::string name) { roleName = name; }
 
-    bool getShouldAvoidDefenseArea() const {return objectsToAvoid.shouldAvoidDefenseArea;}
-    void setShouldAvoidDefenseArea(bool shouldAvoidDefenseArea) {objectsToAvoid.shouldAvoidDefenseArea = shouldAvoidDefenseArea;}
+    AvoidObjects getObjectsToAvoid() const { return avoidObjects; }
+    void setObjectsToAvoid(AvoidObjects objectsToAvoid) { avoidObjects = objectsToAvoid; }
 
-    bool getShouldAvoidBall() const {return objectsToAvoid.shouldAvoidBall;}
-    void setShouldAvoidBall(bool shouldAvoidBall) {objectsToAvoid.shouldAvoidBall = shouldAvoidBall;}
+    bool getShouldAvoidDefenseArea() const {return avoidObjects.shouldAvoidDefenseArea;}
+    void setShouldAvoidDefenseArea(bool shouldAvoidDefenseArea) {avoidObjects.shouldAvoidDefenseArea = shouldAvoidDefenseArea;}
 
-    bool getShouldAvoidOutOfField() const {return objectsToAvoid.shouldAvoidOutOfField;}
-    void setShouldAvoidOutOfField(bool shouldAvoidOutOfField) {objectsToAvoid.shouldAvoidOutOfField = shouldAvoidOutOfField;}
+    bool getShouldAvoidBall() const {return avoidObjects.shouldAvoidBall;}
+    void setShouldAvoidBall(bool shouldAvoidBall) {avoidObjects.shouldAvoidBall = shouldAvoidBall;}
 
-    AvoidObjects getObjectsToAvoid() const { return objectsToAvoid; }
-    void setObjectsToAvoid(AvoidObjects avoidObjects) { objectsToAvoid = avoidObjects; }
-
-
+    bool getShouldAvoidOutOfField() const {return avoidObjects.shouldAvoidOutOfField;}
+    void setShouldAvoidOutOfField(bool shouldAvoidOutOfField) {avoidObjects.shouldAvoidOutOfField = shouldAvoidOutOfField;}
 
    private:
     /**
@@ -189,7 +187,7 @@ struct StpInfo {
     /**
      * Specify what objects the robot should avoid
      */
-    AvoidObjects objectsToAvoid;
+    AvoidObjects avoidObjects;
 
 };
 

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -29,7 +29,7 @@ void Play::updateWorld(world::World *world) noexcept {
 void Play::update() noexcept {
     // clear roleStatuses so it only contains the current tick's statuses
     roleStatuses.clear();
-//    RTT_INFO("Play executing: ", getName())
+    RTT_INFO("Play executing: ", getName())
 
     // Check if the amount of robots changed
     // If so, we will re deal the roles

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -29,7 +29,7 @@ void Play::updateWorld(world::World *world) noexcept {
 void Play::update() noexcept {
     // clear roleStatuses so it only contains the current tick's statuses
     roleStatuses.clear();
-    RTT_INFO("Play executing: ", getName())
+//    RTT_INFO("Play executing: ", getName())
 
     // Check if the amount of robots changed
     // If so, we will re deal the roles


### PR DESCRIPTION
### Comments for the reviewer
The struct 'AvoidObjects' in StpInfoEnums consists of 3 boolean variables. Previously there was only one function that could set all of these at the same time and one that could get them all at the same time. This is not ideal if you only want to set/get only one boolean. 
There have been added setters and getters for each of the boolean variables in the struct. This way it is possible to only set one of the variables to true/false. This makes it easy to for example say that the keeper should not avoid the defend area, but do the rest as the other robots. 
The setter and getter for the complete struct is still there, since this is used in the path planning algorithm. 

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
