### PR TITLE
Making one Defense Play

### DIFF
--- a/include/roboteam_ai/utilities/StpInfoEnums.h
+++ b/include/roboteam_ai/utilities/StpInfoEnums.h
@@ -9,7 +9,7 @@ namespace rtt::ai::stp {
 /**
  * The distance the robot should block at
  */
-enum class BlockDistance { CLOSE, PARTWAY, HALFWAY, FAR};
+enum class BlockDistance { ROBOTRADIUS, CLOSE, PARTWAY, HALFWAY, FAR};
 
 /**
  * Whether this robot should kick or chip in the shoot skill

--- a/src/stp/plays/defensive/DefendShot.cpp
+++ b/src/stp/plays/defensive/DefendShot.cpp
@@ -21,22 +21,21 @@ DefendShot::DefendShot() : Play() {
     keepPlayEvaluation.emplace_back(eval::TheyHaveBall);
     keepPlayEvaluation.emplace_back(GlobalEvaluation::BallNotInOurDefenseAreaAndStill);
 
-    roles = std::array<std::unique_ptr<Role>, stp::control_constants::MAX_ROBOT_COUNT>{
-        std::make_unique<role::Keeper>(role::Keeper("keeper")),           std::make_unique<role::BallDefender>(role::BallDefender("waller_1")),
-        std::make_unique<role::BallDefender>(role::BallDefender("waller_2")),     std::make_unique<role::BallDefender>(role::BallDefender("waller_3")),
-        std::make_unique<role::RobotDefender>(role::RobotDefender("defender_1")),   std::make_unique<role::RobotDefender>(role::RobotDefender("defender_2")),
-        std::make_unique<role::RobotDefender>(role::RobotDefender("robot_defender")),     std::make_unique<role::BallDefender>(role::BallDefender("midfielder_1")),
-        std::make_unique<role::BallDefender>(role::BallDefender("midfielder_2")), std::make_unique<role::BallDefender>(role::BallDefender("midfielder_3")),
-        std::make_unique<role::BallDefender>(role::BallDefender("midfielder_4")),
-    };
+    roles = std::array<std::unique_ptr<Role>, stp::control_constants::MAX_ROBOT_COUNT>{std::make_unique<role::Keeper>(role::Keeper("keeper")),
+                                                                                       std::make_unique<role::BallDefender>(role::BallDefender("waller_1")),
+                                                                                       std::make_unique<role::BallDefender>(role::BallDefender("waller_2")),
+                                                                                       std::make_unique<role::BallDefender>(role::BallDefender("waller_3")),
+                                                                                       std::make_unique<role::RobotDefender>(role::RobotDefender("robot_defender")),
+                                                                                       std::make_unique<role::BallDefender>(role::BallDefender("midfielder_1")),
+                                                                                       std::make_unique<role::BallDefender>(role::BallDefender("midfielder_2")),
+                                                                                       std::make_unique<role::BallDefender>(role::BallDefender("midfielder_3")),
+                                                                                       std::make_unique<role::BallDefender>(role::BallDefender("midfielder_4")),
+                                                                                       std::make_unique<role::BallDefender>(role::BallDefender("midfielder_5")),
+                                                                                       std::make_unique<role::BallDefender>(role::BallDefender("midfielder_6"))};
 }
 
 uint8_t DefendShot::score(const rtt::world::Field& field) noexcept {
-    auto enemyRobot = world->getWorld()->getRobotClosestToBall(world::them);
-    auto goalVisibility =
-        FieldComputations::getPercentageOfGoalVisibleFromPoint(field, true, enemyRobot->get()->getPos(), world->getWorld().value(), enemyRobot->get()->getId(), false);
-    auto position = distanceFromPointToLine(field.getBottomLeftCorner(), field.getTopLeftCorner(), enemyRobot->get()->getPos());
-    return 255 * (field.getFieldLength() - position) / field.getFieldLength() * goalVisibility / 100;
+    return 255;
 }
 
 Dealer::FlagMap DefendShot::decideRoleFlags() const noexcept {
@@ -51,12 +50,12 @@ Dealer::FlagMap DefendShot::decideRoleFlags() const noexcept {
     flagMap.insert({"waller_1", {DealerFlagPriority::HIGH_PRIORITY, {closeToOurGoalFlag}}});
     flagMap.insert({"waller_2", {DealerFlagPriority::HIGH_PRIORITY, {closeToOurGoalFlag}}});
     flagMap.insert({"waller_3", {DealerFlagPriority::HIGH_PRIORITY, {closeToOurGoalFlag}}});
-    flagMap.insert({"defender_1", {DealerFlagPriority::MEDIUM_PRIORITY, {closeToOurGoalFlag}}});
-    flagMap.insert({"defender_2", {DealerFlagPriority::MEDIUM_PRIORITY, {closeToOurGoalFlag}}});
     flagMap.insert({"midfielder_1", {DealerFlagPriority::MEDIUM_PRIORITY, {notImportant}}});
     flagMap.insert({"midfielder_2", {DealerFlagPriority::MEDIUM_PRIORITY, {notImportant}}});
     flagMap.insert({"midfielder_3", {DealerFlagPriority::MEDIUM_PRIORITY, {notImportant}}});
     flagMap.insert({"midfielder_4", {DealerFlagPriority::MEDIUM_PRIORITY, {notImportant}}});
+    flagMap.insert({"midfielder_5", {DealerFlagPriority::MEDIUM_PRIORITY, {notImportant}}});
+    flagMap.insert({"midfielder_6", {DealerFlagPriority::MEDIUM_PRIORITY, {notImportant}}});
 
     return flagMap;
 }
@@ -86,22 +85,6 @@ void DefendShot::calculateInfoForDefenders() noexcept {
 
     erase_if(enemyRobots, [&](const auto enemyRobot) -> bool { return enemyClosestToBall && enemyRobot->getId() == enemyClosestToBall.value()->getId(); });
 
-    auto enemyClosestToOurGoalOne = world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), enemyRobots);
-
-    erase_if(enemyRobots, [&](const auto enemyRobot) -> bool { return enemyClosestToOurGoalOne && enemyRobot->getId() == enemyClosestToOurGoalOne.value()->getId(); });
-
-    auto enemyClosestToOurGoalTwo = world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), enemyRobots);
-
-    erase_if(enemyRobots, [&](const auto enemyRobot) -> bool { return enemyClosestToOurGoalTwo && enemyRobot->getId() == enemyClosestToOurGoalTwo.value()->getId(); });
-
-    stpInfos["defender_1"].setPositionToDefend(field.getOurGoalCenter());
-    stpInfos["defender_1"].setEnemyRobot(enemyClosestToOurGoalOne);
-    stpInfos["defender_1"].setBlockDistance(BlockDistance::CLOSE);
-
-    stpInfos["defender_2"].setPositionToDefend(field.getOurGoalCenter());
-    stpInfos["defender_2"].setEnemyRobot(enemyClosestToOurGoalTwo);
-    stpInfos["defender_2"].setBlockDistance(BlockDistance::CLOSE);
-
     std::map<double, Vector2> enemyMap;
 
     for (auto enemy : enemyRobots) {
@@ -109,10 +92,10 @@ void DefendShot::calculateInfoForDefenders() noexcept {
         enemyMap.insert({score, enemy->getPos()});
     }
 
-    for (int i = 1; i <= 4; i++) {
+    for (int i = 1; i <= 6; i++) {
         if (!enemyMap.empty()) {
             stpInfos["midfielder_" + std::to_string(i)].setPositionToDefend(enemyMap.begin()->second);
-            stpInfos["midfielder_" + std::to_string(i)].setBlockDistance(BlockDistance::CLOSE);
+            stpInfos["midfielder_" + std::to_string(i)].setBlockDistance(BlockDistance::ROBOTRADIUS);
             enemyMap.erase(enemyMap.begin());
         } else {
             break;
@@ -129,7 +112,6 @@ void DefendShot::calculateInfoForRobotDefenders() noexcept {
 void DefendShot::calculateInfoForKeeper() noexcept {
     stpInfos["keeper"].setPositionToMoveTo(field.getOurGoalCenter());
     stpInfos["keeper"].setEnemyRobot(world->getWorld()->getRobotClosestToBall(world::them));
-    stpInfos["keeper"].setPositionToShootAt(world->getWorld()->getRobotClosestToPoint(field.getOurGoalCenter(), world::us).value()->getPos());
     stpInfos["keeper"].setKickOrChip(KickOrChip::KICK);
 }
 

--- a/src/stp/tactics/passive/BlockBall.cpp
+++ b/src/stp/tactics/passive/BlockBall.cpp
@@ -49,6 +49,9 @@ Vector2 BlockBall::calculateTargetPosition(const world::view::BallView &ball, Ve
 
     double distance;
     switch (blockDistance) {
+        case BlockDistance::ROBOTRADIUS:
+            distance = control_constants::ROBOT_RADIUS;
+            break;
         case BlockDistance::CLOSE:
             // Default distance of 0.5m. If the ball is closer than that to the enemy, stand right in front of the ball instead.
             distance = std::min(0.5, targetToBall.length() - control_constants::ROBOT_RADIUS);


### PR DESCRIPTION
Added new distance in Block Ball for our robots to stand close to the enemy robots, changed play DefenseShot to be the one selected when enemy has a ball

### Comments for the reviewer
- Having defense shot as only defense play we have, the scoring for this play is always 255

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
