### PR TITLE
Return ANGLE_RATE to 0.1 pi

### DIFF
--- a/src/stp/constants/ControlConstants.cpp
+++ b/src/stp/constants/ControlConstants.cpp
@@ -41,7 +41,7 @@ constexpr double ENEMY_CLOSE_TO_BALL_DISTANCE = 1.0;
 constexpr double MAX_VEL_CMD = 8;
 constexpr double MAX_DRIBBLER_CMD = 1;
 // Angle increment per tick
-constexpr double ANGLE_RATE = 2 * M_PI;
+constexpr double ANGLE_RATE = 0.1 * M_PI;
 constexpr double MAX_VEL_WHEN_HAS_BALL = 3.0;
 
 /// HasBall margins


### PR DESCRIPTION
Turning too fast in the er simulator actually makes the robot lose the ball. Therefore it is better to set this angle rate to a lower value to avoid this

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
