### PR TITLE
Fix/infinite walling

### DIFF
--- a/include/roboteam_ai/stp/tactics/passive/BallStandBack.h
+++ b/include/roboteam_ai/stp/tactics/passive/BallStandBack.h
@@ -17,7 +17,6 @@ class BallStandBack : public Tactic {
     BallStandBack();
 
    private:
-
     // We want to stand still for a bit to make sure the ball doesnt have backspin
     int standStillCounter = 0;
 

--- a/include/roboteam_ai/world/FieldComputations.h
+++ b/include/roboteam_ai/world/FieldComputations.h
@@ -235,15 +235,15 @@ class FieldComputations {
 
     /**
      * Determine the intersection between a LineSegment and the field lines and return the intersection point closest to the start of the line (if the LineSegment
-     * does not intersect then return a null pointer).
+     * does not intersect then return a null_opt).
      * @param field The field used to determine where the defence area is located.
      * @param lineStart The location of the start of the LineSegment.
      * @param lineEnd The location of the end of the LineSegment.
      * @param margin The outwards margin in which the field area will be expanded/shrinked in all directions (except maybe for the goal side). A positive value means that it will
      * be expanded, a negative value means that it will be shrinked (if unset then it will be neither expanded/shrinked).
-     * @return The closest intersection point to the start of the LineSegment. In case of no intersection point return a null pointer.
+     * @return The closest intersection point to the start of the LineSegment. In case of no intersection point return a null optional.
      */
-    static std::shared_ptr<Vector2> lineIntersectionWithField(const rtt_world::Field &field, const Vector2 &lineStart, const Vector2 &lineEnd, double margin);
+    static std::optional<Vector2> lineIntersectionWithField(const rtt_world::Field &field, const Vector2 &lineStart, const Vector2 &lineEnd, double margin);
 
     /**
      * Compute the total angle a given point makes with the goal, i.e. you create a triangle using this point and both upperside and lowerside of the goal and compute the angle

--- a/src/world/FieldComputations.cpp
+++ b/src/world/FieldComputations.cpp
@@ -132,18 +132,18 @@ std::shared_ptr<Vector2> FieldComputations::lineIntersectionWithDefenseArea(cons
     }
 }
 
-std::shared_ptr<Vector2> FieldComputations::lineIntersectionWithField(const rtt_world::Field &field, const Vector2 &lineStart, const Vector2 &lineEnd, double margin) {
+std::optional<Vector2> FieldComputations::lineIntersectionWithField(const rtt_world::Field &field, const Vector2 &lineStart, const Vector2 &lineEnd, double margin) {
     auto fieldEdges = getFieldEdge(field, margin);
     auto intersections = fieldEdges.intersections({lineStart, lineEnd});
 
     if (intersections.size() == 1) {
-        return std::make_shared<Vector2>(intersections.at(0));
+        return intersections.at(0);
     } else if (intersections.size() == 2) {
         double distanceFirstIntersection = lineStart.dist(intersections.at(0));
         double distanceSecondIntersection = lineStart.dist(intersections.at(1));
-        return std::make_shared<Vector2>(distanceFirstIntersection < distanceSecondIntersection ? intersections.at(0) : intersections.at(1));
+        return distanceFirstIntersection < distanceSecondIntersection ? intersections.at(0) : intersections.at(1);
     } else {
-        return nullptr;
+        return std::nullopt;
     }
 }
 


### PR DESCRIPTION
This PR prevents the walling calculations from accidentally creating an infinite loop, by making the walling line much bigger.

This PR is dependent on [this PR in utils](https://github.com/RoboTeamTwente/roboteam_utils/pull/129)

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
