### PR TITLE
Fix/ball placement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ add_library(roboteam_ai_tactics
         ${PROJECT_SOURCE_DIR}/src/stp/tactics/passive/Formation.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/tactics/passive/Halt.cpp
         ${PROJECT_SOURCE_DIR}/src/stp/tactics/passive/Walling.cpp
-)
+        ${PROJECT_SOURCE_DIR}/src/stp/tactics/passive/BallStandBack.cpp)
 target_include_directories(roboteam_ai_tactics
         PRIVATE include/roboteam_ai
 )

--- a/include/roboteam_ai/stp/roles/active/BallPlacer.h
+++ b/include/roboteam_ai/stp/roles/active/BallPlacer.h
@@ -16,8 +16,6 @@ class BallPlacer : public Role {
      * @param name name of the role
      */
     BallPlacer(std::string name);
-
-    [[nodiscard]] Status update(StpInfo const& info) noexcept override;
 };
 }  // namespace rtt::ai::stp::role
 

--- a/include/roboteam_ai/stp/tactics/active/DriveWithBall.h
+++ b/include/roboteam_ai/stp/tactics/active/DriveWithBall.h
@@ -40,6 +40,14 @@ class DriveWithBall : public Tactic {
     bool shouldTacticReset(const StpInfo &info) noexcept override;
 
     /**
+     * Checks if this tactic should be forced success
+     * It is forced success whenever we are at the right location
+     * @param info
+     * @return whether the tactic is forced success
+     */
+    bool forceTacticSuccess(const StpInfo &info) noexcept override;
+
+    /**
      * Is this tactic an end tactic?
      * @return This will always return false, since it is NOT an endTactic
      */

--- a/include/roboteam_ai/stp/tactics/passive/BallStandBack.h
+++ b/include/roboteam_ai/stp/tactics/passive/BallStandBack.h
@@ -17,6 +17,10 @@ class BallStandBack : public Tactic {
     BallStandBack();
 
    private:
+
+    // We want to stand still for a bit to make sure the ball doesnt have backspin
+    int standStillCounter = 0;
+
     /**
      * Calculate the info for skills from the StpInfo struct parameter
      * @param info info is the StpInfo passed by the role

--- a/include/roboteam_ai/stp/tactics/passive/BallStandBack.h
+++ b/include/roboteam_ai/stp/tactics/passive/BallStandBack.h
@@ -1,0 +1,57 @@
+//
+// Created by agata on 29/06/2022.
+//
+
+#ifndef RTT_BALLSTANDBACK_H
+#define RTT_BALLSTANDBACK_H
+
+#include "stp/Tactic.h"
+
+namespace rtt::ai::stp::tactic {
+
+class BallStandBack : public Tactic {
+   public:
+    /**
+     * Constructor for the tactic, it constructs the state machine of skills
+     */
+    BallStandBack();
+
+   private:
+    /**
+     * Calculate the info for skills from the StpInfo struct parameter
+     * @param info info is the StpInfo passed by the role
+     * @return std::optional<SkillInfo> based on the StpInfo parameter
+     */
+    std::optional<StpInfo> calculateInfoForSkill(StpInfo const &info) noexcept override;
+
+    /**
+     * Is this tactic failing during execution (go back to the previous tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true, tactic will fail (go back to prev tactic), false execution will continue as usual
+     * Fails if there is no position to move to
+     */
+    bool isTacticFailing(const StpInfo &info) noexcept override;
+
+    /**
+     * Should this tactic be reset (go back to the first skill of this tactic)
+     * @param info StpInfo can be used to check some data
+     * @return true if tactic  should reset, false if execution should continue
+     * Resets when robot position is not close enough to the target position
+     */
+    bool shouldTacticReset(const StpInfo &info) noexcept override;
+
+    /**
+     * Is this tactic an end tactic?
+     * @return This will always return true, since it is an endTactic
+     */
+    bool isEndTactic() noexcept override;
+
+    /**
+     * Gets the tactic name
+     * @return The name of this tactic
+     */
+    const char *getName() override;
+};
+}  // namespace rtt::ai::stp::tactic
+
+#endif  // RTT_BALLSTANDBACK_H

--- a/src/stp/roles/active/BallPlacer.cpp
+++ b/src/stp/roles/active/BallPlacer.cpp
@@ -18,7 +18,7 @@ namespace rtt::ai::stp::role {
 
 BallPlacer::BallPlacer(std::string name) : Role(std::move(name)) {
     // create state machine and initializes the first state
-    robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::GetBehindBallInDirection(), tactic::GetBall(), tactic::DriveWithBall(), tactic::BallStandBack(),
+    robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::GetBall(), tactic::DriveWithBall(), tactic::BallStandBack(),
                                                                        tactic::AvoidBall()};
 }
 

--- a/src/stp/roles/active/BallPlacer.cpp
+++ b/src/stp/roles/active/BallPlacer.cpp
@@ -11,13 +11,15 @@
 #include "stp/tactics/active/GetBall.h"
 #include "stp/tactics/active/GetBehindBallInDirection.h"
 #include "stp/tactics/passive/AvoidBall.h"
+#include "stp/tactics/passive/BallStandBack.h"
 #include "world/FieldComputations.h"
 
 namespace rtt::ai::stp::role {
 
 BallPlacer::BallPlacer(std::string name) : Role(std::move(name)) {
     // create state machine and initializes the first state
-    robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::GetBehindBallInDirection(), tactic::GetBall(), tactic::DriveWithBall(), tactic::AvoidBall()};
+    robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::GetBehindBallInDirection(), tactic::GetBall(), tactic::DriveWithBall(), tactic::BallStandBack(),
+                                                                       tactic::AvoidBall()};
 }
 
 Status BallPlacer::update(StpInfo const& info) noexcept {

--- a/src/stp/roles/active/BallPlacer.cpp
+++ b/src/stp/roles/active/BallPlacer.cpp
@@ -21,49 +21,4 @@ BallPlacer::BallPlacer(std::string name) : Role(std::move(name)) {
     robotTactics = collections::state_machine<Tactic, Status, StpInfo>{tactic::GetBall(), tactic::DriveWithBall(), tactic::BallStandBack(),
                                                                        tactic::AvoidBall()};
 }
-
-Status BallPlacer::update(StpInfo const& info) noexcept {
-    // Failure if the required data is not present
-    if (!info.getBall() || !info.getRobot() || !info.getField()) {
-        RTT_WARNING("Required information missing in the tactic info for ", roleName)
-        return Status::Failure;
-    }
-
-    if (!FieldComputations::pointIsInField(info.getField().value(), info.getBall().value()->position) && robotTactics.current_num() == 0) {
-        forceNextTactic();
-    }
-
-    currentRobot = info.getRobot();
-    // Update the current tactic with the new tacticInfo
-    auto status = robotTactics.update(info);
-
-    // Success if the tactic returned success and if all tactics are done
-    if (status == Status::Success && robotTactics.finished()) {
-        RTT_INFO("ROLE SUCCESSFUL for ", info.getRobot()->get()->getId())
-        return Status::Success;
-    }
-
-    // Reset the tactic state machine if a tactic failed and the state machine is not yet finished
-    if (status == Status::Failure && !robotTactics.finished()) {
-        RTT_INFO("State Machine reset for current role for ID = ", info.getRobot()->get()->getId())
-        // Reset all the Skills state machines
-        for (auto& tactic : robotTactics) {
-            tactic->reset();
-        }
-        // Reset Tactics state machine
-        robotTactics.reset();
-    }
-
-    // Success if waiting and tactics are finished
-    // Waiting if waiting but not finished
-    if (status == Status::Waiting) {
-        if (robotTactics.finished()) {
-            return Status::Success;
-        }
-        return Status::Waiting;
-    }
-
-    // Return running by default
-    return Status::Running;
-}
 }  // namespace rtt::ai::stp::role

--- a/src/stp/tactics/active/DriveWithBall.cpp
+++ b/src/stp/tactics/active/DriveWithBall.cpp
@@ -11,13 +11,14 @@
 
 #include "stp/constants/ControlConstants.h"
 #include "stp/skills/GoToPos.h"
+#include "stp/skills/Rotate.h"
 
 namespace rtt::ai::stp::tactic {
 
 DriveWithBall::DriveWithBall() {
     // Create state machine of skills and initialize first skill
     // TODO: The rotate skill might be unnecessary in this tactic if our dribbler works well whilst driving backwards
-    skills = rtt::collections::state_machine<Skill, Status, StpInfo>{/*skill::Rotate(), */ skill::GoToPos()};
+    skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::Rotate(), skill::GoToPos()};
 }
 
 std::optional<StpInfo> DriveWithBall::calculateInfoForSkill(StpInfo const& info) noexcept {
@@ -25,12 +26,14 @@ std::optional<StpInfo> DriveWithBall::calculateInfoForSkill(StpInfo const& info)
 
     if (!skillStpInfo.getPositionToMoveTo() || !skillStpInfo.getBall()) return std::nullopt;
 
-    double angleToBall = (info.getPositionToMoveTo().value() - info.getBall()->get()->position).angle();
-    skillStpInfo.setAngle(angleToBall);
+    if (skills.current_num() == 0){
+        skillStpInfo.setAngle((info.getPositionToShootAt().value() - info.getRobot()->get()->getPos()).angle());
+    }
+    else {
+        double angleToBall = (info.getPositionToMoveTo().value() - info.getBall()->get()->position).angle();
+        skillStpInfo.setAngle(angleToBall);
+    }
 
-    // When driving with ball, we need to activate the dribbler
-    // For now, this means full power, but this might change later
-    // TODO: TUNE better way to determine dribblerspeed
     skillStpInfo.setDribblerSpeed(100);
 
     return skillStpInfo;
@@ -42,10 +45,8 @@ bool DriveWithBall::isTacticFailing(const StpInfo& info) noexcept {
 }
 
 bool DriveWithBall::shouldTacticReset(const StpInfo& info) noexcept {
-    // Should reset if the angle the robot is at is no longer correct
-    auto robotAngle = info.getRobot()->get()->getAngle();
-    auto ballToRobotAngle = (info.getBall()->get()->position - info.getRobot()->get()->getPos()).angle();
-    return fabs(robotAngle + Angle(ballToRobotAngle)) <= stp::control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN;
+    // Should reset if the angle the robot is at is no longer correct after doing rotate
+    return skills.current_num() == 1 && info.getRobot()->get()->getAngle().shortestAngleDiff(info.getAngle()) > control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
 }
 
 bool DriveWithBall::isEndTactic() noexcept {
@@ -54,5 +55,10 @@ bool DriveWithBall::isEndTactic() noexcept {
 }
 
 const char* DriveWithBall::getName() { return "Drive With Ball"; }
+
+bool DriveWithBall::forceTacticSuccess(const StpInfo& info) noexcept {
+    // If were already at the right place, force success
+    return (info.getRobot()->get()->getPos() - info.getPositionToMoveTo().value()).length() < control_constants::GO_TO_POS_ERROR_MARGIN;
+}
 
 }  // namespace rtt::ai::stp::tactic

--- a/src/stp/tactics/passive/BallStandBack.cpp
+++ b/src/stp/tactics/passive/BallStandBack.cpp
@@ -1,0 +1,52 @@
+//
+// Created by agata on 29/06/2022.
+//
+
+#include "stp/tactics/passive/BallStandBack.h"
+
+#include <stp/constants/ControlConstants.h>
+
+#include "stp/skills/GoToPos.h"
+
+namespace rtt::ai::stp::tactic {
+
+BallStandBack::BallStandBack() {
+    // Create state machine of skills and initialize first skill
+    skills = rtt::collections::state_machine<Skill, Status, StpInfo>{skill::GoToPos()};
+}
+
+std::optional<StpInfo> BallStandBack::calculateInfoForSkill(StpInfo const &info) noexcept {
+    StpInfo skillStpInfo = info;
+
+    if (!info.getPositionToMoveTo() || !skillStpInfo.getBall()) return std::nullopt;
+
+    auto moveVector = Vector2(info.getRobot()->get()->getPos() - info.getBall()->get()->getPos());
+
+    auto positionToMove = moveVector.stretchToLength(control_constants::AVOID_BALL_DISTANCE);
+
+    double angle = (info.getBall()->get()->getPos() - positionToMove).angle();
+
+    skillStpInfo.setAngle(angle);
+    skillStpInfo.setPositionToMoveTo(positionToMove);
+
+    // Be 100% sure the dribbler is off during the BallStandBack
+    skillStpInfo.setDribblerSpeed(0);
+
+    return skillStpInfo;
+}
+
+bool BallStandBack::isTacticFailing(const StpInfo &info) noexcept {
+    // BallStandBack tactic fails if there is no location to move to
+    return !info.getPositionToMoveTo();
+}
+
+bool BallStandBack::shouldTacticReset(const StpInfo &info) noexcept { return false; }
+
+bool BallStandBack::isEndTactic() noexcept {
+    // BallStandBack tactic is an end tactic
+    return false;
+}
+
+const char *BallStandBack::getName() { return "BallStandBack"; }
+
+}  // namespace rtt::ai::stp::tactic


### PR DESCRIPTION
### Comments for the reviewer
- After placing the ball robot goes back in the exact opposite direction without rotating to prevent misplacing the ball after ballPlacement.
- To achieve it new tactic called BallStandBack was added

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
