### PR TITLE
Add roles to attacking pass for 11v11

### DIFF
--- a/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
+++ b/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
@@ -35,6 +35,21 @@ class AttackingPass : public Play {
     void calculateInfoForRoles() noexcept override;
 
     /**
+     * Calculates info for the defenders
+     */
+    void calculateInfoForDefenders() noexcept;
+
+    /**
+     * Calculates info for the midfielders
+     */
+    void calculateInfoForMidfielders() noexcept;
+
+    /**
+     * Calculates info for the attackers
+     */
+    void calculateInfoForAttackers() noexcept;
+
+    /**
      * Calculate info for the roles that need to be calculated for scoring
      */
     void calculateInfoForScoredRoles(world::World*) noexcept override;

--- a/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
+++ b/include/roboteam_ai/stp/plays/offensive/AttackingPass.h
@@ -52,7 +52,7 @@ class AttackingPass : public Play {
     /**
      * Calculate info for the roles that need to be calculated for scoring
      */
-    void calculateInfoForScoredRoles(world::World*) noexcept override;
+    void calculateInfoForScoredRoles(world::World*) noexcept override{};
 
     /**
      * Gets the play name

--- a/src/stp/computations/PassComputations.cpp
+++ b/src/stp/computations/PassComputations.cpp
@@ -22,8 +22,6 @@ PassInfo PassComputations::calculatePass(gen::ScoreProfile profile, const rtt::w
     // Find which robot is keeper (bot closest to goal if there was not a keeper yet), store its id, and erase from us
     passInfo.keeperId = getKeeperId(us, world, field);
     if (!keeperCanPass) std::erase_if(us, [passInfo](auto& bot) { return bot->getId() == passInfo.keeperId; });
-    if (keeperCanPass) RTT_DEBUG("Keeper can pass!");
-    if (!keeperCanPass) RTT_DEBUG("Keeper cant pass!");
 
     // Find which robot should be the passer, store its id and location, and erase from us
     passInfo.passerId = getPasserId(ballLocation, us, world);

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -75,6 +75,10 @@ Dealer::FlagMap AttackingPass::decideRoleFlags() const noexcept {
 }
 
 void AttackingPass::calculateInfoForRoles() noexcept {
+    calculateInfoForDefenders();
+    calculateInfoForMidfielders();
+    calculateInfoForAttackers();
+
     /// Keeper
     stpInfos["keeper"].setPositionToMoveTo(field.getOurGoalCenter());
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
@@ -102,9 +106,39 @@ void AttackingPass::calculateInfoForRoles() noexcept {
         } else if (receiverLocation.y < field.getMiddleMidGrid().getOffSetY()) {  // Receiver is going to right of the field
             stpInfos["passer"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
         } else {  // Receiver is going to middle of the field- passer will go to the closest grid on the side of the field
-            auto targetGrid = stpInfos["passer"].getRobot()->get()->getPos().y < 0 ? field.getFrontRightGrid() : field.getFrontLeftGrid();
-            stpInfos["passer"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, targetGrid, gen::OffensivePosition, field, world));
+            auto targetGrid = stpInfos["passer"].getRobot()->get()->getPos().y < 0 ? field.getMiddleRightGrid() : field.getMiddleLeftGrid();
+            stpInfos["passer"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, targetGrid, gen::BlockingPosition, field, world));
         }
+    }
+}
+
+void AttackingPass::calculateInfoForDefenders() noexcept {
+    stpInfos["defender_left"].setPositionToDefend(field.getOurTopGoalSide());
+    stpInfos["defender_left"].setBlockDistance(BlockDistance::HALFWAY);
+
+    stpInfos["defender_mid"].setPositionToDefend(field.getOurBottomGoalSide());
+    stpInfos["defender_mid"].setBlockDistance(BlockDistance::HALFWAY);
+
+    stpInfos["defender_right"].setPositionToDefend(field.getOurGoalCenter());
+    stpInfos["defender_right"].setBlockDistance(BlockDistance::CLOSE);
+}
+
+void AttackingPass::calculateInfoForMidfielders() noexcept {
+    stpInfos["midfielder_left"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleLeftGrid(), gen::OffensivePosition, field, world));
+    stpInfos["midfielder_middle"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleMidGrid(), gen::OffensivePosition, field, world));
+    stpInfos["midfielder_right"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleRightGrid(), gen::OffensivePosition, field, world));
+}
+
+void AttackingPass::calculateInfoForAttackers() noexcept {
+    if (passInfo.passLocation.y > field.getFrontLeftGrid().getOffSetY()) {  // Receiver is going to left of the field
+        stpInfos["attacker_left"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontMidGrid(), gen::OffensivePosition, field, world));
+        stpInfos["attacker_right"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontRightGrid(), gen::OffensivePosition, field, world));
+    } else if (passInfo.passLocation.y < field.getMiddleMidGrid().getOffSetY()) {  // Receiver is going to right of the field
+        stpInfos["attacker_left"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
+        stpInfos["attacker_right"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontMidGrid(), gen::OffensivePosition, field, world));
+    } else {  // Receiver is going to middle of the field
+        stpInfos["attacker_left"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
+        stpInfos["attacker_right"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontRightGrid(), gen::OffensivePosition, field, world));
     }
 }
 

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -13,6 +13,7 @@
 #include "stp/roles/active/PassReceiver.h"
 #include "stp/roles/active/Passer.h"
 #include "stp/roles/passive/Formation.h"
+#include "stp/roles/passive/Defender.h"
 #include "world/views/RobotView.hpp"
 
 namespace rtt::ai::stp::play {
@@ -28,8 +29,17 @@ AttackingPass::AttackingPass() : Play() {
     keepPlayEvaluation.emplace_back(GlobalEvaluation::BallNotInOurDefenseAreaAndStill);
 
     roles = std::array<std::unique_ptr<Role>, stp::control_constants::MAX_ROBOT_COUNT>{
-        std::make_unique<role::Keeper>(role::Keeper("keeper")), std::make_unique<role::Passer>(role::Passer("passer")),
-        std::make_unique<role::PassReceiver>(role::PassReceiver("receiver")), std::make_unique<role::Formation>(role::Formation("midfielder"))};
+        std::make_unique<role::Keeper>(role::Keeper("keeper")),
+        std::make_unique<role::Passer>(role::Passer("passer")),
+        std::make_unique<role::PassReceiver>(role::PassReceiver("receiver")),
+        std::make_unique<role::Defender>(role::Defender("defender_left")),
+        std::make_unique<role::Defender>(role::Defender("defender_mid")),
+        std::make_unique<role::Defender>(role::Defender("defender_right")),
+        std::make_unique<role::Formation>(role::Formation("midfielder_left")),
+        std::make_unique<role::Formation>(role::Formation("midfielder_middle")),
+        std::make_unique<role::Formation>(role::Formation("midfielder_right")),
+        std::make_unique<role::Formation>(role::Formation("attacker_left")),
+        std::make_unique<role::Formation>(role::Formation("attacker_right"))};
 }
 
 uint8_t AttackingPass::score(PlayEvaluator& playEvaluator) noexcept {
@@ -52,7 +62,14 @@ Dealer::FlagMap AttackingPass::decideRoleFlags() const noexcept {
     flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {}, passInfo.keeperId}});
     flagMap.insert({"passer", {DealerFlagPriority::REQUIRED, {}, passInfo.passerId}});
     flagMap.insert({"receiver", {DealerFlagPriority::HIGH_PRIORITY, {}, passInfo.receiverId}});
-    flagMap.insert({"midfielder", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"defender_left", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"defender_mid", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"defender_right", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"midfielder_left", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"midfielder_middle", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"midfielder_right", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"attacker_left", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"attacker_right", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
 
     return flagMap;
 }

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -12,8 +12,8 @@
 #include "stp/roles/Keeper.h"
 #include "stp/roles/active/PassReceiver.h"
 #include "stp/roles/active/Passer.h"
-#include "stp/roles/passive/Formation.h"
 #include "stp/roles/passive/Defender.h"
+#include "stp/roles/passive/Formation.h"
 #include "world/views/RobotView.hpp"
 
 namespace rtt::ai::stp::play {
@@ -28,18 +28,17 @@ AttackingPass::AttackingPass() : Play() {
     keepPlayEvaluation.emplace_back(GlobalEvaluation::TheyDoNotHaveBall);
     keepPlayEvaluation.emplace_back(GlobalEvaluation::BallNotInOurDefenseAreaAndStill);
 
-    roles = std::array<std::unique_ptr<Role>, stp::control_constants::MAX_ROBOT_COUNT>{
-        std::make_unique<role::Keeper>(role::Keeper("keeper")),
-        std::make_unique<role::Passer>(role::Passer("passer")),
-        std::make_unique<role::PassReceiver>(role::PassReceiver("receiver")),
-        std::make_unique<role::Defender>(role::Defender("defender_left")),
-        std::make_unique<role::Defender>(role::Defender("defender_mid")),
-        std::make_unique<role::Defender>(role::Defender("defender_right")),
-        std::make_unique<role::Formation>(role::Formation("midfielder_left")),
-        std::make_unique<role::Formation>(role::Formation("midfielder_middle")),
-        std::make_unique<role::Formation>(role::Formation("midfielder_right")),
-        std::make_unique<role::Formation>(role::Formation("attacker_left")),
-        std::make_unique<role::Formation>(role::Formation("attacker_right"))};
+    roles = std::array<std::unique_ptr<Role>, stp::control_constants::MAX_ROBOT_COUNT>{std::make_unique<role::Keeper>(role::Keeper("keeper")),
+                                                                                       std::make_unique<role::Passer>(role::Passer("passer")),
+                                                                                       std::make_unique<role::PassReceiver>(role::PassReceiver("receiver")),
+                                                                                       std::make_unique<role::Defender>(role::Defender("defender_left")),
+                                                                                       std::make_unique<role::Defender>(role::Defender("defender_mid")),
+                                                                                       std::make_unique<role::Defender>(role::Defender("defender_right")),
+                                                                                       std::make_unique<role::Formation>(role::Formation("midfielder_left")),
+                                                                                       std::make_unique<role::Formation>(role::Formation("midfielder_middle")),
+                                                                                       std::make_unique<role::Formation>(role::Formation("midfielder_right")),
+                                                                                       std::make_unique<role::Formation>(role::Formation("attacker_left")),
+                                                                                       std::make_unique<role::Formation>(role::Formation("attacker_right"))};
 }
 
 uint8_t AttackingPass::score(PlayEvaluator& playEvaluator) noexcept {

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -35,7 +35,7 @@ AttackingPass::AttackingPass() : Play() {
                                                                                        std::make_unique<role::Defender>(role::Defender("defender_mid")),
                                                                                        std::make_unique<role::Defender>(role::Defender("defender_right")),
                                                                                        std::make_unique<role::Formation>(role::Formation("midfielder_left")),
-                                                                                       std::make_unique<role::Formation>(role::Formation("midfielder_middle")),
+                                                                                       std::make_unique<role::Formation>(role::Formation("midfielder_mid")),
                                                                                        std::make_unique<role::Formation>(role::Formation("midfielder_right")),
                                                                                        std::make_unique<role::Formation>(role::Formation("attacker_left")),
                                                                                        std::make_unique<role::Formation>(role::Formation("attacker_right"))};
@@ -65,7 +65,7 @@ Dealer::FlagMap AttackingPass::decideRoleFlags() const noexcept {
     flagMap.insert({"defender_mid", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
     flagMap.insert({"defender_right", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
     flagMap.insert({"midfielder_left", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
-    flagMap.insert({"midfielder_middle", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"midfielder_mid", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
     flagMap.insert({"midfielder_right", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
     flagMap.insert({"attacker_left", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
     flagMap.insert({"attacker_right", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
@@ -124,7 +124,7 @@ void AttackingPass::calculateInfoForDefenders() noexcept {
 
 void AttackingPass::calculateInfoForMidfielders() noexcept {
     stpInfos["midfielder_left"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleLeftGrid(), gen::OffensivePosition, field, world));
-    stpInfos["midfielder_middle"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleMidGrid(), gen::OffensivePosition, field, world));
+    stpInfos["midfielder_mid"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleMidGrid(), gen::OffensivePosition, field, world));
     stpInfos["midfielder_right"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleRightGrid(), gen::OffensivePosition, field, world));
 }
 

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -102,9 +102,9 @@ void AttackingPass::calculateInfoForRoles() noexcept {
 
         // Passer now goes to a front grid, where the receiver is not
         if (receiverLocation.y > field.getFrontLeftGrid().getOffSetY()) {  // Receiver is going to left of the field
-            stpInfos["passer"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontRightGrid(), gen::OffensivePosition, field, world));
+            stpInfos["passer"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleRightGrid(), gen::BlockingPosition, field, world));
         } else if (receiverLocation.y < field.getMiddleMidGrid().getOffSetY()) {  // Receiver is going to right of the field
-            stpInfos["passer"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
+            stpInfos["passer"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleLeftGrid(), gen::BlockingPosition, field, world));
         } else {  // Receiver is going to middle of the field- passer will go to the closest grid on the side of the field
             auto targetGrid = stpInfos["passer"].getRobot()->get()->getPos().y < 0 ? field.getMiddleRightGrid() : field.getMiddleLeftGrid();
             stpInfos["passer"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, targetGrid, gen::BlockingPosition, field, world));

--- a/src/stp/tactics/passive/Formation.cpp
+++ b/src/stp/tactics/passive/Formation.cpp
@@ -20,6 +20,8 @@ Formation::Formation() {
 std::optional<StpInfo> Formation::calculateInfoForSkill(StpInfo const &info) noexcept {
     StpInfo skillStpInfo = info;
 
+    if (!info.getPositionToMoveTo()) return std::nullopt;
+
     // Be 100% sure the dribbler is off during the formation
     skillStpInfo.setDribblerSpeed(0);
 

--- a/test/PassingTests/PassingTests.cpp
+++ b/test/PassingTests/PassingTests.cpp
@@ -33,7 +33,11 @@ TEST_F(RTT_AI_Tests, idTests) {
     EXPECT_TRUE(passInfo.keeperId != -1);
     EXPECT_TRUE((passInfo.receiverId != -1) || (passInfo.passScore == 0));
 
-    auto keeperId = world->getWorld()->getRobotClosestToPoint(world->getField()->getOurGoalCenter(), rtt::world::Team::us).value()->getId();
+    auto us = world->getWorld()->getUs();
+    auto keeperId = world->getWorld()->getRobotClosestToPoint(world->getField()->getOurGoalCenter(), us).value()->getId();
+    erase_if(us, [keeperId](auto bot) { return bot->getId() == keeperId; });
+    auto passerId = world->getWorld()->getRobotClosestToPoint(world->getWorld()->getBall()->get()->getPos(), us).value()->getId();
+    EXPECT_EQ(passInfo.passerId, passerId);
     EXPECT_TRUE(passInfo.keeperId == keeperId);
 }
 


### PR DESCRIPTION
### Comments for the reviewer
This PR adds more roles to that attacking pass can work with 11 bots. The roles still need to be fine-tuned, but that should be done when other plays are also made 11v11 and a 11v11 match can be played

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
