### PR TITLE
Fix wrong check for too little robots

### DIFF
--- a/src/stp/computations/PassComputations.cpp
+++ b/src/stp/computations/PassComputations.cpp
@@ -15,7 +15,7 @@ namespace rtt::ai::stp::computations {
 
 PassInfo PassComputations::calculatePass(gen::ScoreProfile profile, const rtt::world::World* world, const world::Field& field, bool keeperCanPass) {
     PassInfo passInfo;  // Struct used to store the information needed to execute the pass
-    if (!(world->getWorld()->getUs().size() >= 3) || (keeperCanPass && world->getWorld()->getUs().size() >= 2)){
+    if (world->getWorld()->getUs().size() < (keeperCanPass ? 2 : 3)){
         RTT_WARNING("Not enough robots to pass!");
         return passInfo;
     }


### PR DESCRIPTION
I accidentally made a PR for the wrong branch, which was the exact same except that this check was wrong. Oops. 

The previous check was wrong, as it would be true when there were >=3 robots and keeperCanPass was true, even though it should be false in that case.

@Reviewers, running the AI tests before merging a PR might be nice. This mistake broke the tests so would have been fixed before merging if the tests were ran :)

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
