### PR TITLE
Removed margin from penalty keeper

### DIFF
--- a/src/stp/plays/referee_specific/PenaltyThem.cpp
+++ b/src/stp/plays/referee_specific/PenaltyThem.cpp
@@ -55,7 +55,7 @@ Dealer::FlagMap PenaltyThem::decideRoleFlags() const noexcept {
 }
 
 void PenaltyThem::calculateInfoForRoles() noexcept {
-    stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + Constants::KEEPER_CENTREGOAL_MARGIN(), 0));
+    stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x, 0));
     stpInfos["keeper"].setPositionToShootAt(world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), world::us).value()->getPos());
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
     stpInfos["keeper"].setPidType(stp::PIDType::DEFAULT);

--- a/src/stp/plays/referee_specific/PenaltyThemPrepare.cpp
+++ b/src/stp/plays/referee_specific/PenaltyThemPrepare.cpp
@@ -36,7 +36,7 @@ void PenaltyThemPrepare::calculateInfoForRoles() noexcept {
     const double yPosition = Constants::STD_TIMEOUT_TO_TOP() ? distanceToCenterLine : -distanceToCenterLine;
 
     // Keeper
-    stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + Constants::KEEPER_CENTREGOAL_MARGIN(), world->getWorld()->getBall()->get()->getPos().y));
+    stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x, world->getWorld()->getBall()->get()->getPos().y));
 
     // regular bots
     const std::string formation = "formation_";


### PR DESCRIPTION
There was a margin in the position of the penaltykeeper, needed on the physical field. However in the sim it does not need this margin and might give us fauls. For the practice tournament it is removed

### Comments for the reviewer
- 

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
