### PR TITLE
Prevent infinite loop

### DIFF
--- a/src/control/positionControl/BBTrajectories/Trajectory2D.cpp
+++ b/src/control/positionControl/BBTrajectories/Trajectory2D.cpp
@@ -8,6 +8,8 @@
 
 #include "control/positionControl/BBTrajectories/BBTrajectory2D.h"
 
+#include "roboteam_utils/Print.h"
+
 namespace rtt {
 
 Trajectory2D::Trajectory2D(const Vector2 &initialPos, const Vector2 &initialVel, const Vector2 &finalPos, double maxVel, double maxAcc) {
@@ -35,6 +37,13 @@ std::vector<Vector2> Trajectory2D::getPathApproach(double timeStep) const {
     auto totalTime = getTotalTime();
     double time = 0;
 
+    if (totalTime == std::numeric_limits<double>::infinity()) {
+        // TODO: Prevent this from happening!
+        RTT_ERROR("Infinite while loop")
+        //throw std::runtime_error("Total time of infinity!");
+        return {getPosition(0)};
+    }
+
     while (time <= totalTime) {
         time += timeStep;
         points.push_back(getPosition(time));
@@ -46,6 +55,13 @@ std::vector<Vector2> Trajectory2D::getVelocityVector(double timeStep) const {
     std::vector<Vector2> velocities;
     auto totalTime = getTotalTime();
     double time = 0;
+
+    if (totalTime == std::numeric_limits<double>::infinity()) {
+        // TODO: Prevent this from happening!
+        RTT_ERROR("Infinite while loop")
+        //throw std::runtime_error("Total time of infinity!");
+        return {getPosition(0)};
+    }
 
     while (time <= totalTime) {
         time += timeStep;


### PR DESCRIPTION
To calculate the points of the path, it has a while loop untill the end of the path. Somehow, infinite times are calculated when switching from non-referee to referee mode while playing many plays (e.g. Attack, DefendPass, but not AttackingPass).
I looked into the past history, and this bug has been in existence for at least a month.

THIS IS NOT A SOLUTION. Someone, (preferably @TijmenWesteneng , as it is BB related ) should look into this.

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
