### PR TITLE
Add defense area margins after swapping points

### DIFF
--- a/src/world/FieldComputations.cpp
+++ b/src/world/FieldComputations.cpp
@@ -149,11 +149,10 @@ std::shared_ptr<Vector2> FieldComputations::lineIntersectionWithField(const rtt_
 
 // True standard which mean field.getBoundaryWidth() is used otherwise margin is used
 Polygon FieldComputations::getDefenseArea(const rtt_world::Field &field, bool ourDefenseArea, double margin, double backMargin) {
-    Vector2 belowGoal =
-        ourDefenseArea ? field.getBottomLeftOurDefenceArea() + Vector2(-backMargin, -margin) : field.getBottomRightTheirDefenceArea() + Vector2(backMargin, -margin);
-    Vector2 aboveGoal = ourDefenseArea ? field.getTopLeftOurDefenceArea() + Vector2(-backMargin, margin) : field.getTopRightTheirDefenceArea() + Vector2(backMargin, margin);
-    Vector2 bottomPenalty = ourDefenseArea ? field.getLeftPenaltyLineBottom() + Vector2(margin, -margin) : field.getRightPenaltyLineBottom() + Vector2(-margin, -margin);
-    Vector2 topPenalty = ourDefenseArea ? field.getLeftPenaltyLineTop() + Vector2(margin, margin) : field.getRightPenaltyLineTop() + Vector2(-margin, margin);
+    Vector2 belowGoal =ourDefenseArea ? field.getBottomLeftOurDefenceArea() : field.getBottomRightTheirDefenceArea();
+    Vector2 aboveGoal = ourDefenseArea ? field.getTopLeftOurDefenceArea(): field.getTopRightTheirDefenceArea();
+    Vector2 bottomPenalty = ourDefenseArea ? field.getLeftPenaltyLineBottom() : field.getRightPenaltyLineBottom();
+    Vector2 topPenalty = ourDefenseArea ? field.getLeftPenaltyLineTop() : field.getRightPenaltyLineTop();
 
     if (aboveGoal.y < belowGoal.y) {
         std::swap(aboveGoal, belowGoal);
@@ -162,9 +161,15 @@ Polygon FieldComputations::getDefenseArea(const rtt_world::Field &field, bool ou
         std::swap(topPenalty, bottomPenalty);
     }
 
+    belowGoal =
+        ourDefenseArea ? belowGoal + Vector2(-backMargin, -margin) : belowGoal + Vector2(backMargin, -margin);
+    aboveGoal = ourDefenseArea ? aboveGoal + Vector2(-backMargin, margin) : aboveGoal + Vector2(backMargin, margin);
+    bottomPenalty = ourDefenseArea ? bottomPenalty + Vector2(margin, -margin) : bottomPenalty + Vector2(-margin, -margin);
+    topPenalty = ourDefenseArea ? topPenalty + Vector2(margin, margin) : topPenalty + Vector2(-margin, margin);
+
     std::vector<Vector2> defenseArea = {belowGoal, bottomPenalty, topPenalty, aboveGoal};
     interface::Input::drawDebugData(defenseArea);
-    return Polygon(defenseArea);
+    return {defenseArea};
 }
 
 Polygon FieldComputations::getGoalArea(const rtt_world::Field &field, bool ourGoal, double margin, bool hasBackMargin) {


### PR DESCRIPTION
Otherwise, the margins might be added to the wrong points

### Comments for the reviewer
- 

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
