### PR TITLE
Check for empty optional before access

### DIFF
--- a/src/stp/Play.cpp
+++ b/src/stp/Play.cpp
@@ -87,7 +87,8 @@ void Play::refreshData() noexcept {
             // Get a new RobotView from world using the old robot id
             stpInfo->second.setRobot(world->getWorld()->getRobotForId(stpInfo->second.getRobot()->get()->getId()));
 
-            stpInfo->second.setMaxRobotVelocity(control::ControlUtils::getMaxVelocity(stpInfo->second.getRobot().value()->hasBall()));
+            // Set max velocity depending on the gamestate rules and whether we have the ball
+            if (stpInfo->second.getRobot()) stpInfo->second.setMaxRobotVelocity(control::ControlUtils::getMaxVelocity(stpInfo->second.getRobot().value()->hasBall()));
 
             // The keeper does not need to avoid our defense area
             if (stpInfo->second.getRoleName() == "keeper") stpInfo->second.setShouldAvoidDefenseArea(false);


### PR DESCRIPTION
Pretty straightforward, I forgot to check for an empty optional here. This can cause the AI to crash in case the robot we are looking for isn't in world. This is why AI sometimes crashed when a robot was obscured.