### PR TITLE
Move settings of third party software

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,35 +3,6 @@ project(roboteam_ai)
 
 add_subdirectory(src)
 
-
-# AUTOMOC is verified to work with the following:
-# - libprotoc 3.19.4
-# - macOS 12.2.1
-# - qt 5.15.2
-
-# On some operating systems, AUTOMOC might produce errors related to protobuf files.
-# In such a case, header files to be MOC-ed must be manually specified
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC OFF)
-set(CMAKE_AUTOUIC OFF)
-set(CMAKE_INCLUDE_CURRENT_DIR OFF) # Find includes in corresponding build directories
-
-#for MacOS X or iOS, watchOS, tvOS(since 3.10.3)
-if (APPLE)
-    set(GTEST_LIB
-            /usr/local/lib/libgtest.a
-            /usr/local/lib/libgtest_main.a
-            /usr/local/lib/libgmock.a
-            /usr/local/lib/libgmock_main.a
-            )
-else (NOT APPLE)
-    set(GTEST_LIB
-            PUBLIC gtest
-            PUBLIC gmock)
-endif ()
-
-find_package(Qt5 COMPONENTS Widgets Charts REQUIRED)
-
 ###### UTILS #######
 add_library(roboteam_ai_utils
         ${PROJECT_SOURCE_DIR}/src/utilities/GameStateManager.cpp


### PR DESCRIPTION
### Comments for the reviewer
AI sets settings for both GoogleTest and Qt, but other repos, such as utils (and soon the new interface) need these settings too. Therefore, I moved these settings to the place where the third party software is included into our project.
This PR is dependent on [the PR in suite](https://github.com/RoboTeamTwente/roboteam_suite/pull/37)

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
