### PR TITLE
Fix old keeper kick target and penaltyThem position

### DIFF
--- a/src/stp/plays/PlayTemplate.cpp
+++ b/src/stp/plays/PlayTemplate.cpp
@@ -74,8 +74,8 @@ void PlayTemplate::calculateInfoForScoredRoles(world::World* world) noexcept {
 void PlayTemplate::calculateInfoForRoles() noexcept {
     /// Function where are roles get their information, make sure not to compute roles twice.
     calculateInfoForScoredRoles(world);  // DONT TOUCH.
+    stpInfos["keeper"].setPositionToMoveTo(field.getOurGoalCenter() + Vector2(control_constants::DISTANCE_FROM_GOAL_CLOSE, 0));
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
-    stpInfos["keeper"].setPositionToShootAt(field.getTheirGoalCenter());
 
     stpInfos["role_1"].setPositionToMoveTo(pos::getPosition(stpInfos["role_1"].getPositionToMoveTo(), gen::gridRightTop, gen::GoalShootPosition, field, world));
     stpInfos["role_2"].setPositionToMoveTo(pos::getPosition(stpInfos["role_2"].getPositionToMoveTo(), gen::gridRightBot, gen::OffensivePosition, field, world));

--- a/src/stp/plays/ReflectKick.cpp
+++ b/src/stp/plays/ReflectKick.cpp
@@ -138,7 +138,7 @@ void ReflectKick::calculateInfoForRoles() noexcept {
 
     // Keeper
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
-    stpInfos["keeper"].setPositionToShootAt(Vector2());
+    stpInfos["keeper"].setPositionToMoveTo(field.getOurGoalCenter() + Vector2(control_constants::DISTANCE_FROM_GOAL_CLOSE, 0));
 }
 
 const char *ReflectKick::getName() { return "Reflect Kick"; }

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -64,8 +64,6 @@ void GetBallPossession::calculateInfoForRoles() noexcept {
     calculateInfoForScoredRoles(world);
 
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
-    // If keeper has ball, shoot at one of our robots thats closest to our goal
-    stpInfos["keeper"].setPositionToShootAt(world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), world::us).value()->getPos());
 
     stpInfos["defender_0"].setPositionToDefend(field.getOurGoalCenter());
     stpInfos["defender_0"].setEnemyRobot(world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), world::them));

--- a/src/stp/plays/offensive/GenericPass.cpp
+++ b/src/stp/plays/offensive/GenericPass.cpp
@@ -56,7 +56,6 @@ void GenericPass::calculateInfoForRoles() noexcept {
     auto ball = world->getWorld()->getBall()->get();
 
     /// Keeper
-    stpInfos["keeper"].setPositionToShootAt(Vector2{0.0, 0.0});
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
 
     /// Passer and receivers

--- a/src/stp/plays/referee_specific/KickOffThem.cpp
+++ b/src/stp/plays/referee_specific/KickOffThem.cpp
@@ -32,8 +32,7 @@ uint8_t KickOffThem::score(const rtt::world::Field& field) noexcept {
 
 void KickOffThem::calculateInfoForRoles() noexcept {
     // Keeper
-    stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter()));
-    stpInfos["keeper"].setPositionToShootAt(Vector2{0.0, 0.0});
+    stpInfos["keeper"].setPositionToMoveTo(field.getOurGoalCenter() + Vector2(control_constants::DISTANCE_FROM_GOAL_CLOSE, 0));
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
 }
 

--- a/src/stp/plays/referee_specific/KickOffUs.cpp
+++ b/src/stp/plays/referee_specific/KickOffUs.cpp
@@ -41,8 +41,7 @@ uint8_t KickOffUs::score(const rtt::world::Field &field) noexcept {
 
 void KickOffUs::calculateInfoForRoles() noexcept {
     // Keeper
-    // TODO: set good position to shoot at (compute pass location)- possibly do this in the keeper role
-    stpInfos["keeper"].setPositionToShootAt(Vector2{0.0, 0.0});
+    stpInfos["keeper"].setPositionToMoveTo(field.getOurGoalCenter() + Vector2(control_constants::DISTANCE_FROM_GOAL_CLOSE, 0));
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
 
     // Kicker

--- a/src/stp/plays/referee_specific/PenaltyThem.cpp
+++ b/src/stp/plays/referee_specific/PenaltyThem.cpp
@@ -55,8 +55,7 @@ Dealer::FlagMap PenaltyThem::decideRoleFlags() const noexcept {
 }
 
 void PenaltyThem::calculateInfoForRoles() noexcept {
-    stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + Constants::KEEPER_CENTREGOAL_MARGIN(), 0));
-    stpInfos["keeper"].setPositionToShootAt(world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), world::us).value()->getPos());
+    stpInfos["keeper"].setPositionToMoveTo(field.getOurGoalCenter());
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
     stpInfos["keeper"].setPidType(stp::PIDType::DEFAULT);
 }

--- a/src/stp/plays/referee_specific/PenaltyThemPrepare.cpp
+++ b/src/stp/plays/referee_specific/PenaltyThemPrepare.cpp
@@ -36,7 +36,7 @@ void PenaltyThemPrepare::calculateInfoForRoles() noexcept {
     const double yPosition = Constants::STD_TIMEOUT_TO_TOP() ? distanceToCenterLine : -distanceToCenterLine;
 
     // Keeper
-    stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter().x + Constants::KEEPER_CENTREGOAL_MARGIN(), world->getWorld()->getBall()->get()->getPos().y));
+    stpInfos["keeper"].setPositionToMoveTo(field.getOurGoalCenter());
 
     // regular bots
     const std::string formation = "formation_";

--- a/src/stp/plays/referee_specific/PenaltyUs.cpp
+++ b/src/stp/plays/referee_specific/PenaltyUs.cpp
@@ -66,9 +66,6 @@ void PenaltyUs::calculateInfoForRoles() noexcept {
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
 
     // TODO: the shoot position might need to change
-    stpInfos["keeper"].setPositionToShootAt(Vector2{0, -2});
-
-    // TODO: the shoot position might need to change
     stpInfos["kicker"].setPositionToShootAt(field.getTheirGoalCenter() + Vector2{1.0, 0.5});
     stpInfos["kicker"].setShotType(ShotType::PASS);
 }


### PR DESCRIPTION
### Comments for the reviewer
Since we have the KeeperKickBall play, the keeper does not kick during other plays anymore (nor does the keeper role contain getBall/kickAtPos anymore). However, the positionToShootTo was still set for the keeper in some places. This is not needed anymore and this PR removes those lines.

Furthermore, this PR changes the keepers position to move to during penalties, as that was previously not following the rules (the keeper has to always touch our goal line before the ball is kicked)

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
