### PR TITLE
Revert changes that required newer qt5

### DIFF
--- a/src/interface/widgets/MainControlsWidget.cpp
+++ b/src/interface/widgets/MainControlsWidget.cpp
@@ -106,12 +106,12 @@ MainControlsWidget::MainControlsWidget(QWidget *parent, ApplicationManager *appM
         GameStateManager::updateInterfaceGameState(rtt::ApplicationManager::plays[index].get()->getName());
     });
 
-    QObject::connect(select_goalie, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::textActivated), [=](const QString &goalieId) {
+    QObject::connect(select_goalie, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::activated), [=](const QString &goalieId) {
         // http://doc.qt.io/qt-5/qcombobox.html#currentIndexChanged-1
         interface::Output::setKeeperId(goalieId.toInt());
     });
 
-    QObject::connect(select_ruleset, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::textActivated), [=](const QString &rulesetName) {
+    QObject::connect(select_ruleset, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::activated), [=](const QString &rulesetName) {
         // http://doc.qt.io/qt-5/qcombobox.html#currentIndexChanged-1
         interface::Output::setRuleSetName(rulesetName.toStdString());
     });

--- a/src/interface/widgets/widget.cpp
+++ b/src/interface/widgets/widget.cpp
@@ -20,6 +20,7 @@ Visualizer::Visualizer(QWidget *parent) : QWidget(parent) {}
 void Visualizer::paintEvent(QPaintEvent *event) {
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setRenderHint(QPainter::HighQualityAntialiasing, true);
     std::optional<rtt::world::view::WorldDataView> world;
     std::optional<rtt::world::Field> field;
     auto const &[_, worldPtr] = rtt::world::World::instance();


### PR DESCRIPTION
These changes updated code that was deprecated on some newer versions of qt5, but unfortunately, this broke older versions of qt5 (such as the newest one available on ubuntu)

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
