### PR TITLE
Limit sim config pub to Primary AI

### DIFF
--- a/include/roboteam_ai/utilities/IOManager.h
+++ b/include/roboteam_ai/utilities/IOManager.h
@@ -45,7 +45,8 @@ class IOManager {
     void publishAllRobotCommands(const std::vector<proto::RobotCommand> &vector);
     void publishSettings(const Settings &settings);
     void onSettingsOfPrimaryAI(const proto::Setting &settings);
-    void sendSimulationConfiguration(const proto::SimulationConfiguration& configuration);
+    // Returns success. Only Primary AI is allowed to send simulation configuration
+    bool sendSimulationConfiguration(const proto::SimulationConfiguration& configuration);
 
     bool init(bool isPrimaryAI);
     proto::State getState();

--- a/src/interface/widgets/widget.cpp
+++ b/src/interface/widgets/widget.cpp
@@ -116,7 +116,11 @@ void Visualizer::paintEvent(QPaintEvent *event) {
         proto::SimulationConfiguration configuration;                    // Create packet
         configuration.mutable_ball_location()->set_x(field_position.x);  // Set x
         configuration.mutable_ball_location()->set_y(field_position.y);  // Set y
-        io::io.sendSimulationConfiguration(configuration);  // Send packet
+
+        bool sentConfig = io::io.sendSimulationConfiguration(configuration);  // Send packet
+        if (!sentConfig) {
+            RTT_WARNING("Failed to send Simulation Configuration command. Is this the primary AI?")
+        }
     }
 }
 

--- a/src/utilities/IOManager.cpp
+++ b/src/utilities/IOManager.cpp
@@ -17,7 +17,6 @@ bool IOManager::init(bool isPrimaryAI) {
 
     auto worldCallback = std::bind(&IOManager::handleState, this, std::placeholders::_1);
     this->worldSubscriber = std::make_unique<rtt::net::WorldSubscriber>(worldCallback);
-    this->simulationConfigurationPublisher = std::make_unique<rtt::net::SimulationConfigurationPublisher>();
 
     if (isPrimaryAI) {
         try {
@@ -25,6 +24,12 @@ bool IOManager::init(bool isPrimaryAI) {
         } catch (zmqpp::zmq_internal_exception e) {
             success = false;
             RTT_ERROR("Failed to open settings publisher channel. Is it already taken?")
+        }
+        try {
+            this->simulationConfigurationPublisher = std::make_unique<rtt::net::SimulationConfigurationPublisher>();
+        } catch (zmqpp::zmq_internal_exception e) {
+            success = false;
+            RTT_ERROR("Failed to open simulation configuration publisher channel. Is it already taken?")
         }
     } else {
         try {
@@ -150,8 +155,11 @@ bool IOManager::obtainTeamColorChannel(bool toYellowChannel) {
     return obtainedChannel;
 }
 
-void IOManager::sendSimulationConfiguration(const proto::SimulationConfiguration& configuration) {
-    this->simulationConfigurationPublisher->publish(configuration);
+bool IOManager::sendSimulationConfiguration(const proto::SimulationConfiguration& configuration) {
+    if (this->simulationConfigurationPublisher != nullptr) {
+        return this->simulationConfigurationPublisher->publish(configuration);
+    }
+    return false;
 }
 
 }  // namespace rtt::ai::io


### PR DESCRIPTION
### Comments for the reviewer
This PR makes sure only the primary AI is allowed to send simulation configuration commands to the simulator. Without this check, both AI's will try to obtain the publisher, resulting in one of them crashing

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
