### PR TITLE
Fix/has ball margin

### DIFF
--- a/include/roboteam_ai/utilities/Constants.h
+++ b/include/roboteam_ai/utilities/Constants.h
@@ -68,6 +68,9 @@ class Constants {
     static double CENTRE_TO_FRONT();
     static double CLOSE_TO_BORDER_DISTANCE();
 
+    static double HAS_BALL_DISTANCE();
+    static double HAS_BALL_ANGLE();
+
     /// REF STATES ///
     static constexpr double MAX_VEL() { return 1.5; };
     static constexpr double MAX_STOP_STATE_VEL() { return 1.5; };
@@ -85,7 +88,6 @@ class Constants {
     static double OUT_OF_FIELD_MARGIN();
     static double MAX_BALL_BOUNCE_RANGE();
     static double MAX_BALL_RANGE();  // Could maybe be even less? Is a LOT lower in real life, think max 0.05 m.
-    static double HAS_BALL_ANGLE();
     static double MAX_KICK_RANGE();
     static double MAX_PASS_DISTANCE();
     static bool REFLECT_KICK();

--- a/include/roboteam_ai/world/FieldComputations.h
+++ b/include/roboteam_ai/world/FieldComputations.h
@@ -9,6 +9,7 @@
 
 #include "control/ControlUtils.h"
 #include "interface/api/Input.h"
+#include "stp/constants/ControlConstants.h"
 #include "utilities/StpInfoEnums.h"
 #include "views/WorldDataView.hpp"
 #include "world/Field.h"

--- a/include/roboteam_ai/world/views/RobotView.hpp
+++ b/include/roboteam_ai/world/views/RobotView.hpp
@@ -6,7 +6,7 @@
 #define RTT_ROBOT_VIEW_HPP
 
 #include <roboteam_utils/Vector2.h>
-#include <stp/constants/ControlConstants.h>
+#include <utilities/Constants.h>
 
 #include <world/Robot.hpp>
 
@@ -84,8 +84,7 @@ class RobotView {
      * @param angleErrorMargin angle error margin for ball possession
      * @return true if ballSensorSeesBall (both sim or irl) or when ball is within dist/angle margin (only irl)
      */
-    [[nodiscard]] bool hasBall(double distanceErrorMargin = ai::stp::control_constants::HAS_BALL_DISTANCE_ERROR_MARGIN,
-                               double angleErrorMargin = ai::stp::control_constants::HAS_BALL_ANGLE_ERROR_MARGIN) const noexcept;
+    [[nodiscard]] bool hasBall(double distanceErrorMargin = ai::Constants::HAS_BALL_DISTANCE(), double angleErrorMargin = ai::Constants::HAS_BALL_ANGLE()) const noexcept;
 
     /**
      * Gets the kicker for the Robot that this view is viewing

--- a/src/stp/constants/ControlConstants.cpp
+++ b/src/stp/constants/ControlConstants.cpp
@@ -44,14 +44,6 @@ constexpr double MAX_DRIBBLER_CMD = 1;
 constexpr double ANGLE_RATE = 0.1 * M_PI;
 constexpr double MAX_VEL_WHEN_HAS_BALL = 3.0;
 
-/// HasBall margins
-// Angle margin robot to ball. Within this margin, the robot has the ball
-constexpr double HAS_BALL_ANGLE_ERROR_MARGIN = 0.10;
-// Distance margin robot to ball. Within this margin, the robot has the ball
-/// WHEN IN GRSIM, this is not used, as using feedback is a more accurate. If using this, set distance to 0.12
-/// WHEN IRL, CHANGE HAS_BALL_DISTANCE_ERROR_MARGIN TO 0.10
-constexpr double HAS_BALL_DISTANCE_ERROR_MARGIN = 0.12;
-
 /// GTP Constants
 // Distance margin for 'goToPos'. If the robot is within this margin, goToPos is successful
 constexpr double GO_TO_POS_ERROR_MARGIN = 0.08;

--- a/src/stp/plays/defensive/KeeperKickBall.cpp
+++ b/src/stp/plays/defensive/KeeperKickBall.cpp
@@ -6,6 +6,7 @@
 
 #include "stp/computations/PassComputations.h"
 #include "stp/computations/PositionScoring.h"
+#include "stp/constants/ControlConstants.h"
 #include "stp/roles/active/PassReceiver.h"
 #include "stp/roles/active/Passer.h"
 #include "stp/roles/passive/Formation.h"
@@ -113,7 +114,7 @@ bool KeeperKickBall::shouldEndPlay() noexcept {
         if (stpInfos["receiver"].getRobot()->hasBall()) return true;
 
         // True if the passer has shot the ball, but it is now almost stationary (pass was too soft, was reflected, etc.)
-        if (ballKicked() && stpInfos["keeper"].getRobot()->get()->getDistanceToBall() >= control_constants::HAS_BALL_DISTANCE_ERROR_MARGIN * 1.5 &&
+        if (ballKicked() && stpInfos["keeper"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&
             world->getWorld()->getBall()->get()->getVelocity().length() < control_constants::BALL_STILL_VEL)
             return true;
     }

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -9,6 +9,7 @@
 
 #include "stp/computations/PassComputations.h"
 #include "stp/computations/PositionScoring.h"
+#include "stp/constants/ControlConstants.h"
 #include "stp/roles/Keeper.h"
 #include "stp/roles/active/PassReceiver.h"
 #include "stp/roles/active/Passer.h"
@@ -146,7 +147,7 @@ bool AttackingPass::shouldEndPlay() noexcept {
         if (stpInfos["receiver"].getRobot()->hasBall()) return true;
 
         // True if the passer has shot the ball, but it is now almost stationary (pass was too soft, was reflected, etc.)
-        if (ballKicked() && stpInfos["passer"].getRobot()->get()->getDistanceToBall() >= control_constants::HAS_BALL_DISTANCE_ERROR_MARGIN * 1.5 &&
+        if (ballKicked() && stpInfos["passer"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&
             world->getWorld()->getBall()->get()->getVelocity().length() < control_constants::BALL_STILL_VEL)
             return true;
     }

--- a/src/stp/plays/referee_specific/FreeKickUsPass.cpp
+++ b/src/stp/plays/referee_specific/FreeKickUsPass.cpp
@@ -139,7 +139,7 @@ bool FreeKickUsPass::shouldEndPlay() noexcept {
         if (stpInfos["receiver"].getRobot()->hasBall()) return true;
 
         // True if the free_kick_taker has shot the ball, but it is now almost stationary (pass was too soft, was reflected, etc.)
-        if (ballKicked() && stpInfos["free_kick_taker"].getRobot()->get()->getDistanceToBall() >= control_constants::HAS_BALL_DISTANCE_ERROR_MARGIN * 1.5 &&
+        if (ballKicked() && stpInfos["free_kick_taker"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&
             world->getWorld()->getBall()->get()->getVelocity().length() < control_constants::BALL_STILL_VEL)
             return true;
     }

--- a/src/stp/plays/referee_specific/KickOffUs.cpp
+++ b/src/stp/plays/referee_specific/KickOffUs.cpp
@@ -90,7 +90,7 @@ bool KickOffUs::shouldEndPlay() noexcept {
         if (stpInfos["receiver"].getRobot()->hasBall()) return true;
 
         // True if the kick_off_taker has shot the ball, but it is now stationary (pass was too soft, was reflected, etc.)
-        return ballKicked() && stpInfos["kick_off_taker"].getRobot()->get()->getDistanceToBall() >= control_constants::HAS_BALL_DISTANCE_ERROR_MARGIN * 1.5 &&
+        return ballKicked() && stpInfos["kick_off_taker"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&
                world->getWorld()->getBall()->get()->getVelocity().length() < control_constants::BALL_STILL_VEL;
     }
     return false;

--- a/src/stp/skills/Chip.cpp
+++ b/src/stp/skills/Chip.cpp
@@ -4,6 +4,8 @@
 
 #include "stp/skills/Chip.h"
 
+#include "stp/constants/ControlConstants.h"
+
 namespace rtt::ai::stp::skill {
 
 Status Chip::onUpdate(const StpInfo &info) noexcept {

--- a/src/stp/skills/Kick.cpp
+++ b/src/stp/skills/Kick.cpp
@@ -4,6 +4,8 @@
 
 #include "stp/skills/Kick.h"
 
+#include "stp/constants/ControlConstants.h"
+
 namespace rtt::ai::stp::skill {
 
 Status Kick::onUpdate(const StpInfo &info) noexcept {

--- a/src/stp/skills/Orbit.cpp
+++ b/src/stp/skills/Orbit.cpp
@@ -4,6 +4,8 @@
 
 #include "stp/skills/Orbit.h"
 
+#include "stp/constants/ControlConstants.h"
+
 namespace rtt::ai::stp::skill {
 
 Status Orbit::onUpdate(const StpInfo &info) noexcept {

--- a/src/stp/skills/Rotate.cpp
+++ b/src/stp/skills/Rotate.cpp
@@ -5,6 +5,7 @@
 #include "stp/skills/Rotate.h"
 
 #include "control/ControlUtils.h"
+#include "stp/constants/ControlConstants.h"
 
 namespace rtt::ai::stp::skill {
 

--- a/src/stp/skills/Shoot.cpp
+++ b/src/stp/skills/Shoot.cpp
@@ -5,6 +5,7 @@
 #include "stp/skills/Shoot.h"
 
 #include "roboteam_utils/Print.h"
+#include "stp/constants/ControlConstants.h"
 
 namespace rtt::ai::stp::skill {
 

--- a/src/stp/tactics/Intercept.cpp
+++ b/src/stp/tactics/Intercept.cpp
@@ -5,6 +5,7 @@
 
 #include "stp/tactics/Intercept.h"
 
+#include "stp/constants/ControlConstants.h"
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Rotate.h"
 

--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -6,6 +6,7 @@
 
 #include "control/ControlUtils.h"
 #include "roboteam_utils/LineSegment.h"
+#include "stp/constants/ControlConstants.h"
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Rotate.h"
 

--- a/src/stp/tactics/PositionAndAim.cpp
+++ b/src/stp/tactics/PositionAndAim.cpp
@@ -5,6 +5,7 @@
 
 #include "stp/tactics/PositionAndAim.h"
 
+#include "stp/constants/ControlConstants.h"
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Rotate.h"
 

--- a/src/stp/tactics/active/ChipAtPos.cpp
+++ b/src/stp/tactics/active/ChipAtPos.cpp
@@ -8,6 +8,7 @@
 #include "stp/tactics/active/ChipAtPos.h"
 
 #include "control/ControlUtils.h"
+#include "stp/constants/ControlConstants.h"
 #include "stp/skills/Chip.h"
 #include "stp/skills/Rotate.h"
 

--- a/src/stp/tactics/active/DriveWithBall.cpp
+++ b/src/stp/tactics/active/DriveWithBall.cpp
@@ -9,8 +9,8 @@
 
 #include "stp/tactics/active/DriveWithBall.h"
 
+#include "stp/constants/ControlConstants.h"
 #include "stp/skills/GoToPos.h"
-#include "stp/skills/Rotate.h"
 
 namespace rtt::ai::stp::tactic {
 

--- a/src/stp/tactics/active/GetBall.cpp
+++ b/src/stp/tactics/active/GetBall.cpp
@@ -24,7 +24,7 @@ std::optional<StpInfo> GetBall::calculateInfoForSkill(StpInfo const &info) noexc
     Vector2 ballPosition = skillStpInfo.getBall().value()->getPos();
     double ballDistance = (ballPosition - robotPosition).length();
 
-    if (skillStpInfo.getRobot()->get()->getAngleDiffToBall() > control_constants::HAS_BALL_ANGLE_ERROR_MARGIN * M_PI && ballDistance < control_constants::AVOID_BALL_DISTANCE) {
+    if (skillStpInfo.getRobot()->get()->getAngleDiffToBall() > Constants::HAS_BALL_ANGLE() * M_PI && ballDistance < control_constants::AVOID_BALL_DISTANCE) {
         // don't move too close to the ball until the angle to the ball is (roughly) correct
         skillStpInfo.setPositionToMoveTo(
             FieldComputations::projectPointToValidPosition(info.getField().value(), skillStpInfo.getRobot()->get()->getPos(), info.getObjectsToAvoid()));
@@ -49,7 +49,7 @@ std::optional<StpInfo> GetBall::calculateInfoForSkill(StpInfo const &info) noexc
 bool GetBall::isTacticFailing(const StpInfo &info) noexcept { return false; }
 
 bool GetBall::shouldTacticReset(const StpInfo &info) noexcept {
-    return (info.getRobot()->get()->getAngleDiffToBall() < control_constants::HAS_BALL_ANGLE_ERROR_MARGIN * M_PI) && (skills.current_num() == 1);
+    return (info.getRobot()->get()->getAngleDiffToBall() < Constants::HAS_BALL_ANGLE() * M_PI) && (skills.current_num() == 1);
 }
 
 bool GetBall::isEndTactic() noexcept {

--- a/src/stp/tactics/active/GetBehindBallInDirection.cpp
+++ b/src/stp/tactics/active/GetBehindBallInDirection.cpp
@@ -7,6 +7,7 @@
 #include <roboteam_utils/LineSegment.h>
 
 #include "roboteam_utils/Circle.h"
+#include "stp/constants/ControlConstants.h"
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Orbit.h"
 

--- a/src/stp/tactics/active/KickAtPos.cpp
+++ b/src/stp/tactics/active/KickAtPos.cpp
@@ -9,6 +9,7 @@
 #include "stp/tactics/active/KickAtPos.h"
 
 #include "control/ControlUtils.h"
+#include "stp/constants/ControlConstants.h"
 #include "stp/skills/Kick.h"
 #include "stp/skills/Rotate.h"
 

--- a/src/stp/tactics/active/Receive.cpp
+++ b/src/stp/tactics/active/Receive.cpp
@@ -7,6 +7,7 @@
 
 #include "stp/tactics/active/Receive.h"
 
+#include "stp/constants/ControlConstants.h"
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Rotate.h"
 

--- a/src/stp/tactics/active/ShootAtPos.cpp
+++ b/src/stp/tactics/active/ShootAtPos.cpp
@@ -10,6 +10,7 @@
 #include <roboteam_utils/Print.h>
 
 #include "control/ControlUtils.h"
+#include "stp/constants/ControlConstants.h"
 #include "stp/skills/Rotate.h"
 #include "stp/skills/Shoot.h"
 

--- a/src/stp/tactics/passive/Walling.cpp
+++ b/src/stp/tactics/passive/Walling.cpp
@@ -6,6 +6,7 @@
 
 #include "stp/tactics/passive/Walling.h"
 
+#include "stp/constants/ControlConstants.h"
 #include "stp/skills/GoToPos.h"
 #include "stp/skills/Rotate.h"
 

--- a/src/utilities/Constants.cpp
+++ b/src/utilities/Constants.cpp
@@ -2,12 +2,13 @@
 // Created by mrlukasbos on 8-2-19.
 //
 
-#include "utilities/Constants.h"
-
 #include <assert.h>
 #include <roboteam_utils/Print.h>
 
-#include <iostream>
+#include "utilities/Settings.h"
+#include "utilities/Constants.h"
+
+// TODO: Clean this up and remove unneeded variables
 
 namespace rtt::ai {
 
@@ -110,8 +111,6 @@ double Constants::MAX_BALL_RANGE() { return 0.04; }
 
 double Constants::MAX_KICK_RANGE() { return 0.05; }
 
-double Constants::HAS_BALL_ANGLE() { return 0.2; }
-
 double Constants::MAX_INTERCEPT_TIME() { return 3.0; }
 
 double Constants::MAX_RECEIVE_TIME() { return 1.0; }
@@ -165,6 +164,12 @@ bool Constants::STD_SHOW_DEBUG_VALUES() { return true; }
 bool Constants::STD_USE_REFEREE() { return true; }
 
 bool Constants::STD_TIMEOUT_TO_TOP() { return false; }
+
+// The max distance the ball can be from the robot for the robot to have the ball
+double Constants::HAS_BALL_DISTANCE() { return (SETTINGS.getRobotHubMode() == Settings::BASESTATION) ? 0.10 : 0.12; }
+
+// The max angle the ball can have to the robot for the robot to have the ball
+double Constants::HAS_BALL_ANGLE() { return 0.10; }
 
 std::map<int, bool> Constants::ROBOTS_WITH_WORKING_DRIBBLER() {
     static std::map<int, bool> workingDribblerRobots;

--- a/src/world/views/WorldDataView.cpp
+++ b/src/world/views/WorldDataView.cpp
@@ -4,6 +4,7 @@
 
 #include "world/views/WorldDataView.hpp"
 
+#include "stp/constants/ControlConstants.h"
 #include "world/WorldData.hpp"
 
 namespace rtt::world::view {


### PR DESCRIPTION
### Comments for the reviewer
The distance within which the robot can have the ball differs between the sim and irl. Previously, this meant that the constant denoting this distance had to be changed manually depending on whether you were using the sim or not. This PR makes sure this is done automatically be using a constant-like function that returns one of two numbers depending on the RobotHubMode.

###### Code Quality
- [x] Is the code is understandable and easy to read
- [x] Changes to the code comply with set clang-format rules
- [x] No use of manual memory control (e.g new/malloc/colloc etc)
- [x] Are (only) smart pointers used?

###### Testing
- [x] All tests are passing.
- [x] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [x] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [x] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [x] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
