### PR TITLE
Chore/clean ball

### DIFF
--- a/docs/Ball.md
+++ b/docs/Ball.md
@@ -27,13 +27,13 @@ serves the purpose of representing the ball. Things like position and velocity a
 
 `updateBallAtRobotPosition` -> Updates `expectedEndPosition` and draws to the interface.
 
-`getPos` -> Returns `position`
+`getPosBall` -> Returns `position`
 
-`getVelocity` -> Returns `velocity`
+`getVelocityBall` -> Returns `velocity`
 
-`isVisible` -> Returns `visible`
+`isVisibleBall` -> Returns `visible`
 
-`getExpectedEndPosition` -> Returns `expectedEndPosition` 
+`getExpectedEndPositionBall` -> Returns `expectedEndPosition` 
 
 `getFilteredVelocity` -> Returns `filteredVelocity`
 

--- a/include/roboteam_ai/world/Ball.hpp
+++ b/include/roboteam_ai/world/Ball.hpp
@@ -15,37 +15,6 @@ class World;
 
 namespace rtt::world::ball {
 
-/**
- * The movement friction during simulation and real life are different, because the simulation does not model
- * everything. So the movement friction has to be adjusted to compensate for this difference.
- *
- * The expected movement friction of the ball during simulation
- */
-constexpr static float SIMULATION_FRICTION = 1.22;
-
-/**
- * The expected movement friction of the ball during simulation
- */
-constexpr static float REAL_FRICTION = 0.61;
-
-/**
- * The maximum possible factor used for the Kalman filter which is used when filtering the velocity.
- */
-constexpr static float FILTER_MAX_FACTOR_FOR_VELOCITY = 0.8;
-
-/**
- * The smallest velocity used for the Kalman filter for which we have that the factor is equal
- * THRESHOLD_ROBOT_CLOSE_TO_BALL. Larger velocities will also have THRESHOLD_ROBOT_CLOSE_TO_BALL as factor.
- */
-constexpr static float FILTER_VELOCITY_WITH_MAX_FACTOR = 8.0;
-
-/**
- * The threshold used for the filtered velocity, if it exceeds this value then we use the velocity
- * instead as estimation for the filtered velocity. More information can be found in the comment in the
- * filterBallVelocity method of the Ball.cpp file.
- */
-constexpr static float MAXIMUM_FILTER_VELOCITY = 100.0;
-
 class Ball {
    private:
     /**

--- a/include/roboteam_ai/world/Ball.hpp
+++ b/include/roboteam_ai/world/Ball.hpp
@@ -16,7 +16,7 @@ class World;
 namespace rtt::world::ball {
 
 class Ball {
-   private:
+public:
     Vector2 position; /// Position of the ball
     Vector2 velocity; /// Velocity of the ball
     bool visible = false; /// Whether the ball is visible by any camera
@@ -46,15 +46,6 @@ class Ball {
      * Also updates which robot has the ball and the location
      */
     void updateBallAtRobotPosition(const world::World *data) noexcept;
-
-   public:
-    [[nodiscard]] const Vector2 &getPos() const noexcept;
-
-    [[nodiscard]] const Vector2 &getVelocity() const noexcept;
-
-    [[nodiscard]] bool isVisible() const noexcept;
-
-    [[nodiscard]] const Vector2 &getExpectedEndPosition() const noexcept;
 
     /**
      * Create a Ball object with the current data about the ball.

--- a/include/roboteam_ai/world/Ball.hpp
+++ b/include/roboteam_ai/world/Ball.hpp
@@ -23,17 +23,9 @@ public:
     Vector2 expectedEndPosition; /// Expected position of the ball after it stopped moving
 
     /**
-     * Initializes:
-     *  Expected end pos
-     *  Sets position if it's currently unknown
-     *  Updates position
+     * Initializes ball at the previously seen position, if the current ball is not visible
      */
-    void initializeCalculations(const world::World *data) noexcept;
-
-    /**
-     * Initializes ball at the robot's position if `this` does not have a position
-     */
-    void initBallAtRobotPosition(const world::World *data) noexcept;
+    void initBallAtExpectedPosition(const world::World *data) noexcept;
 
     /**
      * Updates the expected ball end position
@@ -41,9 +33,7 @@ public:
     void updateExpectedBallEndPosition(const world::World *data) noexcept;
 
     /**
-     * Updates expectedEndPosition and draws to interface
-     * If ball not visible -> get last position if robot can confirm
-     * Also updates which robot has the ball and the location
+     * Places the ball in front of the robot that has the ball, if any
      */
     void updateBallAtRobotPosition(const world::World *data) noexcept;
 

--- a/include/roboteam_ai/world/Ball.hpp
+++ b/include/roboteam_ai/world/Ball.hpp
@@ -38,13 +38,7 @@ class Ball {
     Vector2 expectedEndPosition;
 
     /**
-     * The velocity but thn adjusted to determine a more realistic end position
-     */
-    Vector2 filteredVelocity;
-
-    /**
      * Initializes:
-     *  Filtered velocity
      *  Expected end pos
      *  Sets position if it's currently unknown
      *  Updates position
@@ -55,11 +49,6 @@ class Ball {
      * Initializes ball at the robot's position if `this` does not have a position
      */
     void initBallAtRobotPosition(const world::World *data) noexcept;
-
-    /**
-     * Sets filteredVelocity
-     */
-    void filterBallVelocity(const world::World *data) noexcept;
 
     /**
      * Updates the expected ball end position
@@ -81,8 +70,6 @@ class Ball {
     [[nodiscard]] bool isVisible() const noexcept;
 
     [[nodiscard]] const Vector2 &getExpectedEndPosition() const noexcept;
-
-    [[nodiscard]] const Vector2 &getFilteredVelocity() const noexcept;
 
     /**
      * Default ctor for containers

--- a/include/roboteam_ai/world/Ball.hpp
+++ b/include/roboteam_ai/world/Ball.hpp
@@ -17,25 +17,10 @@ namespace rtt::world::ball {
 
 class Ball {
    private:
-    /**
-     * The position where this ball currently is
-     */
-    Vector2 position;
-
-    /**
-     * The current velocity of the ball
-     */
-    Vector2 velocity;
-
-    /**
-     * Boolean flag that indicates whether the ball is currently visible by any camera
-     */
-    bool visible = false;
-
-    /**
-     * Expected ball end position (where it lays still) after following its path
-     */
-    Vector2 expectedEndPosition;
+    Vector2 position; /// Position of the ball
+    Vector2 velocity; /// Velocity of the ball
+    bool visible = false; /// Whether the ball is visible by any camera
+    Vector2 expectedEndPosition; /// Expected position of the ball after it stopped moving
 
     /**
      * Initializes:
@@ -72,11 +57,6 @@ class Ball {
     [[nodiscard]] const Vector2 &getExpectedEndPosition() const noexcept;
 
     /**
-     * Default ctor for containers
-     */
-    Ball() = default;
-
-    /**
      * Create a Ball object with the current data about the ball.
      * @param copy The current data about the ball
      */
@@ -85,14 +65,11 @@ class Ball {
     /**
      * Defaulted constructors
      */
+    Ball() = default;
     Ball &operator=(Ball const &) = default;
-
     Ball(Ball const &) = default;
-
     Ball &operator=(Ball &&) = default;
-
     Ball(Ball &&) = default;
-
     ~Ball() = default;
 };
 

--- a/include/roboteam_ai/world/Robot.hpp
+++ b/include/roboteam_ai/world/Robot.hpp
@@ -48,6 +48,7 @@ class Robot {
 
     bool seesBall{};
     float ballPos{};
+    bool robotHasBall{};
 
    private:
     void updateFromFeedback(const proto::RobotProcessedFeedback &feedback) noexcept;
@@ -82,6 +83,8 @@ class Robot {
 
     void setBallSensorSeesBall(bool _seesBall) noexcept;
 
+    void setHasBall(bool _hasBall) noexcept;
+
     void setBallPosBallSensor(float _ballPos) noexcept;
 
     void setLastUpdatedWorldNumber(unsigned long lastUpdatedWorldNumber) noexcept;
@@ -114,6 +117,8 @@ class Robot {
     [[nodiscard]] bool isWorkingBallSensor() const noexcept;
 
     [[nodiscard]] bool ballSensorSeesBall() const noexcept;
+
+    [[nodiscard]] bool hasBall() const noexcept;
 
     [[nodiscard]] float getBallPosBallSensor() const noexcept;
 

--- a/include/roboteam_ai/world/views/RobotView.hpp
+++ b/include/roboteam_ai/world/views/RobotView.hpp
@@ -21,8 +21,6 @@ namespace rtt::world::view {
 class RobotView {
     robot::Robot const *robotPtr;
 
-    [[nodiscard]] bool hasBallAccordingToVision(double maxDist, double maxAngle) const noexcept;
-
    public:
     /**
      * Constructs a RobotView from a Robot
@@ -77,14 +75,6 @@ class RobotView {
     RobotView(RobotView &&) = default;
 
     ~RobotView() = default;
-
-    /**
-     * Check whether the current robot has the ball
-     * @param distanceErrorMargin distance error margin for ball possession
-     * @param angleErrorMargin angle error margin for ball possession
-     * @return true if ballSensorSeesBall (both sim or irl) or when ball is within dist/angle margin (only irl)
-     */
-    [[nodiscard]] bool hasBall(double distanceErrorMargin = ai::Constants::HAS_BALL_DISTANCE(), double angleErrorMargin = ai::Constants::HAS_BALL_ANGLE()) const noexcept;
 
     /**
      * Gets the kicker for the Robot that this view is viewing

--- a/include/roboteam_ai/world/views/WorldDataView.hpp
+++ b/include/roboteam_ai/world/views/WorldDataView.hpp
@@ -165,7 +165,7 @@ class WorldDataView {
      * @param maxDist Maximum distance the robot is allowed to be from the ball for "having ball"
      * @return true if the robot with id has the ball, false if not
      */
-    [[nodiscard]] bool robotHasBall(uint8_t id, bool ourTeam, double maxDist = ai::Constants::MAX_BALL_RANGE()) const noexcept;
+    [[nodiscard]] bool robotHasBall(uint8_t id, bool ourTeam, double maxDist = ai::Constants::HAS_BALL_DISTANCE()) const noexcept;
 
     /**
      * Check whether our robot with @refitem id has the ball
@@ -173,7 +173,7 @@ class WorldDataView {
      * @param maxDist Maximum distance the robot is allowed to be from the ball for "having ball"
      * @return Returns true if that robot has the ball, false if not
      */
-    [[nodiscard]] bool ourRobotHasBall(uint8_t id, double maxDist = ai::Constants::MAX_BALL_RANGE()) const noexcept;
+    [[nodiscard]] bool ourRobotHasBall(uint8_t id, double maxDist = ai::Constants::HAS_BALL_DISTANCE()) const noexcept;
 
     /**
      * Check whether their robot with @refitem id has the ball
@@ -181,7 +181,7 @@ class WorldDataView {
      * @param maxDist Maximum distance the robot is allowed to be from the ball for "having ball"
      * @return true if that robot has the ball, false if not
      */
-    [[nodiscard]] bool theirRobotHasBall(int id, double maxDist = ai::Constants::MAX_BALL_RANGE()) const noexcept;
+    [[nodiscard]] bool theirRobotHasBall(int id, double maxDist = ai::Constants::HAS_BALL_DISTANCE()) const noexcept;
 
     /**
      * Gets a view over the robot that currently has the ball

--- a/include/roboteam_ai/world/views/WorldDataView.hpp
+++ b/include/roboteam_ai/world/views/WorldDataView.hpp
@@ -186,10 +186,9 @@ class WorldDataView {
     /**
      * Gets a view over the robot that currently has the ball
      * @param team Team enum of team to fetch from
-     * @param maxDist Maximum distance the robot is allowed to be from the ball for "having ball"
      * @return A non-owning view of the robot that has the ball
      */
-    [[nodiscard]] std::optional<RobotView> whichRobotHasBall(Team team = both, double maxDist = ai::Constants::MAX_BALL_RANGE());
+    [[nodiscard]] std::optional<RobotView> whichRobotHasBall(Team team = both) const;
 
    private:
     /**

--- a/src/control/ControlModule.cpp
+++ b/src/control/ControlModule.cpp
@@ -38,7 +38,7 @@ void ControlModule::limitVel(rtt::RobotCommand& command, std::optional<rtt::worl
     }
 
     // Limit robot velocity when the robot has the ball
-    if (robot->hasBall() && limitedVelocity.length() > stp::control_constants::MAX_VEL_WHEN_HAS_BALL) {
+    if (robot.value()->hasBall() && limitedVelocity.length() > stp::control_constants::MAX_VEL_WHEN_HAS_BALL) {
         // Clamp velocity
         limitedVelocity = control::ControlUtils::velocityLimiter(limitedVelocity, stp::control_constants::MAX_VEL_WHEN_HAS_BALL, 0.0, false);
     }
@@ -49,7 +49,7 @@ void ControlModule::limitVel(rtt::RobotCommand& command, std::optional<rtt::worl
 void ControlModule::limitAngularVel(rtt::RobotCommand& command, std::optional<rtt::world::view::RobotView> robot) {
     // Limit the angular velocity when the robot has the ball by setting the target angle in small steps
     // Might want to limit on the robot itself
-    if (robot->hasBall() && !command.useAngularVelocity) {
+    if (robot.value()->hasBall() && !command.useAngularVelocity) {
         auto targetAngle = command.targetAngle;
         // TODO: Why use optional robotView if we never check for the case where it does not contain one?
         auto robotAngle = robot.value()->getAngle();

--- a/src/control/positionControl/BBTrajectories/WorldObjects.cpp
+++ b/src/control/positionControl/BBTrajectories/WorldObjects.cpp
@@ -89,7 +89,7 @@ void WorldObjects::calculateDefenseAreaCollisions(const rtt::world::Field &field
 void WorldObjects::calculateBallCollisions(const rtt::world::World *world, std::vector<CollisionData> &collisionDatas, std::vector<Vector2> pathPoints, double timeStep) {
     if (ruleset.minDistanceToBall > 0) {
         auto startPositionBall = world->getWorld()->getBall()->get()->getPos();
-        auto VelocityBall = world->getWorld()->getBall()->get()->getFilteredVelocity();
+        auto VelocityBall = world->getWorld()->getBall()->get()->getVelocity();
         std::vector<Vector2> ballTrajectory;
 
         // TODO: improve ball trajectory approximation

--- a/src/control/positionControl/BBTrajectories/WorldObjects.cpp
+++ b/src/control/positionControl/BBTrajectories/WorldObjects.cpp
@@ -88,8 +88,8 @@ void WorldObjects::calculateDefenseAreaCollisions(const rtt::world::Field &field
 
 void WorldObjects::calculateBallCollisions(const rtt::world::World *world, std::vector<CollisionData> &collisionDatas, std::vector<Vector2> pathPoints, double timeStep) {
     if (ruleset.minDistanceToBall > 0) {
-        auto startPositionBall = world->getWorld()->getBall()->get()->getPos();
-        auto VelocityBall = world->getWorld()->getBall()->get()->getVelocity();
+        auto startPositionBall = world->getWorld()->getBall()->get()->position;
+        auto VelocityBall = world->getWorld()->getBall()->get()->velocity;
         std::vector<Vector2> ballTrajectory;
 
         // TODO: improve ball trajectory approximation
@@ -122,7 +122,7 @@ void WorldObjects::calculateEnemyRobotCollisions(const rtt::world::World *world,
         // The >= 2 is used for checking for collisions within 2 seconds
         // TODO: fine tune maximum collision check time
         if (currentTime - timeStepsDone * timeStep >= 2) break;
-        // Vector2 ourVel = Trajectory.getVelocity(currentTime);
+        // Vector2 ourVel = Trajectory.getVelocityBall(currentTime);
         for (const auto &theirRobot : theirRobots) {
             Vector2 theirVel = theirRobot->getVel();
             // TODO: improve position prediction. Current model uses x + v*t

--- a/src/interface/widgets/widget.cpp
+++ b/src/interface/widgets/widget.cpp
@@ -268,10 +268,10 @@ void Visualizer::drawFieldHints(const rtt::world::Field &field, QPainter &painte
 
 // draw the ball on the screen
 void Visualizer::drawBall(QPainter &painter, rtt::world::view::BallView ball) {
-    rtt::Vector2 ballPosition = toScreenPosition(ball->getPos());
+    rtt::Vector2 ballPosition = toScreenPosition(ball->position);
     QPointF qballPosition(ballPosition.x, ballPosition.y);
 
-    painter.setBrush(ball->isVisible() ? Constants::BALL_COLOR() : Qt::red);
+    painter.setBrush(ball->visible ? Constants::BALL_COLOR() : Qt::red);
 
     // draw a see-through gradient around the ball to make it more visible
     painter.setPen(Qt::NoPen);  // stroke

--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -87,7 +87,7 @@ void Play::refreshData() noexcept {
             // Get a new RobotView from world using the old robot id
             stpInfo->second.setRobot(world->getWorld()->getRobotForId(stpInfo->second.getRobot()->get()->getId()));
 
-            stpInfo->second.setMaxRobotVelocity(control::ControlUtils::getMaxVelocity(stpInfo->second.getRobot()->hasBall()));
+            stpInfo->second.setMaxRobotVelocity(control::ControlUtils::getMaxVelocity(stpInfo->second.getRobot().value()->hasBall()));
 
             // The keeper does not need to avoid our defense area
             if (stpInfo->second.getRoleName() == "keeper") stpInfo->second.setShouldAvoidDefenseArea(false);

--- a/src/stp/computations/GoalComputations.cpp
+++ b/src/stp/computations/GoalComputations.cpp
@@ -12,7 +12,7 @@
 namespace rtt::ai::stp::computations {
 Vector2 GoalComputations::calculateGoalTarget(rtt_world::World *world, const rtt_world::Field &field) {
     // Position of the ball from which the goal target is determined
-    auto sourcePoint = world->getWorld().value().getBall().value()->getPos();
+    auto sourcePoint = world->getWorld().value().getBall().value()->position;
 
     // Make a vector with all robotViews to see if one of the robots is in front of the goal
     std::vector<world::view::RobotView> allRobotsVec = world->getWorld().value().getUs();

--- a/src/stp/computations/PassComputations.cpp
+++ b/src/stp/computations/PassComputations.cpp
@@ -21,7 +21,7 @@ PassInfo PassComputations::calculatePass(gen::ScoreProfile profile, const rtt::w
     }
 
     auto us = world->getWorld()->getUs();
-    auto ballLocation = world->getWorld()->getBall()->get()->getPos();
+    auto ballLocation = world->getWorld()->getBall()->get()->position;
 
     // Find which robot is keeper (bot closest to goal if there was not a keeper yet), store its id, and erase from us
     passInfo.keeperId = getKeeperId(us, world, field);

--- a/src/stp/computations/PositionComputations.cpp
+++ b/src/stp/computations/PositionComputations.cpp
@@ -42,7 +42,7 @@ std::vector<Vector2> PositionComputations::determineWallPositions(const rtt::wor
     double spacingRobots = radius * 0.5;
     double spaceBetweenDefenseArea = 2 * radius;
 
-    Vector2 ballPos = FieldComputations::projectPointInField(field, world->getWorld().value().getBall()->get()->getPos());
+    Vector2 ballPos = FieldComputations::projectPointInField(field, world->getWorld().value().getBall()->get()->position);
 
     std::vector<Vector2> positions = {};
 

--- a/src/stp/computations/PositionScoring.cpp
+++ b/src/stp/computations/PositionScoring.cpp
@@ -53,7 +53,7 @@ double PositionScoring::determineOpenScore(Vector2 &point, const rtt::world::Fie
 }
 
 double PositionScoring::determineLineOfSightScore(Vector2 &point, const rtt::world::World *world, gen::PositionScores &scores) {
-    Vector2 ballPos = world->getWorld().value()->getBall()->get()->getPos();
+    Vector2 ballPos = world->getWorld().value()->getBall()->get()->position;
     double pointDistance = ballPos.dist(point);
     std::vector<double> enemyDistancesToBall;
     std::vector<double> enemyAnglesToBallvsPoint;
@@ -77,7 +77,7 @@ double PositionScoring::determineGoalShotScore(Vector2 &point, const rtt::world:
 }
 
 double PositionScoring::determineBlockingScore(Vector2 &point, const rtt::world::World *world, gen::PositionScores &scores) {
-    Vector2 ballPos = world->getWorld().value()->getBall()->get()->getPos();
+    Vector2 ballPos = world->getWorld().value()->getBall()->get()->position;
     double pointDistance = ballPos.dist(point);
     std::vector<double> enemyDistancesToBall;
     std::vector<double> enemyAnglesToBallvsPoint;

--- a/src/stp/evaluations/global/BallCloseToUsGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/BallCloseToUsGlobalEvaluation.cpp
@@ -29,7 +29,7 @@ BallCloseToUsGlobalEvaluation::BallCloseToUsGlobalEvaluation() noexcept {
 
 uint8_t BallCloseToUsGlobalEvaluation::metricCheck(const world::World* world, const world::Field* field) const noexcept {
     auto& us = world->getWorld()->getUs();
-    auto ballPos = world->getWorld()->getBall()->get()->getPos();
+    auto ballPos = world->getWorld()->getBall()->get()->position;
     std::vector<double> distances{};
 
     if (us.empty()) {

--- a/src/stp/evaluations/global/BallGotShotGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/BallGotShotGlobalEvaluation.cpp
@@ -26,7 +26,7 @@ BallGotShotGlobalEvaluation::BallGotShotGlobalEvaluation() noexcept {
 }
 
 uint8_t BallGotShotGlobalEvaluation::metricCheck(const world::World* world, const world::Field* field) const noexcept {
-    return calculateMetric(world->getWorld()->getBall()->get()->getVelocity().length());
+    return calculateMetric(world->getWorld()->getBall()->get()->velocity.length());
 }
 
 uint8_t BallGotShotGlobalEvaluation::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }

--- a/src/stp/evaluations/global/BallInOurDefenseAreaAndStillGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/BallInOurDefenseAreaAndStillGlobalEvaluation.cpp
@@ -10,8 +10,8 @@
 
 namespace rtt::ai::stp::evaluation {
 uint8_t BallInOurDefenseAreaAndStillGlobalEvaluation::metricCheck(const world::World* world, const world::Field* field) const noexcept {
-    return (FieldComputations::pointIsInOurDefenseArea(*field, world->getWorld()->getBall()->get()->getPos()) &&
-            world->getWorld()->getBall()->get()->getVelocity().length() < control_constants::BALL_STILL_VEL)
+    return (FieldComputations::pointIsInOurDefenseArea(*field, world->getWorld()->getBall()->get()->position) &&
+            world->getWorld()->getBall()->get()->velocity.length() < control_constants::BALL_STILL_VEL)
                ? control_constants::FUZZY_TRUE
                : control_constants::FUZZY_FALSE;
 }

--- a/src/stp/evaluations/global/BallIsFreeGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/BallIsFreeGlobalEvaluation.cpp
@@ -15,6 +15,6 @@ uint8_t BallIsFreeGlobalEvaluation::metricCheck(const world::World* world, const
     if (robots.empty()) {
         return stp::control_constants::FUZZY_TRUE;
     }
-    return std::any_of(robots.begin(), robots.end(), [](auto& robot) { return robot.hasBall(); }) ? stp::control_constants::FUZZY_FALSE : stp::control_constants::FUZZY_TRUE;
+    return std::any_of(robots.begin(), robots.end(), [](auto& robot) { return robot->hasBall(); }) ? stp::control_constants::FUZZY_FALSE : stp::control_constants::FUZZY_TRUE;
 }
 }  // namespace rtt::ai::stp::evaluation

--- a/src/stp/evaluations/global/BallMovesSlowGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/BallMovesSlowGlobalEvaluation.cpp
@@ -26,7 +26,7 @@ BallMovesSlowGlobalEvaluation::BallMovesSlowGlobalEvaluation() noexcept {
 }
 
 uint8_t BallMovesSlowGlobalEvaluation::metricCheck(const world::World* world, const world::Field* field) const noexcept {
-    return calculateMetric(world->getWorld()->getBall()->get()->getVelocity().length());
+    return calculateMetric(world->getWorld()->getBall()->get()->velocity.length());
 }
 
 uint8_t BallMovesSlowGlobalEvaluation::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }

--- a/src/stp/evaluations/global/BallNotInOurDefenseAreaAndStillGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/BallNotInOurDefenseAreaAndStillGlobalEvaluation.cpp
@@ -10,8 +10,8 @@
 
 namespace rtt::ai::stp::evaluation {
 uint8_t BallNotInOurDefenseAreaAndStillGlobalEvaluation::metricCheck(const world::World* world, const world::Field* field) const noexcept {
-    return (FieldComputations::pointIsInOurDefenseArea(*field, world->getWorld()->getBall()->get()->getPos()) &&
-            world->getWorld()->getBall()->get()->getVelocity().length() < control_constants::BALL_STILL_VEL)
+    return (FieldComputations::pointIsInOurDefenseArea(*field, world->getWorld()->getBall()->get()->position) &&
+            world->getWorld()->getBall()->get()->velocity.length() < control_constants::BALL_STILL_VEL)
                ? control_constants::FUZZY_FALSE
                : control_constants::FUZZY_TRUE;
 }

--- a/src/stp/evaluations/global/BallOnOurSideGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/BallOnOurSideGlobalEvaluation.cpp
@@ -8,6 +8,6 @@
 
 namespace rtt::ai::stp::evaluation {
 uint8_t BallOnOurSideGlobalEvaluation::metricCheck(const world::World* world, const world::Field* field) const noexcept {
-    return world->getWorld()->getBall().value()->getPos().x < 0 ? control_constants::FUZZY_TRUE : control_constants::FUZZY_FALSE;
+    return world->getWorld()->getBall().value()->position.x < 0 ? control_constants::FUZZY_TRUE : control_constants::FUZZY_FALSE;
 }
 }  // namespace rtt::ai::stp::evaluation

--- a/src/stp/evaluations/global/BallOnTheirSideGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/BallOnTheirSideGlobalEvaluation.cpp
@@ -8,6 +8,6 @@
 
 namespace rtt::ai::stp::evaluation {
 uint8_t BallOnTheirSideGlobalEvaluation::metricCheck(const world::World* world, const world::Field* field) const noexcept {
-    return world->getWorld()->getBall().value()->getPos().x >= 0 ? control_constants::FUZZY_TRUE : control_constants::FUZZY_FALSE;
+    return world->getWorld()->getBall().value()->position.x >= 0 ? control_constants::FUZZY_TRUE : control_constants::FUZZY_FALSE;
 }
 }  // namespace rtt::ai::stp::evaluation

--- a/src/stp/evaluations/global/DistanceFromBallGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/DistanceFromBallGlobalEvaluation.cpp
@@ -28,7 +28,7 @@ DistanceFromBallGlobalEvaluation::DistanceFromBallGlobalEvaluation() noexcept {
 
 uint8_t DistanceFromBallGlobalEvaluation::metricCheck(const world::World* world, const world::Field* field) const noexcept {
     auto& us = world->getWorld()->getUs();
-    auto ballPos = world->getWorld()->getBall()->get()->getPos();
+    auto ballPos = world->getWorld()->getBall()->get()->position;
     std::vector<double> distances{};
     distances.reserve(control_constants::MAX_ROBOT_COUNT);
 

--- a/src/stp/evaluations/global/GoalVisionFromBallGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/GoalVisionFromBallGlobalEvaluation.cpp
@@ -30,7 +30,7 @@ GoalVisionFromBallGlobalEvaluation::GoalVisionFromBallGlobalEvaluation() noexcep
 
 uint8_t GoalVisionFromBallGlobalEvaluation::metricCheck(const world::World* world, const world::Field* field) const noexcept {
     return calculateMetric(
-        FieldComputations::getPercentageOfGoalVisibleFromPoint(*field, false, world->getWorld()->getBall().value()->getPos(), world->getWorld().value(), -1, true));
+        FieldComputations::getPercentageOfGoalVisibleFromPoint(*field, false, world->getWorld()->getBall().value()->position, world->getWorld().value(), -1, true));
 }
 
 uint8_t GoalVisionFromBallGlobalEvaluation::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }

--- a/src/stp/evaluations/global/NoGoalVisionFromBallGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/NoGoalVisionFromBallGlobalEvaluation.cpp
@@ -19,7 +19,7 @@ NoGoalVisionFromBallGlobalEvaluation::NoGoalVisionFromBallGlobalEvaluation() noe
 
 uint8_t NoGoalVisionFromBallGlobalEvaluation::metricCheck(const world::World* world, const world::Field* field) const noexcept {
     return calculateMetric(
-        FieldComputations::getPercentageOfGoalVisibleFromPoint(*field, false, world->getWorld()->getBall().value()->getPos(), world->getWorld().value(), -1, false));
+        FieldComputations::getPercentageOfGoalVisibleFromPoint(*field, false, world->getWorld()->getBall().value()->position, world->getWorld().value(), -1, false));
 }
 
 uint8_t NoGoalVisionFromBallGlobalEvaluation::calculateMetric(const double& x) const noexcept { return piecewiseLinearFunction->yForX(x); }

--- a/src/stp/evaluations/global/TheyDoNotHaveBallGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/TheyDoNotHaveBallGlobalEvaluation.cpp
@@ -13,6 +13,6 @@ uint8_t TheyDoNotHaveBallGlobalEvaluation::metricCheck(const world::World* world
     if (them.empty()) {
         return stp::control_constants::FUZZY_TRUE;
     }
-    return std::any_of(them.begin(), them.end(), [](auto& robot) { return robot.hasBall(); }) ? stp::control_constants::FUZZY_FALSE : stp::control_constants::FUZZY_TRUE;
+    return std::any_of(them.begin(), them.end(), [](auto& robot) { return robot->hasBall(); }) ? stp::control_constants::FUZZY_FALSE : stp::control_constants::FUZZY_TRUE;
 }
 }  // namespace rtt::ai::stp::evaluation

--- a/src/stp/evaluations/global/TheyHaveBallGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/TheyHaveBallGlobalEvaluation.cpp
@@ -13,6 +13,6 @@ uint8_t TheyHaveBallGlobalEvaluation::metricCheck(const world::World* world, con
     if (them.empty()) {
         return stp::control_constants::FUZZY_FALSE;
     }
-    return std::any_of(them.begin(), them.end(), [](auto& robot) { return robot.hasBall(); }) ? stp::control_constants::FUZZY_TRUE : stp::control_constants::FUZZY_FALSE;
+    return std::any_of(them.begin(), them.end(), [](auto& robot) { return robot->hasBall(); }) ? stp::control_constants::FUZZY_TRUE : stp::control_constants::FUZZY_FALSE;
 }
 }  // namespace rtt::ai::stp::evaluation

--- a/src/stp/evaluations/global/WeHaveBallGlobalEvaluation.cpp
+++ b/src/stp/evaluations/global/WeHaveBallGlobalEvaluation.cpp
@@ -13,6 +13,6 @@ uint8_t WeHaveBallGlobalEvaluation::metricCheck(const world::World* world, const
     if (us.empty()) {
         return stp::control_constants::FUZZY_FALSE;
     }
-    return std::any_of(us.begin(), us.end(), [](auto& robot) { return robot.hasBall(); }) ? stp::control_constants::FUZZY_TRUE : stp::control_constants::FUZZY_FALSE;
+    return std::any_of(us.begin(), us.end(), [](auto& robot) { return robot->hasBall(); }) ? stp::control_constants::FUZZY_TRUE : stp::control_constants::FUZZY_FALSE;
 }
 }  // namespace rtt::ai::stp::evaluation

--- a/src/stp/plays/ReflectKick.cpp
+++ b/src/stp/plays/ReflectKick.cpp
@@ -83,8 +83,8 @@ void ReflectKick::calculateInfoForRoles() noexcept {
     auto ball = world->getWorld()->getBall().value();
     std::optional<Vector2> intersection;
 
-    if ((ball->getPos() - passPosition).length() <= 2.0 && ball->getVelocity().length() > 0.1) {
-        LineSegment ballDirection = LineSegment(ball->getPos(), ball->getPos() + ball->getVelocity());
+    if ((ball->position - passPosition).length() <= 2.0 && ball->velocity.length() > 0.1) {
+        LineSegment ballDirection = LineSegment(ball->position, ball->position + ball->velocity);
         LineSegment betweenPassAndGoal = LineSegment(passPosition, field.getTheirGoalCenter());
         intersection = ballDirection.intersects(betweenPassAndGoal);
     }

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -57,7 +57,7 @@ void GetBallPossession::calculateInfoForScoredRoles(world::World* world) noexcep
     // TODO-Jaro: When futureSTPInfo is a thing, make posToShootAt the receiver of a pass if that will be the next Play
     stpInfos["ball_getter"].setPositionToShootAt(field.getTheirGoalCenter());
     stpInfos["ball_getter"].setRoleScore(evaluation::TimeToPositionEvaluation().metricCheck(
-        world->getWorld()->getRobotClosestToBall(world::us), world->getWorld()->getRobotClosestToBall(world::them), world->getWorld()->getBall().value()->getPos()));
+        world->getWorld()->getRobotClosestToBall(world::us), world->getWorld()->getRobotClosestToBall(world::them), world->getWorld()->getBall().value()->position));
 }
 
 void GetBallPossession::calculateInfoForRoles() noexcept {

--- a/src/stp/plays/defensive/DefendPass.cpp
+++ b/src/stp/plays/defensive/DefendPass.cpp
@@ -140,7 +140,7 @@ void DefendPass::calculateInfoForRobotDefenders() noexcept {
 
 void DefendPass::calculateInfoForOffenders() noexcept {
     stpInfos["offender_1"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontMidGrid(), gen::OffensivePosition, field, world));
-    if (world->getWorld()->getBall().value()->getPos().y > 0) {
+    if (world->getWorld()->getBall().value()->position.y > 0) {
         stpInfos["offender_2"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
     } else {
         stpInfos["offender_2"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontRightGrid(), gen::OffensivePosition, field, world));

--- a/src/stp/plays/defensive/DefendShot.cpp
+++ b/src/stp/plays/defensive/DefendShot.cpp
@@ -66,10 +66,10 @@ void DefendShot::calculateInfoForRoles() noexcept {
 }
 
 void DefendShot::calculateInfoForWallers() noexcept {
-    stpInfos["waller_1"].setAngle((world->getWorld()->getBall()->get()->getPos() - field.getOurGoalCenter()).angle());
-    stpInfos["waller_2"].setAngle((world->getWorld()->getBall()->get()->getPos() - field.getOurGoalCenter()).angle());
-    stpInfos["waller_3"].setAngle((world->getWorld()->getBall()->get()->getPos() - field.getOurGoalCenter()).angle());
-    stpInfos["waller_4"].setAngle((world->getWorld()->getBall()->get()->getPos() - field.getOurGoalCenter()).angle());
+    stpInfos["waller_1"].setAngle((world->getWorld()->getBall()->get()->position - field.getOurGoalCenter()).angle());
+    stpInfos["waller_2"].setAngle((world->getWorld()->getBall()->get()->position - field.getOurGoalCenter()).angle());
+    stpInfos["waller_3"].setAngle((world->getWorld()->getBall()->get()->position - field.getOurGoalCenter()).angle());
+    stpInfos["waller_4"].setAngle((world->getWorld()->getBall()->get()->position - field.getOurGoalCenter()).angle());
 
     stpInfos["waller_1"].setPositionToMoveTo(PositionComputations::getWallPosition(0, 4, field, world));
     stpInfos["waller_2"].setPositionToMoveTo(PositionComputations::getWallPosition(1, 4, field, world));

--- a/src/stp/plays/defensive/KeeperKickBall.cpp
+++ b/src/stp/plays/defensive/KeeperKickBall.cpp
@@ -111,7 +111,7 @@ bool KeeperKickBall::ballKicked() {
 bool KeeperKickBall::shouldEndPlay() noexcept {
     if (stpInfos["receiver"].getRobot() && stpInfos["keeper"].getRobot()) {
         // True if receiver has ball
-        if (stpInfos["receiver"].getRobot()->hasBall()) return true;
+        if (stpInfos["receiver"].getRobot().value()->hasBall()) return true;
 
         // True if the passer has shot the ball, but it is now almost stationary (pass was too soft, was reflected, etc.)
         if (ballKicked() && stpInfos["keeper"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&

--- a/src/stp/plays/defensive/KeeperKickBall.cpp
+++ b/src/stp/plays/defensive/KeeperKickBall.cpp
@@ -73,7 +73,7 @@ void KeeperKickBall::calculateInfoForRoles() noexcept {
     } else {
         auto ball = world->getWorld()->getBall().value();
         // Receiver goes to the passLocation projected on the trajectory of the ball
-        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getVelocity().stretchToLength(field.getFieldLength()));
+        auto ballTrajectory = LineSegment(ball->position, ball->position + ball->velocity.stretchToLength(field.getFieldLength()));
         auto receiverLocation = FieldComputations::projectPointToValidPositionOnLine(field, passInfo.passLocation, ballTrajectory.start, ballTrajectory.end);
         stpInfos["receiver"].setPositionToMoveTo(receiverLocation);
 
@@ -115,7 +115,7 @@ bool KeeperKickBall::shouldEndPlay() noexcept {
 
         // True if the passer has shot the ball, but it is now almost stationary (pass was too soft, was reflected, etc.)
         if (ballKicked() && stpInfos["keeper"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&
-            world->getWorld()->getBall()->get()->getVelocity().length() < control_constants::BALL_STILL_VEL)
+            world->getWorld()->getBall()->get()->velocity.length() < control_constants::BALL_STILL_VEL)
             return true;
     }
     // True if a different pass has a higher score than the current pass (by some margin)

--- a/src/stp/plays/defensive/KeeperKickBall.cpp
+++ b/src/stp/plays/defensive/KeeperKickBall.cpp
@@ -73,7 +73,7 @@ void KeeperKickBall::calculateInfoForRoles() noexcept {
     } else {
         auto ball = world->getWorld()->getBall().value();
         // Receiver goes to the passLocation projected on the trajectory of the ball
-        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getFilteredVelocity().stretchToLength(field.getFieldLength()));
+        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getVelocity().stretchToLength(field.getFieldLength()));
         auto receiverLocation = FieldComputations::projectPointToValidPositionOnLine(field, passInfo.passLocation, ballTrajectory.start, ballTrajectory.end);
         stpInfos["receiver"].setPositionToMoveTo(receiverLocation);
 

--- a/src/stp/plays/offensive/Attack.cpp
+++ b/src/stp/plays/offensive/Attack.cpp
@@ -40,7 +40,7 @@ Attack::Attack() : Play() {
 
 uint8_t Attack::score(const rtt::world::Field& field) noexcept {
     // Score the position of the ball based on the odds of scoring
-    return PositionScoring::scorePosition(world->getWorld()->getBall().value()->getPos(), gen::GoalShot, field, world).score;
+    return PositionScoring::scorePosition(world->getWorld()->getBall().value()->position, gen::GoalShot, field, world).score;
 }
 
 Dealer::FlagMap Attack::decideRoleFlags() const noexcept {
@@ -97,12 +97,12 @@ void Attack::calculateInfoForMidfielders() noexcept {
 
     // If the ball (and therefore striker) are in the front of the field, let the attacking midfielder go to the midfield
     // If the striker is not in the front field already, let the attacking midfielder go to the free section in the front field
-    if (world->getWorld()->getBall()->get()->getPos().x > field.getFrontMidGrid().getOffSetX()) {
+    if (world->getWorld()->getBall()->get()->position.x > field.getFrontMidGrid().getOffSetX()) {
         stpInfos["attacking_midfielder"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleMidGrid(), gen::OffensivePosition, field, world));
     } else {
-        if (world->getWorld()->getBall().value()->getPos().y > field.getFrontLeftGrid().getOffSetY()) {  // Ball is in left of field
+        if (world->getWorld()->getBall().value()->position.y > field.getFrontLeftGrid().getOffSetY()) {  // Ball is in left of field
             stpInfos["attacking_midfielder"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
-        } else if (world->getWorld()->getBall().value()->getPos().y < field.getFrontMidGrid().getOffSetY()) {  // Ball is in right of field
+        } else if (world->getWorld()->getBall().value()->position.y < field.getFrontMidGrid().getOffSetY()) {  // Ball is in right of field
             stpInfos["attacking_midfielder"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontRightGrid(), gen::OffensivePosition, field, world));
         } else {  // Ball is in middle of field
             stpInfos["attacking_midfielder"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontMidGrid(), gen::OffensivePosition, field, world));
@@ -112,10 +112,10 @@ void Attack::calculateInfoForMidfielders() noexcept {
 
 void Attack::calculateInfoForAttackers() noexcept {
     // Set the attackers to go to the part of the field where the ball is NOT (in y-direction), since that is where the striker will be
-    if (world->getWorld()->getBall().value()->getPos().y > field.getFrontLeftGrid().getOffSetY()) {  // Ball is in left of field
+    if (world->getWorld()->getBall().value()->position.y > field.getFrontLeftGrid().getOffSetY()) {  // Ball is in left of field
         stpInfos["attacker_1"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontMidGrid(), gen::OffensivePosition, field, world));
         stpInfos["attacker_2"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontRightGrid(), gen::OffensivePosition, field, world));
-    } else if (world->getWorld()->getBall().value()->getPos().y < field.getFrontMidGrid().getOffSetY()) {  // Ball is in right of field
+    } else if (world->getWorld()->getBall().value()->position.y < field.getFrontMidGrid().getOffSetY()) {  // Ball is in right of field
         stpInfos["attacker_1"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
         stpInfos["attacker_2"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontMidGrid(), gen::OffensivePosition, field, world));
     } else {  // Ball is in middle of field

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -88,7 +88,7 @@ void AttackingPass::calculateInfoForRoles() noexcept {
     } else {
         // Receiver goes to the passLocation projected on the trajectory of the ball
         auto ball = world->getWorld()->getBall()->get();
-        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getVelocity().stretchToLength(field.getFieldLength()));
+        auto ballTrajectory = LineSegment(ball->position, ball->position + ball->velocity.stretchToLength(field.getFieldLength()));
         auto receiverLocation = FieldComputations::projectPointToValidPositionOnLine(field, passInfo.passLocation, ballTrajectory.start, ballTrajectory.end);
         stpInfos["receiver"].setPositionToMoveTo(receiverLocation);
 
@@ -148,7 +148,7 @@ bool AttackingPass::shouldEndPlay() noexcept {
 
         // True if the passer has shot the ball, but it is now almost stationary (pass was too soft, was reflected, etc.)
         if (ballKicked() && stpInfos["passer"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&
-            world->getWorld()->getBall()->get()->getVelocity().length() < control_constants::BALL_STILL_VEL)
+            world->getWorld()->getBall()->get()->velocity.length() < control_constants::BALL_STILL_VEL)
             return true;
     }
     // True if a different pass has a higher score than the current pass (by some margin)

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -88,7 +88,7 @@ void AttackingPass::calculateInfoForRoles() noexcept {
     } else {
         // Receiver goes to the passLocation projected on the trajectory of the ball
         auto ball = world->getWorld()->getBall()->get();
-        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getFilteredVelocity().stretchToLength(field.getFieldLength()));
+        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getVelocity().stretchToLength(field.getFieldLength()));
         auto receiverLocation = FieldComputations::projectPointToValidPositionOnLine(field, passInfo.passLocation, ballTrajectory.start, ballTrajectory.end);
         stpInfos["receiver"].setPositionToMoveTo(receiverLocation);
 

--- a/src/stp/plays/offensive/AttackingPass.cpp
+++ b/src/stp/plays/offensive/AttackingPass.cpp
@@ -144,7 +144,7 @@ bool AttackingPass::ballKicked() {
 bool AttackingPass::shouldEndPlay() noexcept {
     if (stpInfos["receiver"].getRobot() && stpInfos["passer"].getRobot()) {
         // True if receiver has ball
-        if (stpInfos["receiver"].getRobot()->hasBall()) return true;
+        if (stpInfos["receiver"].getRobot().value()->hasBall()) return true;
 
         // True if the passer has shot the ball, but it is now almost stationary (pass was too soft, was reflected, etc.)
         if (ballKicked() && stpInfos["passer"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&

--- a/src/stp/plays/offensive/GenericPass.cpp
+++ b/src/stp/plays/offensive/GenericPass.cpp
@@ -70,7 +70,7 @@ void GenericPass::calculateInfoForRoles() noexcept {
 
     /// Midfielder
     if (stpInfos["midfielder_1"].getRobot()) {
-        stpInfos["midfielder_1"].setAngle((ball->getPos() - stpInfos["midfielder_1"].getRobot()->get()->getPos()).angle());
+        stpInfos["midfielder_1"].setAngle((ball->position - stpInfos["midfielder_1"].getRobot()->get()->getPos()).angle());
     }
     auto fieldWidth = field.getFieldWidth();
     auto searchGrid = Grid(-0.15 * fieldWidth, -2, 0.10 * fieldWidth, 4, 4, 4);
@@ -103,7 +103,7 @@ Dealer::FlagMap GenericPass::decideRoleFlags() const noexcept {
 const char* GenericPass::getName() { return "Generic Pass"; }
 
 void GenericPass::calculateInfoForPass(const world::ball::Ball* ball) noexcept {
-    if (!passerShot && ball->getVelocity().length() > control_constants::BALL_STILL_VEL * 10) {
+    if (!passerShot && ball->velocity.length() > control_constants::BALL_STILL_VEL * 10) {
         passerShot = true;
     }
 
@@ -130,17 +130,17 @@ void GenericPass::calculateInfoForPass(const world::ball::Ball* ball) noexcept {
         }
     }
     /// Receiver should intercept when constraints are met
-    if (passLeft && ball->getVelocity().length() > control_constants::HAS_KICKED_ERROR_MARGIN) {
-        receiverPositionLeft.position = Line(ball->getPos(), ball->getPos() + ball->getVelocity()).project(passingPosition);
-    } else if (ball->getVelocity().length() > control_constants::HAS_KICKED_ERROR_MARGIN) {
-        receiverPositionRight.position = Line(ball->getPos(), ball->getPos() + ball->getVelocity()).project(passingPosition);
+    if (passLeft && ball->velocity.length() > control_constants::HAS_KICKED_ERROR_MARGIN) {
+        receiverPositionLeft.position = Line(ball->position, ball->position + ball->velocity).project(passingPosition);
+    } else if (ball->velocity.length() > control_constants::HAS_KICKED_ERROR_MARGIN) {
+        receiverPositionRight.position = Line(ball->position, ball->position + ball->velocity).project(passingPosition);
     }
     // Receiver
     stpInfos["receiver_left"].setPositionToMoveTo(receiverPositionLeft.position);
     stpInfos["receiver_right"].setPositionToMoveTo(receiverPositionRight.position);
 
     // decide kick or chip
-    auto passLine = Tube(ball->getPos(), passingPosition, control_constants::ROBOT_CLOSE_TO_POINT / 2);
+    auto passLine = Tube(ball->position, passingPosition, control_constants::ROBOT_CLOSE_TO_POINT / 2);
     auto allBots = world->getWorld()->getRobotsNonOwning();
     // For all bots except passer and receivers, check if they are on the pass line, aka robot should chip
     if (std::any_of(allBots.begin(), allBots.end(), [&](const auto& bot) {

--- a/src/stp/plays/offensive/GenericPass.cpp
+++ b/src/stp/plays/offensive/GenericPass.cpp
@@ -103,7 +103,7 @@ Dealer::FlagMap GenericPass::decideRoleFlags() const noexcept {
 const char* GenericPass::getName() { return "Generic Pass"; }
 
 void GenericPass::calculateInfoForPass(const world::ball::Ball* ball) noexcept {
-    if (!passerShot && ball->getFilteredVelocity().length() > control_constants::BALL_STILL_VEL * 10) {
+    if (!passerShot && ball->getVelocity().length() > control_constants::BALL_STILL_VEL * 10) {
         passerShot = true;
     }
 
@@ -131,9 +131,9 @@ void GenericPass::calculateInfoForPass(const world::ball::Ball* ball) noexcept {
     }
     /// Receiver should intercept when constraints are met
     if (passLeft && ball->getVelocity().length() > control_constants::HAS_KICKED_ERROR_MARGIN) {
-        receiverPositionLeft.position = Line(ball->getPos(), ball->getPos() + ball->getFilteredVelocity()).project(passingPosition);
+        receiverPositionLeft.position = Line(ball->getPos(), ball->getPos() + ball->getVelocity()).project(passingPosition);
     } else if (ball->getVelocity().length() > control_constants::HAS_KICKED_ERROR_MARGIN) {
-        receiverPositionRight.position = Line(ball->getPos(), ball->getPos() + ball->getFilteredVelocity()).project(passingPosition);
+        receiverPositionRight.position = Line(ball->getPos(), ball->getPos() + ball->getVelocity()).project(passingPosition);
     }
     // Receiver
     stpInfos["receiver_left"].setPositionToMoveTo(receiverPositionLeft.position);

--- a/src/stp/plays/referee_specific/BallPlacementUs.cpp
+++ b/src/stp/plays/referee_specific/BallPlacementUs.cpp
@@ -40,7 +40,7 @@ void BallPlacementUs::calculateInfoForRoles() noexcept {
 
     // Adjust placement position to be one robot radius away in the distance of movement
     if (stpInfos["ball_placer"].getRobot())
-        ballTarget -= (world->getWorld()->get()->getBall()->get()->getPos() - stpInfos["ball_placer"].getRobot()->get()->getPos()).stretchToLength(control_constants::ROBOT_RADIUS);
+        ballTarget -= (world->getWorld()->get()->getBall()->get()->position - stpInfos["ball_placer"].getRobot()->get()->getPos()).stretchToLength(control_constants::ROBOT_RADIUS);
 
     stpInfos["ball_placer"].setPositionToShootAt(ballTarget);
     stpInfos["ball_placer"].setPositionToMoveTo(ballTarget);

--- a/src/stp/plays/referee_specific/FreeKickThem.cpp
+++ b/src/stp/plays/referee_specific/FreeKickThem.cpp
@@ -124,7 +124,7 @@ void FreeKickThem::calculateInfoForKeeper() noexcept {
 }
 
 void FreeKickThem::calculateInfoForHarassers() noexcept {
-    auto ballPos = world->getWorld()->getBall()->get()->getPos();
+    auto ballPos = world->getWorld()->getBall()->get()->position;
     auto goalPos = field.getOurGoalCenter();
 
     auto targetPos = (ballPos + goalPos) / 2;
@@ -138,7 +138,7 @@ void FreeKickThem::calculateInfoForHarassers() noexcept {
 
 void FreeKickThem::calculateInfoForOffenders() noexcept {
     stpInfos["offender_1"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontMidGrid(), gen::OffensivePosition, field, world));
-    if (world->getWorld()->getBall().value()->getPos().y > 0) {
+    if (world->getWorld()->getBall().value()->position.y > 0) {
         stpInfos["offender_2"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
     } else {
         stpInfos["offender_2"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontRightGrid(), gen::OffensivePosition, field, world));

--- a/src/stp/plays/referee_specific/FreeKickUsAtGoal.cpp
+++ b/src/stp/plays/referee_specific/FreeKickUsAtGoal.cpp
@@ -35,7 +35,7 @@ FreeKickUsAtGoal::FreeKickUsAtGoal() : Play() {
 
 uint8_t FreeKickUsAtGoal::score(const rtt::world::Field& field) noexcept {
     // If we are in the FreeKickUsAtGoal gameState, we always want to execute this play
-    return PositionScoring::scorePosition(world->getWorld()->getBall().value()->getPos(), gen::GoalShot, field, world).score;
+    return PositionScoring::scorePosition(world->getWorld()->getBall().value()->position, gen::GoalShot, field, world).score;
 }
 
 Dealer::FlagMap FreeKickUsAtGoal::decideRoleFlags() const noexcept {
@@ -93,12 +93,12 @@ void FreeKickUsAtGoal::calculateInfoForMidfielders() noexcept {
 
     // If the ball (and therefore striker) are in the front of the field, let the attacking midfielder go to the midfield
     // If the striker is not in the front field already, let the attacking midfielder go to the free section in the front field
-    if (world->getWorld()->getBall()->get()->getPos().x > field.getFrontMidGrid().getOffSetX()) {
+    if (world->getWorld()->getBall()->get()->position.x > field.getFrontMidGrid().getOffSetX()) {
         stpInfos["attacking_midfielder"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getMiddleMidGrid(), gen::OffensivePosition, field, world));
     } else {
-        if (world->getWorld()->getBall().value()->getPos().y > field.getFrontLeftGrid().getOffSetY()) {  // Ball is in left of field
+        if (world->getWorld()->getBall().value()->position.y > field.getFrontLeftGrid().getOffSetY()) {  // Ball is in left of field
             stpInfos["attacking_midfielder"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
-        } else if (world->getWorld()->getBall().value()->getPos().y < field.getFrontMidGrid().getOffSetY()) {  // Ball is in right of field
+        } else if (world->getWorld()->getBall().value()->position.y < field.getFrontMidGrid().getOffSetY()) {  // Ball is in right of field
             stpInfos["attacking_midfielder"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontRightGrid(), gen::OffensivePosition, field, world));
         } else {  // Ball is in middle of field
             stpInfos["attacking_midfielder"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontMidGrid(), gen::OffensivePosition, field, world));
@@ -108,10 +108,10 @@ void FreeKickUsAtGoal::calculateInfoForMidfielders() noexcept {
 
 void FreeKickUsAtGoal::calculateInfoForAttackers() noexcept {
     // Set the attackers to go to the part of the field where the ball is NOT (in y-direction), since that is where the striker will be
-    if (world->getWorld()->getBall().value()->getPos().y > field.getFrontLeftGrid().getOffSetY()) {  // Ball is in left of field
+    if (world->getWorld()->getBall().value()->position.y > field.getFrontLeftGrid().getOffSetY()) {  // Ball is in left of field
         stpInfos["attacker_1"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontMidGrid(), gen::OffensivePosition, field, world));
         stpInfos["attacker_2"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontRightGrid(), gen::OffensivePosition, field, world));
-    } else if (world->getWorld()->getBall().value()->getPos().y < field.getFrontMidGrid().getOffSetY()) {  // Ball is in right of field
+    } else if (world->getWorld()->getBall().value()->position.y < field.getFrontMidGrid().getOffSetY()) {  // Ball is in right of field
         stpInfos["attacker_1"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontLeftGrid(), gen::OffensivePosition, field, world));
         stpInfos["attacker_2"].setPositionToMoveTo(PositionComputations::getPosition(std::nullopt, field.getFrontMidGrid(), gen::OffensivePosition, field, world));
     } else {  // Ball is in middle of field

--- a/src/stp/plays/referee_specific/FreeKickUsPass.cpp
+++ b/src/stp/plays/referee_specific/FreeKickUsPass.cpp
@@ -80,7 +80,7 @@ void FreeKickUsPass::calculateInfoForRoles() noexcept {
     } else {
         // Receiver goes to the passLocation projected on the trajectory of the ball
         auto ball = world->getWorld()->getBall()->get();
-        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getVelocity().stretchToLength(field.getFieldLength()));
+        auto ballTrajectory = LineSegment(ball->position, ball->position + ball->velocity.stretchToLength(field.getFieldLength()));
         auto receiverLocation = FieldComputations::projectPointToValidPositionOnLine(field, passInfo.passLocation, ballTrajectory.start, ballTrajectory.end);
         stpInfos["receiver"].setPositionToMoveTo(receiverLocation);
 
@@ -140,7 +140,7 @@ bool FreeKickUsPass::shouldEndPlay() noexcept {
 
         // True if the free_kick_taker has shot the ball, but it is now almost stationary (pass was too soft, was reflected, etc.)
         if (ballKicked() && stpInfos["free_kick_taker"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&
-            world->getWorld()->getBall()->get()->getVelocity().length() < control_constants::BALL_STILL_VEL)
+            world->getWorld()->getBall()->get()->velocity.length() < control_constants::BALL_STILL_VEL)
             return true;
     }
     // True if a different pass has a higher score than the current pass (by some margin)

--- a/src/stp/plays/referee_specific/FreeKickUsPass.cpp
+++ b/src/stp/plays/referee_specific/FreeKickUsPass.cpp
@@ -136,7 +136,7 @@ bool FreeKickUsPass::ballKicked() {
 bool FreeKickUsPass::shouldEndPlay() noexcept {
     if (stpInfos["receiver"].getRobot() && stpInfos["free_kick_taker"].getRobot()) {
         // True if receiver has ball
-        if (stpInfos["receiver"].getRobot()->hasBall()) return true;
+        if (stpInfos["receiver"].getRobot().value()->hasBall()) return true;
 
         // True if the free_kick_taker has shot the ball, but it is now almost stationary (pass was too soft, was reflected, etc.)
         if (ballKicked() && stpInfos["free_kick_taker"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&

--- a/src/stp/plays/referee_specific/FreeKickUsPass.cpp
+++ b/src/stp/plays/referee_specific/FreeKickUsPass.cpp
@@ -80,7 +80,7 @@ void FreeKickUsPass::calculateInfoForRoles() noexcept {
     } else {
         // Receiver goes to the passLocation projected on the trajectory of the ball
         auto ball = world->getWorld()->getBall()->get();
-        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getFilteredVelocity().stretchToLength(field.getFieldLength()));
+        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getVelocity().stretchToLength(field.getFieldLength()));
         auto receiverLocation = FieldComputations::projectPointToValidPositionOnLine(field, passInfo.passLocation, ballTrajectory.start, ballTrajectory.end);
         stpInfos["receiver"].setPositionToMoveTo(receiverLocation);
 

--- a/src/stp/plays/referee_specific/KickOffUs.cpp
+++ b/src/stp/plays/referee_specific/KickOffUs.cpp
@@ -59,7 +59,7 @@ void KickOffUs::calculateInfoForRoles() noexcept {
         stpInfos["receiver"].setPositionToMoveTo(passLocation);
     } else {
         auto ball = world->getWorld()->getBall()->get();
-        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getVelocity().stretchToLength(field.getFieldLength()));
+        auto ballTrajectory = LineSegment(ball->position, ball->position + ball->velocity.stretchToLength(field.getFieldLength()));
         auto receiverLocation = FieldComputations::projectPointToValidPositionOnLine(field, passLocation, ballTrajectory.start, ballTrajectory.end);
         stpInfos["receiver"].setPositionToMoveTo(receiverLocation);
     }
@@ -91,7 +91,7 @@ bool KickOffUs::shouldEndPlay() noexcept {
 
         // True if the kick_off_taker has shot the ball, but it is now stationary (pass was too soft, was reflected, etc.)
         return ballKicked() && stpInfos["kick_off_taker"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&
-               world->getWorld()->getBall()->get()->getVelocity().length() < control_constants::BALL_STILL_VEL;
+               world->getWorld()->getBall()->get()->velocity.length() < control_constants::BALL_STILL_VEL;
     }
     return false;
 }

--- a/src/stp/plays/referee_specific/KickOffUs.cpp
+++ b/src/stp/plays/referee_specific/KickOffUs.cpp
@@ -87,7 +87,7 @@ Dealer::FlagMap KickOffUs::decideRoleFlags() const noexcept {
 bool KickOffUs::shouldEndPlay() noexcept {
     if (stpInfos["receiver"].getRobot() && stpInfos["kick_off_taker"].getRobot()) {
         // True if receiver has ball
-        if (stpInfos["receiver"].getRobot()->hasBall()) return true;
+        if (stpInfos["receiver"].getRobot().value()->hasBall()) return true;
 
         // True if the kick_off_taker has shot the ball, but it is now stationary (pass was too soft, was reflected, etc.)
         return ballKicked() && stpInfos["kick_off_taker"].getRobot()->get()->getDistanceToBall() >= Constants::HAS_BALL_DISTANCE() * 1.5 &&

--- a/src/stp/plays/referee_specific/KickOffUs.cpp
+++ b/src/stp/plays/referee_specific/KickOffUs.cpp
@@ -59,7 +59,7 @@ void KickOffUs::calculateInfoForRoles() noexcept {
         stpInfos["receiver"].setPositionToMoveTo(passLocation);
     } else {
         auto ball = world->getWorld()->getBall()->get();
-        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getFilteredVelocity().stretchToLength(field.getFieldLength()));
+        auto ballTrajectory = LineSegment(ball->getPos(), ball->getPos() + ball->getVelocity().stretchToLength(field.getFieldLength()));
         auto receiverLocation = FieldComputations::projectPointToValidPositionOnLine(field, passLocation, ballTrajectory.start, ballTrajectory.end);
         stpInfos["receiver"].setPositionToMoveTo(receiverLocation);
     }

--- a/src/stp/plays/referee_specific/KickOffUsPrepare.cpp
+++ b/src/stp/plays/referee_specific/KickOffUsPrepare.cpp
@@ -39,7 +39,7 @@ void KickOffUsPrepare::calculateInfoForRoles() noexcept {
     // The "kicker" will go to the ball
     if (stpInfos["kicker"].getRobot() && stpInfos["kicker"].getRobot()->get()->getPos().x < 0) {
         Vector2 robotPos = stpInfos["kicker"].getRobot()->get()->getPos();
-        Vector2 ballPos = world->getWorld()->getBall()->get()->getPos();
+        Vector2 ballPos = world->getWorld()->getBall()->get()->position;
         if ((robotPos - ballPos).length() < 0.7) {
             stpInfos["kicker"].setPositionToMoveTo(Vector2(-0.25, 0.0));
         } else if (robotPos.y > 0) {

--- a/src/stp/plays/referee_specific/PenaltyUsPrepare.cpp
+++ b/src/stp/plays/referee_specific/PenaltyUsPrepare.cpp
@@ -39,7 +39,7 @@ void PenaltyUsPrepare::calculateInfoForRoles() noexcept {
     stpInfos["keeper"].setPositionToMoveTo(Vector2(field.getOurGoalCenter()));
 
     // kicker, position right behind the ball
-    stpInfos["kicker_formation"].setPositionToMoveTo(world->getWorld()->getBall()->get()->getPos() - Vector2{0.25, 0.0});
+    stpInfos["kicker_formation"].setPositionToMoveTo(world->getWorld()->getBall()->get()->position - Vector2{0.25, 0.0});
 
     // regular bots
     const std::string formation = "formation_";

--- a/src/stp/roles/PenaltyKeeper.cpp
+++ b/src/stp/roles/PenaltyKeeper.cpp
@@ -38,7 +38,7 @@ Status PenaltyKeeper::update(StpInfo const& info) noexcept {
     }
 
     // Stop Formation tactic when ball is moving, start blocking, getting the ball and pass (normal keeper behavior)
-    if (robotTactics.current_num() == 0 && info.getBall().value()->getVelocity().length() > control_constants::BALL_STILL_VEL) forceNextTactic();
+    if (robotTactics.current_num() == 0 && info.getBall().value()->velocity.length() > control_constants::BALL_STILL_VEL) forceNextTactic();
 
     currentRobot = info.getRobot();
     // Update the current tactic with the new tacticInfo

--- a/src/stp/roles/active/BallPlacer.cpp
+++ b/src/stp/roles/active/BallPlacer.cpp
@@ -27,7 +27,7 @@ Status BallPlacer::update(StpInfo const& info) noexcept {
         return Status::Failure;
     }
 
-    if (!FieldComputations::pointIsInField(info.getField().value(), info.getBall().value()->getPos()) && robotTactics.current_num() == 0) {
+    if (!FieldComputations::pointIsInField(info.getField().value(), info.getBall().value()->position) && robotTactics.current_num() == 0) {
         forceNextTactic();
     }
 

--- a/src/stp/skills/Chip.cpp
+++ b/src/stp/skills/Chip.cpp
@@ -40,7 +40,7 @@ Status Chip::onUpdate(const StpInfo &info) noexcept {
     // forward the generated command to the ControlModule, for checking and limiting
     forwardRobotCommand(info.getCurrentWorld());
 
-    if (info.getBall()->get()->getVelocity().length() > stp::control_constants::HAS_CHIPPED_ERROR_MARGIN) {
+    if (info.getBall()->get()->velocity.length() > stp::control_constants::HAS_CHIPPED_ERROR_MARGIN) {
         chipAttempts = 0;
         return Status::Success;
     }

--- a/src/stp/skills/GoToPos.cpp
+++ b/src/stp/skills/GoToPos.cpp
@@ -36,7 +36,7 @@ Status GoToPos::onUpdate(const StpInfo &info) noexcept {
     }
 
     double targetVelocityLength;
-    if (info.getPidType() == stp::PIDType::KEEPER && (info.getRobot()->get()->getPos() - info.getBall()->get()->getPos()).length() > control_constants::ROBOT_RADIUS / 2) {
+    if (info.getPidType() == stp::PIDType::KEEPER && (info.getRobot()->get()->getPos() - info.getBall()->get()->position).length() > control_constants::ROBOT_RADIUS / 2) {
         RTT_DEBUG("Setting max vel");
         targetVelocityLength = info.getMaxRobotVelocity();
     } else {

--- a/src/stp/skills/Kick.cpp
+++ b/src/stp/skills/Kick.cpp
@@ -40,7 +40,7 @@ Status Kick::onUpdate(const StpInfo &info) noexcept {
     // forward the generated command to the ControlModule, for checking and limiting
     forwardRobotCommand(info.getCurrentWorld());
 
-    if (!info.getRobot()->hasBall()) {
+    if (!info.getRobot().value()->hasBall()) {
         kickAttempts = 0;
         return Status::Success;
     }

--- a/src/stp/skills/Orbit.cpp
+++ b/src/stp/skills/Orbit.cpp
@@ -9,9 +9,9 @@
 namespace rtt::ai::stp::skill {
 
 Status Orbit::onUpdate(const StpInfo &info) noexcept {
-    Vector2 directionVector = (info.getBall()->get()->getPos() - info.getRobot()->get()->getPos());
+    Vector2 directionVector = (info.getBall()->get()->position - info.getRobot()->get()->getPos());
     double normalAngle = directionVector.rotate(M_PI).rotate(M_PI_2).angle();
-    Angle targetAngle = (info.getPositionToShootAt().value() - info.getBall()->get()->getPos()).toAngle();
+    Angle targetAngle = (info.getPositionToShootAt().value() - info.getBall()->get()->position).toAngle();
 
     double margin = control_constants::ROBOT_RADIUS + 1.5 * stp::control_constants::BALL_RADIUS;
     double adjustDistance = (info.getRobot()->get()->getDistanceToBall() - margin);

--- a/src/stp/skills/Shoot.cpp
+++ b/src/stp/skills/Shoot.cpp
@@ -52,7 +52,7 @@ Status Shoot::onUpdateKick(const StpInfo &info) noexcept {
     // forward the generated command to the ControlModule, for checking and limiting
     forwardRobotCommand(info.getCurrentWorld());
 
-    if (!info.getRobot()->hasBall()) {
+    if (!info.getRobot().value()->hasBall()) {
         shootAttempts = 0;
         return Status::Success;
     }
@@ -91,7 +91,7 @@ Status Shoot::onUpdateChip(const StpInfo &info) noexcept {
     // publish the generated command
     forwardRobotCommand(info.getCurrentWorld());
 
-    if (!info.getRobot()->hasBall()) {
+    if (!info.getRobot().value()->hasBall()) {
         shootAttempts = 0;
         return Status::Success;
     }

--- a/src/stp/tactics/Intercept.cpp
+++ b/src/stp/tactics/Intercept.cpp
@@ -42,7 +42,7 @@ bool Intercept::isTacticFailing(const StpInfo& info) noexcept {
 
 bool Intercept::shouldTacticReset(const StpInfo& info) noexcept {
     // If the robot does not have the ball, reset so GoToPos is called to move to the ball again
-    return !info.getRobot()->hasBall(stp::control_constants::ROBOT_RADIUS);
+    return !info.getRobot().value()->hasBall();
 }
 
 double Intercept::calculateAngle(const world::view::RobotView& robot, const world::view::BallView& ball) { return (ball->position - robot->getPos()).angle(); }

--- a/src/stp/tactics/Intercept.cpp
+++ b/src/stp/tactics/Intercept.cpp
@@ -37,7 +37,7 @@ std::optional<StpInfo> Intercept::calculateInfoForSkill(const StpInfo& info) noe
 
 bool Intercept::isTacticFailing(const StpInfo& info) noexcept {
     // If the ball doesn't move, the robot can't intercept
-    return info.getBall()->get()->getVelocity().length() <= stp::control_constants::BALL_STILL_VEL;
+    return info.getBall()->get()->velocity.length() <= stp::control_constants::BALL_STILL_VEL;
 }
 
 bool Intercept::shouldTacticReset(const StpInfo& info) noexcept {
@@ -45,7 +45,7 @@ bool Intercept::shouldTacticReset(const StpInfo& info) noexcept {
     return !info.getRobot()->hasBall(stp::control_constants::ROBOT_RADIUS);
 }
 
-double Intercept::calculateAngle(const world::view::RobotView& robot, const world::view::BallView& ball) { return (ball->getPos() - robot->getPos()).angle(); }
+double Intercept::calculateAngle(const world::view::RobotView& robot, const world::view::BallView& ball) { return (ball->position - robot->getPos()).angle(); }
 
 int Intercept::determineDribblerSpeed(const world::view::RobotView& robot) {
     double turnOnDribblerDistance = 1.0;

--- a/src/stp/tactics/KeeperBlockBall.cpp
+++ b/src/stp/tactics/KeeperBlockBall.cpp
@@ -27,7 +27,7 @@ std::optional<StpInfo> KeeperBlockBall::calculateInfoForSkill(StpInfo const &inf
     }
 
     // Look towards ball to ensure ball hits the front assembly to reduce odds of ball reflecting in goal
-    auto keeperToBall = ball->getPos() - skillStpInfo.getRobot()->get()->getPos();
+    auto keeperToBall = ball->position - skillStpInfo.getRobot()->get()->getPos();
     skillStpInfo.setAngle(keeperToBall.angle());
 
     auto enemyRobot = info.getEnemyRobot().value();
@@ -61,9 +61,9 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
     auto maxKeeperY = field.getOurTopGoalSide().y - control_constants::DISTANCE_TO_ROBOT_CLOSE;
 
     // Intercept ball when it is moving towards the goal
-    if (ball->getVelocity().length() > control_constants::BALL_STILL_VEL) {
-        auto start = ball->getPos();
-        auto end = start + ball->getVelocity().stretchToLength(field.getFieldLength());
+    if (ball->velocity.length() > control_constants::BALL_STILL_VEL) {
+        auto start = ball->position;
+        auto end = start + ball->velocity.stretchToLength(field.getFieldLength());
         // Goal is made a bit "bigger" to ensure robot still moves towards ball trajectory
         // even when it thinks the ball will just miss, as this can be error prone
         auto startGoal = field.getOurTopGoalSide() + Vector2(0, control_constants::DISTANCE_TO_ROBOT_CLOSE);
@@ -104,7 +104,7 @@ std::pair<Vector2, stp::PIDType> KeeperBlockBall::calculateTargetPosition(const 
     }
 
     // Default positioning, stand at same y as the ball is currently located, clamped between the goal
-    auto targetPosition = Vector2(field.getOurGoalCenter().x + control_constants::ROBOT_CLOSE_TO_POINT, std::clamp(ball->getPos().y, minKeeperY, maxKeeperY));
+    auto targetPosition = Vector2(field.getOurGoalCenter().x + control_constants::ROBOT_CLOSE_TO_POINT, std::clamp(ball->position.y, minKeeperY, maxKeeperY));
     return std::make_pair(targetPosition, PIDType::DEFAULT);
 }
 

--- a/src/stp/tactics/active/ChipAtPos.cpp
+++ b/src/stp/tactics/active/ChipAtPos.cpp
@@ -50,7 +50,7 @@ bool ChipAtPos::isTacticFailing(const StpInfo &info) noexcept {
     // robot doesn't have the ball or if there is no shootTarget
     // But only check when we are not chipping
     if (skills.current_num() != 1) {
-        return !info.getRobot()->hasBall() || !info.getPositionToShootAt();
+        return !info.getRobot().value()->hasBall() || !info.getPositionToShootAt();
     }
     return false;
 }

--- a/src/stp/tactics/active/ChipAtPos.cpp
+++ b/src/stp/tactics/active/ChipAtPos.cpp
@@ -29,7 +29,7 @@ std::optional<StpInfo> ChipAtPos::calculateInfoForSkill(StpInfo const &info) noe
     skillStpInfo.setAngle(angleToTarget);
 
     // Calculate the distance and the chip force
-    double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
+    double distanceBallToTarget = (info.getBall()->get()->position - info.getPositionToShootAt().value()).length();
     skillStpInfo.setKickChipVelocity(control::ControlUtils::determineChipForce(distanceBallToTarget, skillStpInfo.getShotType()));
 
     // When rotating, we need to dribble to keep the ball, but when chipping we don't

--- a/src/stp/tactics/active/DriveWithBall.cpp
+++ b/src/stp/tactics/active/DriveWithBall.cpp
@@ -25,7 +25,7 @@ std::optional<StpInfo> DriveWithBall::calculateInfoForSkill(StpInfo const& info)
 
     if (!skillStpInfo.getPositionToMoveTo() || !skillStpInfo.getBall()) return std::nullopt;
 
-    double angleToBall = (info.getPositionToMoveTo().value() - info.getBall()->get()->getPos()).angle();
+    double angleToBall = (info.getPositionToMoveTo().value() - info.getBall()->get()->position).angle();
     skillStpInfo.setAngle(angleToBall);
 
     // When driving with ball, we need to activate the dribbler
@@ -44,7 +44,7 @@ bool DriveWithBall::isTacticFailing(const StpInfo& info) noexcept {
 bool DriveWithBall::shouldTacticReset(const StpInfo& info) noexcept {
     // Should reset if the angle the robot is at is no longer correct
     auto robotAngle = info.getRobot()->get()->getAngle();
-    auto ballToRobotAngle = (info.getBall()->get()->getPos() - info.getRobot()->get()->getPos()).angle();
+    auto ballToRobotAngle = (info.getBall()->get()->position - info.getRobot()->get()->getPos()).angle();
     return fabs(robotAngle + Angle(ballToRobotAngle)) <= stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN;
 }
 

--- a/src/stp/tactics/active/DriveWithBall.cpp
+++ b/src/stp/tactics/active/DriveWithBall.cpp
@@ -38,7 +38,7 @@ std::optional<StpInfo> DriveWithBall::calculateInfoForSkill(StpInfo const& info)
 
 bool DriveWithBall::isTacticFailing(const StpInfo& info) noexcept {
     // Fail if we don't have the ball or there is no movement position
-    return !info.getRobot()->hasBall() || !info.getPositionToMoveTo();
+    return !info.getRobot().value()->hasBall() || !info.getPositionToMoveTo();
 }
 
 bool DriveWithBall::shouldTacticReset(const StpInfo& info) noexcept {

--- a/src/stp/tactics/active/GetBall.cpp
+++ b/src/stp/tactics/active/GetBall.cpp
@@ -21,7 +21,7 @@ std::optional<StpInfo> GetBall::calculateInfoForSkill(StpInfo const &info) noexc
     if (!skillStpInfo.getRobot() || !skillStpInfo.getBall()) return std::nullopt;
 
     Vector2 robotPosition = skillStpInfo.getRobot().value()->getPos();
-    Vector2 ballPosition = skillStpInfo.getBall().value()->getPos();
+    Vector2 ballPosition = skillStpInfo.getBall().value()->position;
     double ballDistance = (ballPosition - robotPosition).length();
 
     if (skillStpInfo.getRobot()->get()->getAngleDiffToBall() > Constants::HAS_BALL_ANGLE() * M_PI && ballDistance < control_constants::AVOID_BALL_DISTANCE) {

--- a/src/stp/tactics/active/GetBall.cpp
+++ b/src/stp/tactics/active/GetBall.cpp
@@ -24,7 +24,7 @@ std::optional<StpInfo> GetBall::calculateInfoForSkill(StpInfo const &info) noexc
     Vector2 ballPosition = skillStpInfo.getBall().value()->position;
     double ballDistance = (ballPosition - robotPosition).length();
 
-    if (skillStpInfo.getRobot()->get()->getAngleDiffToBall() > Constants::HAS_BALL_ANGLE() * M_PI && ballDistance < control_constants::AVOID_BALL_DISTANCE) {
+    if (skillStpInfo.getRobot()->get()->getAngleDiffToBall() > Constants::HAS_BALL_ANGLE() && ballDistance < control_constants::AVOID_BALL_DISTANCE) {
         // don't move too close to the ball until the angle to the ball is (roughly) correct
         skillStpInfo.setPositionToMoveTo(
             FieldComputations::projectPointToValidPosition(info.getField().value(), skillStpInfo.getRobot()->get()->getPos(), info.getObjectsToAvoid()));
@@ -49,7 +49,7 @@ std::optional<StpInfo> GetBall::calculateInfoForSkill(StpInfo const &info) noexc
 bool GetBall::isTacticFailing(const StpInfo &info) noexcept { return false; }
 
 bool GetBall::shouldTacticReset(const StpInfo &info) noexcept {
-    return (info.getRobot()->get()->getAngleDiffToBall() < Constants::HAS_BALL_ANGLE() * M_PI) && (skills.current_num() == 1);
+    return (info.getRobot()->get()->getAngleDiffToBall() < Constants::HAS_BALL_ANGLE()) && (skills.current_num() == 1);
 }
 
 bool GetBall::isEndTactic() noexcept {
@@ -57,7 +57,7 @@ bool GetBall::isEndTactic() noexcept {
     return false;
 }
 
-bool GetBall::forceTacticSuccess(const StpInfo &info) noexcept { return info.getRobot()->hasBall(); }
+bool GetBall::forceTacticSuccess(const StpInfo &info) noexcept { return info.getRobot().value()->hasBall(); }
 
 const char *GetBall::getName() { return "Get Ball"; }
 

--- a/src/stp/tactics/active/GetBehindBallInDirection.cpp
+++ b/src/stp/tactics/active/GetBehindBallInDirection.cpp
@@ -26,8 +26,8 @@ std::optional<StpInfo> GetBehindBallInDirection::calculateInfoForSkill(StpInfo c
     skillStpInfo.setAngle((info.getPositionToShootAt().value() - info.getRobot()->get()->getPos()).angle());
 
     // If the robot is far from the ball, go to the target position
-    if ((info.getBall()->get()->getPos() - info.getRobot()->get()->getPos()).length() > 0.5) {
-        auto targetPos = GetBehindBallInDirection::calculateTargetPosition(info.getBall()->get()->getPos(), info.getRobot()->get()->getPos(), info.getPositionToShootAt().value());
+    if ((info.getBall()->get()->position - info.getRobot()->get()->getPos()).length() > 0.5) {
+        auto targetPos = GetBehindBallInDirection::calculateTargetPosition(info.getBall()->get()->position, info.getRobot()->get()->getPos(), info.getPositionToShootAt().value());
         skillStpInfo.setPositionToMoveTo(targetPos);
     }
 
@@ -61,7 +61,7 @@ Vector2 GetBehindBallInDirection::calculateTargetPosition(Vector2 ballPosition, 
 bool GetBehindBallInDirection::isTacticFailing(const StpInfo &info) noexcept { return !info.getPositionToShootAt(); }
 
 bool GetBehindBallInDirection::shouldTacticReset(const StpInfo &info) noexcept {
-    return ((info.getBall()->get()->getPos() - info.getRobot()->get()->getPos()).length() > 0.5) && (skills.current_num() == 1);
+    return ((info.getBall()->get()->position - info.getRobot()->get()->getPos()).length() > 0.5) && (skills.current_num() == 1);
 }
 
 bool GetBehindBallInDirection::isEndTactic() noexcept {

--- a/src/stp/tactics/active/KickAtPos.cpp
+++ b/src/stp/tactics/active/KickAtPos.cpp
@@ -30,7 +30,7 @@ std::optional<StpInfo> KickAtPos::calculateInfoForSkill(StpInfo const &info) noe
     skillStpInfo.setAngle(angleToTarget);
 
     // Calculate the distance and the kick force
-    double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
+    double distanceBallToTarget = (info.getBall()->get()->position - info.getPositionToShootAt().value()).length();
     skillStpInfo.setKickChipVelocity(control::ControlUtils::determineKickForce(distanceBallToTarget, skillStpInfo.getShotType()));
 
     skillStpInfo.setDribblerSpeed(100);

--- a/src/stp/tactics/active/KickAtPos.cpp
+++ b/src/stp/tactics/active/KickAtPos.cpp
@@ -46,7 +46,7 @@ bool KickAtPos::isEndTactic() noexcept {
 bool KickAtPos::isTacticFailing(const StpInfo &info) noexcept {
     // Fail tactic if:
     // robot doesn't have the ball or if there is no shootTarget
-    return !info.getRobot()->hasBall() || !info.getPositionToShootAt();
+    return !info.getRobot().value()->hasBall() || !info.getPositionToShootAt();
 }
 
 bool KickAtPos::shouldTacticReset(const StpInfo &info) noexcept {

--- a/src/stp/tactics/active/Receive.cpp
+++ b/src/stp/tactics/active/Receive.cpp
@@ -48,7 +48,7 @@ bool Receive::isEndTactic() noexcept {
     return true;
 }
 
-double Receive::calculateAngle(const world::view::RobotView &robot, const world::view::BallView &ball) { return (ball->getPos() - robot->getPos()).angle(); }
+double Receive::calculateAngle(const world::view::RobotView &robot, const world::view::BallView &ball) { return (ball->position - robot->getPos()).angle(); }
 
 const char *Receive::getName() { return "Receive"; }
 

--- a/src/stp/tactics/active/ShootAtPos.cpp
+++ b/src/stp/tactics/active/ShootAtPos.cpp
@@ -42,7 +42,7 @@ std::optional<StpInfo> ShootAtPos::calculateInfoForKick(StpInfo const &info) noe
     skillStpInfo.setAngle(angleToTarget);
 
     // Calculate the distance and the kick force
-    double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
+    double distanceBallToTarget = (info.getBall()->get()->position - info.getPositionToShootAt().value()).length();
     skillStpInfo.setKickChipVelocity(control::ControlUtils::determineKickForce(distanceBallToTarget, skillStpInfo.getShotType()));
 
     // Set the dribblerSpeed
@@ -61,7 +61,7 @@ std::optional<StpInfo> ShootAtPos::calculateInfoForChip(StpInfo const &info) noe
     skillStpInfo.setAngle(angleToTarget);
 
     // Calculate the distance and the chip force
-    double distanceBallToTarget = (info.getBall()->get()->getPos() - info.getPositionToShootAt().value()).length();
+    double distanceBallToTarget = (info.getBall()->get()->position - info.getPositionToShootAt().value()).length();
     skillStpInfo.setKickChipVelocity(control::ControlUtils::determineChipForce(distanceBallToTarget, skillStpInfo.getShotType()));
 
     skillStpInfo.setDribblerSpeed(100);

--- a/src/stp/tactics/active/ShootAtPos.cpp
+++ b/src/stp/tactics/active/ShootAtPos.cpp
@@ -77,7 +77,7 @@ bool ShootAtPos::isEndTactic() noexcept {
 bool ShootAtPos::isTacticFailing(const StpInfo &info) noexcept {
     // Fail tactic if:
     // robot doesn't have the ball or if there is no shootTarget
-    return !info.getRobot()->hasBall() || !info.getPositionToShootAt();
+    return !info.getRobot().value()->hasBall() || !info.getPositionToShootAt();
 }
 
 bool ShootAtPos::shouldTacticReset(const StpInfo &info) noexcept {

--- a/src/stp/tactics/passive/AvoidBall.cpp
+++ b/src/stp/tactics/passive/AvoidBall.cpp
@@ -28,7 +28,7 @@ std::optional<StpInfo> AvoidBall::calculateInfoForSkill(StpInfo const& info) noe
     skillStpInfo.setDribblerSpeed(0);
 
     Vector2 targetPos = skillStpInfo.getPositionToMoveTo().value();
-    auto ballPosition = skillStpInfo.getBall()->get()->getPos();
+    auto ballPosition = skillStpInfo.getBall()->get()->position;
 
     std::unique_ptr<Shape> avoidShape;
 
@@ -58,7 +58,7 @@ bool AvoidBall::isEndTactic() noexcept { return true; }
 
 bool AvoidBall::isTacticFailing(const StpInfo& info) noexcept {
     return (info.getRoleName() == "ball_placer" &&
-            (info.getBall()->get()->getPos() - rtt::ai::GameStateManager::getRefereeDesignatedPosition()).length() > control_constants::BALL_PLACEMENT_MARGIN);
+            (info.getBall()->get()->position - rtt::ai::GameStateManager::getRefereeDesignatedPosition()).length() > control_constants::BALL_PLACEMENT_MARGIN);
 }
 
 bool AvoidBall::shouldTacticReset(const StpInfo& info) noexcept { return false; }

--- a/src/stp/tactics/passive/BlockBall.cpp
+++ b/src/stp/tactics/passive/BlockBall.cpp
@@ -21,11 +21,11 @@ std::optional<StpInfo> BlockBall::calculateInfoForSkill(StpInfo const &info) noe
     auto targetPosition = calculateTargetPosition(info.getBall().value(), defendPos, info.getBlockDistance());
 
     // Make sure this position is valid
-    targetPosition = FieldComputations::projectPointToValidPositionOnLine(info.getField().value(), targetPosition, defendPos, info.getBall()->get()->getPos());
+    targetPosition = FieldComputations::projectPointToValidPositionOnLine(info.getField().value(), targetPosition, defendPos, info.getBall()->get()->position);
 
     skillStpInfo.setPositionToMoveTo(targetPosition);
 
-    auto targetAngle = (info.getBall()->get()->getPos() - info.getRobot()->get()->getPos()).angle();
+    auto targetAngle = (info.getBall()->get()->position - info.getRobot()->get()->getPos()).angle();
     skillStpInfo.setAngle(targetAngle);
 
     return skillStpInfo;
@@ -40,7 +40,7 @@ bool BlockBall::shouldTacticReset(const StpInfo &info) noexcept { return false; 
 const char *BlockBall::getName() { return "Block Ball"; }
 
 Vector2 BlockBall::calculateTargetPosition(const world::view::BallView &ball, Vector2 defendPos, BlockDistance blockDistance) noexcept {
-    auto targetToBall = ball->getPos() - defendPos;
+    auto targetToBall = ball->position - defendPos;
 
     double distance;
     switch (blockDistance) {

--- a/src/utilities/Constants.cpp
+++ b/src/utilities/Constants.cpp
@@ -107,8 +107,6 @@ double Constants::OUT_OF_FIELD_MARGIN() { return 0.03; }
 
 double Constants::MAX_BALL_BOUNCE_RANGE() { return GRSIM() ? 0.4 : 0.15; }
 
-double Constants::MAX_BALL_RANGE() { return 0.04; }
-
 double Constants::MAX_KICK_RANGE() { return 0.05; }
 
 double Constants::MAX_INTERCEPT_TIME() { return 3.0; }
@@ -169,7 +167,7 @@ bool Constants::STD_TIMEOUT_TO_TOP() { return false; }
 double Constants::HAS_BALL_DISTANCE() { return (SETTINGS.getRobotHubMode() == Settings::BASESTATION) ? 0.10 : 0.12; }
 
 // The max angle the ball can have to the robot for the robot to have the ball
-double Constants::HAS_BALL_ANGLE() { return 0.10; }
+double Constants::HAS_BALL_ANGLE() { return 0.10 * M_PI; }
 
 std::map<int, bool> Constants::ROBOTS_WITH_WORKING_DRIBBLER() {
     static std::map<int, bool> workingDribblerRobots;

--- a/src/utilities/Dealer.cpp
+++ b/src/utilities/Dealer.cpp
@@ -353,7 +353,7 @@ double Dealer::getDefaultFlagScores(const v::RobotView &robot, const Dealer::Dea
         case DealerFlagTitle::READY_TO_INTERCEPT_GOAL_SHOT: {
             // get distance to line between ball and goal
             // TODO this method can be improved by choosing a better line for the interception.
-            LineSegment lineSegment = {world.getBall()->get()->getPos(), field->getOurGoalCenter()};
+            LineSegment lineSegment = {world.getBall()->get()->position, field->getOurGoalCenter()};
             return lineSegment.distanceToLine(robot->getPos());
         }
         case DealerFlagTitle::KEEPER:

--- a/src/utilities/StrategyManager.cpp
+++ b/src/utilities/StrategyManager.cpp
@@ -22,7 +22,7 @@ void StrategyManager::setCurrentRefGameState(RefCommand command, proto::SSL_Refe
     if ((currentRefGameState.commandId == RefCommand::DIRECT_FREE_THEM || currentRefGameState.commandId == RefCommand::DIRECT_FREE_US ||
          currentRefGameState.commandId == RefCommand::DO_KICKOFF || currentRefGameState.commandId == RefCommand::DEFEND_KICKOFF ||
          currentRefGameState.commandId == RefCommand::INDIRECT_FREE_US || currentRefGameState.commandId == RefCommand::INDIRECT_FREE_THEM) &&
-        ballOpt.has_value() && (ballOpt.value()->getVelocity().length() > stp::control_constants::BALL_IS_MOVING_SLOW_LIMIT)) {
+        ballOpt.has_value() && (ballOpt.value()->velocity.length() > stp::control_constants::BALL_IS_MOVING_SLOW_LIMIT)) {
         RefGameState newState = getRefGameStateForRefCommand(RefCommand::NORMAL_START);
         currentRefGameState = newState;
         currentRefCmd = command;

--- a/src/utilities/StrategyManager.cpp
+++ b/src/utilities/StrategyManager.cpp
@@ -22,7 +22,7 @@ void StrategyManager::setCurrentRefGameState(RefCommand command, proto::SSL_Refe
     if ((currentRefGameState.commandId == RefCommand::DIRECT_FREE_THEM || currentRefGameState.commandId == RefCommand::DIRECT_FREE_US ||
          currentRefGameState.commandId == RefCommand::DO_KICKOFF || currentRefGameState.commandId == RefCommand::DEFEND_KICKOFF ||
          currentRefGameState.commandId == RefCommand::INDIRECT_FREE_US || currentRefGameState.commandId == RefCommand::INDIRECT_FREE_THEM) &&
-        ballOpt.has_value() && (ballOpt.value()->getFilteredVelocity().length() > stp::control_constants::BALL_IS_MOVING_SLOW_LIMIT)) {
+        ballOpt.has_value() && (ballOpt.value()->getVelocity().length() > stp::control_constants::BALL_IS_MOVING_SLOW_LIMIT)) {
         RefGameState newState = getRefGameStateForRefCommand(RefCommand::NORMAL_START);
         currentRefGameState = newState;
         currentRefCmd = command;

--- a/src/world/Ball.cpp
+++ b/src/world/Ball.cpp
@@ -45,14 +45,6 @@ Ball::Ball(const proto::WorldBall& copy, const World* data) : position{copy.pos(
     initializeCalculations(data);
 }
 
-const Vector2& Ball::getPos() const noexcept { return position; }
-
-const Vector2& Ball::getVelocity() const noexcept { return velocity; }
-
-bool Ball::isVisible() const noexcept { return visible; }
-
-const Vector2& Ball::getExpectedEndPosition() const noexcept { return expectedEndPosition; }
-
 void Ball::initializeCalculations(const world::World* data) noexcept {
     initBallAtRobotPosition(data);
     updateExpectedBallEndPosition(data);
@@ -74,14 +66,14 @@ void Ball::initBallAtRobotPosition(const world::World* data) noexcept {
 
     auto previousBall = optionalPreviousBall.value();
 
-    if (position != Vector2() || previousBall->getPos() == Vector2()) {
+    if (position != Vector2() || previousBall->position == Vector2()) {
         return;
     }
 
     // Current ball does not have a position, set it to the old pos
     auto rbtView = previousWorld->getRobotClosestToBall(us);
     if (rbtView) {
-        this->position = previousBall->getPos();
+        this->position = previousBall->position;
     }
 }
 
@@ -100,19 +92,19 @@ void Ball::updateExpectedBallEndPosition(const world::World* data) noexcept {
 
     auto ball = optionalPreviousBall.value();
 
-    double ballVelSquared = ball->getVelocity().length2();
+    double ballVelSquared = ball->velocity.length2();
     const double frictionCoefficient = ai::Constants::GRSIM() ? SIMULATION_FRICTION : REAL_FRICTION;
 
-    expectedEndPosition = ball->getPos() + ball->velocity.stretchToLength(ballVelSquared / frictionCoefficient);
+    expectedEndPosition = ball->position + ball->velocity.stretchToLength(ballVelSquared / frictionCoefficient);
 
     // Visualize the Expected Ball End Position
-    ai::interface::Input::drawData(ai::interface::Visual::BALL_DATA, {getExpectedEndPosition()}, ai::Constants::BALL_COLOR(), -1, ai::interface::Drawing::CIRCLES, 8, 8, 6);
-    ai::interface::Input::drawData(ai::interface::Visual::BALL_DATA, {position, getExpectedEndPosition()}, ai::Constants::BALL_COLOR(), -1,
+    ai::interface::Input::drawData(ai::interface::Visual::BALL_DATA, {expectedEndPosition}, ai::Constants::BALL_COLOR(), -1, ai::interface::Drawing::CIRCLES, 8, 8, 6);
+    ai::interface::Input::drawData(ai::interface::Visual::BALL_DATA, {position, expectedEndPosition}, ai::Constants::BALL_COLOR(), -1,
                                    ai::interface::Drawing::LINES_CONNECTED);
 }
 
 void Ball::updateBallAtRobotPosition(const world::World* data) noexcept {
-    if (isVisible()) {
+    if (visible) {
         return;
     }
 

--- a/src/world/Ball.cpp
+++ b/src/world/Ball.cpp
@@ -10,6 +10,37 @@
 
 namespace rtt::world::ball {
 
+/**
+ * The movement friction during simulation and real life are different, because the simulation does not model
+ * everything. So the movement friction has to be adjusted to compensate for this difference.
+ *
+ * The expected movement friction of the ball during simulation
+ */
+constexpr static float SIMULATION_FRICTION = 1.22;
+
+/**
+ * The expected movement friction of the ball during simulation
+ */
+constexpr static float REAL_FRICTION = 0.61;
+
+/**
+ * The maximum possible factor used for the Kalman filter which is used when filtering the velocity.
+ */
+constexpr static float FILTER_MAX_FACTOR_FOR_VELOCITY = 0.8;
+
+/**
+ * The smallest velocity used for the Kalman filter for which we have that the factor is equal
+ * THRESHOLD_ROBOT_CLOSE_TO_BALL. Larger velocities will also have THRESHOLD_ROBOT_CLOSE_TO_BALL as factor.
+ */
+constexpr static float FILTER_VELOCITY_WITH_MAX_FACTOR = 8.0;
+
+/**
+ * The threshold used for the filtered velocity, if it exceeds this value then we use the velocity
+ * instead as estimation for the filtered velocity. More information can be found in the comment in the
+ * filterBallVelocity method of the Ball.cpp file.
+ */
+constexpr static float MAXIMUM_FILTER_VELOCITY = 100.0;
+
 Ball::Ball(const proto::WorldBall& copy, const World* data) : position{copy.pos().x(), copy.pos().y()}, velocity{copy.vel().x(), copy.vel().y()}, visible{copy.visible()} {
     initializeCalculations(data);
 }

--- a/src/world/Robot.cpp
+++ b/src/world/Robot.cpp
@@ -31,8 +31,8 @@ Robot::Robot(const proto::WorldRobot &copy, rtt::world::Team team, std::optional
     }
 
     if (ball.has_value()) {
-        setDistanceToBall(pos.dist((*ball)->getPos()));
-        auto angleRobotToBall = ((*ball)->getPos() - pos).angle();
+        setDistanceToBall(pos.dist((*ball)->position));
+        auto angleRobotToBall = ((*ball)->position - pos).angle();
         setAngleDiffToBall(angle.shortestAngleDiff(Angle(angleRobotToBall)));
     }
 }

--- a/src/world/Robot.cpp
+++ b/src/world/Robot.cpp
@@ -34,6 +34,14 @@ Robot::Robot(const proto::WorldRobot &copy, rtt::world::Team team, std::optional
         setDistanceToBall(pos.dist((*ball)->position));
         auto angleRobotToBall = ((*ball)->position - pos).angle();
         setAngleDiffToBall(angle.shortestAngleDiff(Angle(angleRobotToBall)));
+
+        if (seesBall) setHasBall(true);
+        else if (!(team == Team::us && SETTINGS.getRobotHubMode() == Settings::RobotHubMode::SIMULATOR)){ // For our own robots in the sim, we only use the ballSensor, since its more accurate
+            // If the ball is not visible, we should go closer to the ball before thinking we have it, for safety (since we can't actually see if we have the ball or not)
+            auto hasBallDist = ball->get()->visible ? ai::Constants::HAS_BALL_DISTANCE() : ai::Constants::HAS_BALL_DISTANCE() * 0.75;
+            auto hasBallAccordingToVision = distanceToBall < hasBallDist && angleDiffToBall < ai::Constants::HAS_BALL_ANGLE();
+            setHasBall(hasBallAccordingToVision || seesBall);
+        }
     }
 }
 
@@ -88,6 +96,10 @@ void Robot::setWorkingBallSensor(bool _workingBallSensor) noexcept { Robot::work
 bool Robot::ballSensorSeesBall() const noexcept { return seesBall; }
 
 void Robot::setBallSensorSeesBall(bool _seesBall) noexcept { Robot::seesBall = _seesBall; }
+
+void Robot::setHasBall(bool _hasBall) noexcept { Robot::robotHasBall = _hasBall; }
+
+bool Robot::hasBall() const noexcept { return robotHasBall; }
 
 float Robot::getBallPosBallSensor() const noexcept { return ballPos; }
 

--- a/src/world/views/RobotView.cpp
+++ b/src/world/views/RobotView.cpp
@@ -15,33 +15,11 @@ robot::Robot const &RobotView::operator*() const noexcept { return *get(); }
 
 robot::Robot const *RobotView::operator->() const noexcept { return get(); }
 
-// TODO: Move this functionality to roboteam_world. That repo should decide whether a robot has the ball
-// TODO: TEST whether maxDist and Angle are suitable on the field and whether ballsensor works well irl
-bool RobotView::hasBall(double maxDist, double maxAngle) const noexcept {
-    // If we use a simulator and this robot is ours, we only use the ballsensor to determine if a robot has the ball
-    // In all other cases, we check for distance and ballsensor, one of which needs to be true
-    bool robotHasBall = false;
-
-    if (this->robotPtr->getTeam() == Team::us && SETTINGS.getRobotHubMode() == Settings::RobotHubMode::SIMULATOR) {
-        robotHasBall = get()->ballSensorSeesBall();
-    } else {
-        robotHasBall = get()->ballSensorSeesBall() || hasBallAccordingToVision(maxDist, maxAngle);
-    }
-
-    return robotHasBall;
-}
-
 Vector2 RobotView::getKicker() const noexcept {
     Vector2 distanceToKicker{ai::stp::control_constants::CENTER_TO_FRONT + 0.1, 0};
     return get()->getPos() + distanceToKicker.rotate(get()->getAngle());
 }
 
 RobotView::operator bool() const noexcept { return get() != nullptr; }
-
-bool RobotView::hasBallAccordingToVision(double maxDist, double maxAngle) const noexcept {
-    auto dist = get()->getDistanceToBall();
-    auto angle = get()->getAngleDiffToBall();
-    return dist < maxDist && angle < maxAngle * M_PI;
-}
 
 }  // namespace rtt::world::view

--- a/src/world/views/WorldDataView.cpp
+++ b/src/world/views/WorldDataView.cpp
@@ -83,14 +83,14 @@ bool WorldDataView::ourRobotHasBall(uint8_t id, double maxDist) const noexcept {
     auto robot = getRobotForId(id, true);
     if (!robot) return false;
 
-    return (*robot).hasBall(maxDist);
+    return (*robot)->hasBall();
 }
 
 bool WorldDataView::theirRobotHasBall(int id, double maxDist) const noexcept {
     auto robot = getRobotForId(id, false);
     if (!robot) return false;
 
-    return (*robot).hasBall(maxDist);
+    return (*robot)->hasBall();
 }
 
 std::optional<RobotView> WorldDataView::whichRobotHasBall(Team team, double maxDist) {

--- a/src/world/views/WorldDataView.cpp
+++ b/src/world/views/WorldDataView.cpp
@@ -93,7 +93,9 @@ bool WorldDataView::theirRobotHasBall(int id, double maxDist) const noexcept {
     return (*robot)->hasBall();
 }
 
-std::optional<RobotView> WorldDataView::whichRobotHasBall(Team team, double maxDist) {
+std::optional<RobotView> WorldDataView::whichRobotHasBall(Team team) const {
+    if (!getBall()) return std::nullopt;
+
     std::vector<RobotView> robots;
     if (team == us) {
         robots = getUs();
@@ -103,12 +105,15 @@ std::optional<RobotView> WorldDataView::whichRobotHasBall(Team team, double maxD
         robots = getRobotsNonOwning();
     }
 
-    double bestDistance = maxDist;
+    double bestDistance = 9e9;
     RobotView bestRobot = RobotView{nullptr};
     for (auto &robot : robots) {
-        if (0 <= robot->getDistanceToBall() && robot->getDistanceToBall() < bestDistance) {
-            bestRobot = robot;
-            bestDistance = robot->getDistanceToBall();
+        if (robot->hasBall()) {
+            auto distanceToBall = robot->getDistanceToBall();
+            if (distanceToBall < bestDistance){
+                bestDistance = distanceToBall;
+                bestRobot = robot;
+            }
         }
     }
 

--- a/src/world/views/WorldDataView.cpp
+++ b/src/world/views/WorldDataView.cpp
@@ -75,7 +75,7 @@ std::optional<RobotView> WorldDataView::getRobotClosestToPoint(const Vector2 &po
     return getRobotClosestToPoint(point, robots);
 }
 
-std::optional<RobotView> WorldDataView::getRobotClosestToBall(Team team) const noexcept { return getRobotClosestToPoint((*getBall())->getPos(), team); }
+std::optional<RobotView> WorldDataView::getRobotClosestToBall(Team team) const noexcept { return getRobotClosestToPoint((*getBall())->position, team); }
 
 bool WorldDataView::robotHasBall(uint8_t id, bool ourTeam, double maxDist) const noexcept { return ourTeam ? ourRobotHasBall(id, maxDist) : theirRobotHasBall(id, maxDist); }
 

--- a/test/PassingTests/PassingTests.cpp
+++ b/test/PassingTests/PassingTests.cpp
@@ -36,7 +36,7 @@ TEST_F(RTT_AI_Tests, idTests) {
     auto us = world->getWorld()->getUs();
     auto keeperId = world->getWorld()->getRobotClosestToPoint(world->getField()->getOurGoalCenter(), us).value()->getId();
     erase_if(us, [keeperId](auto bot) { return bot->getId() == keeperId; });
-    auto passerId = world->getWorld()->getRobotClosestToPoint(world->getWorld()->getBall()->get()->getPos(), us).value()->getId();
+    auto passerId = world->getWorld()->getRobotClosestToPoint(world->getWorld()->getBall()->get()->position, us).value()->getId();
     EXPECT_EQ(passInfo.passerId, passerId);
     EXPECT_TRUE(passInfo.keeperId == keeperId);
 }
@@ -67,7 +67,7 @@ TEST_F(RTT_AI_Tests, keeperPassTest) {
     world->updateWorld(protoWorld);
     world->updateField(field);
 
-    ASSERT_TRUE(world->getWorld()->getBall()->get()->getPos() == world->getField()->getOurGoalCenter());
+    ASSERT_TRUE(world->getWorld()->getBall()->get()->position == world->getField()->getOurGoalCenter());
 
     PassInfo passInfo;
     do {

--- a/test/PositionScoringTests/PositionScoringTest.cpp
+++ b/test/PositionScoringTests/PositionScoringTest.cpp
@@ -76,7 +76,7 @@ void saveRobotLocations(world::World* world, world::Team team, const std::string
 void saveBallLocation(world::World* world, const std::string& fileName) {
     std::ofstream f;
     f.open(fileName);
-    f << world->getWorld()->getBall()->get()->getPos().x << ", " << world->getWorld()->getBall()->get()->getPos().y << "\n";
+    f << world->getWorld()->getBall()->get()->position.x << ", " << world->getWorld()->getBall()->get()->position.y << "\n";
     f.close();
 }
 }  // namespace rtt

--- a/test/WorldTests/BallTests.cpp
+++ b/test/WorldTests/BallTests.cpp
@@ -23,15 +23,15 @@ TEST(BallAndView, test_getters) {
     auto const &[_, world] = rtt::world::World::instance();
     Ball data{protoData, world};
 
-    EXPECT_EQ(data.getVelocity(), Vector2(10.0, 3.0));
-    EXPECT_EQ(data.getPos(), Vector2(10.0, 3.0));  // yeye memory leak doesn't rlly matter
-    EXPECT_EQ(data.isVisible(), true);
+    EXPECT_EQ(data.velocity, Vector2(10.0, 3.0));
+    EXPECT_EQ(data.position, Vector2(10.0, 3.0));  // yeye memory leak doesn't rlly matter
+    EXPECT_EQ(data.visible(), true);
     EXPECT_EQ(0, 0);
 
     view::BallView _view{&data};
-    EXPECT_EQ(data.getVelocity(), _view->getVelocity());
-    EXPECT_EQ(data.getPos(), _view->getPos());
-    EXPECT_EQ(data.isVisible(), _view->isVisible());
+    EXPECT_EQ(data.velocity, _view->velocity);
+    EXPECT_EQ(data.position, _view->position);
+    EXPECT_EQ(data.visible(), _view->visible());
 
     EXPECT_EQ((bool)_view, true);
     EXPECT_EQ(_view.get(), &data);


### PR DESCRIPTION
Observer filters the ball data. This should be quite accurate. When AI receives this filtered data, it starts filtering again, resulting in a delay. This is of course completely redundant and unnecessary, so this PR removes this filtering and cleans up the ball class in general by moving constants around and making the class public. The latter can be done because the only way to access the ball is by means of a const reference, so accidentally editing the values is impossible. The added benefit is that it takes less function calls to get to these values, and the values do not have to be copied over and over.

Here are plots to show the delay that the filtering of AI causes.
![KickPlot](https://user-images.githubusercontent.com/57089651/175993810-75acd0c8-c9d6-4165-a1a7-10c355697355.png)

Above you see the total graph of a kick of a ball, and below a zoom, where you can easily see the added difference of AI to Observer to Simulator

![KickPlotZoom](https://user-images.githubusercontent.com/57089651/175994232-c33074eb-37bb-4c14-bbe6-ed5a9f62cc54.png)


###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
