### PR TITLE
Changed PID type to DEFEAULT

### DIFF
--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -72,7 +72,7 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
         if (intersection) {
             // Clamp y between goal to ensure robot does not move out of goal
             intersection.value().y = std::clamp(intersection.value().y, field.getOurBottomGoalSide().y, field.getOurTopGoalSide().y);
-            return std::make_pair(intersection.value(), PIDType::KEEPER);
+            return std::make_pair(intersection.value(), PIDType::DEFAULT);
         }
     }
 


### PR DESCRIPTION
The keeper does not overshoot anymore. It is not ideal, however for now it is better to not overshoot than too go to the other side of the field. Needs to be tested on the field still.

### Comments for the reviewer
- 

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
