### PR TITLE
Only use hasBallMap for our team

### DIFF
--- a/include/roboteam_ai/world/Robot.hpp
+++ b/include/roboteam_ai/world/Robot.hpp
@@ -63,6 +63,8 @@ class Robot {
    private:
     void updateFromFeedback(const proto::RobotProcessedFeedback &feedback) noexcept;
 
+    void updateHasBallMap(std::optional<view::BallView>& ball);
+
     void setId(int id) noexcept;
 
     void setTeam(Team team) noexcept;

--- a/src/world/Robot.cpp
+++ b/src/world/Robot.cpp
@@ -8,8 +8,7 @@
 #include "world/World.hpp"
 
 namespace rtt::world::robot {
-Robot::Robot(const proto::WorldRobot &copy, rtt::world::Team team, std::optional<view::BallView> ball,
-             unsigned char dribblerState, unsigned long worldNumber)
+Robot::Robot(const proto::WorldRobot &copy, rtt::world::Team team, std::optional<view::BallView> ball, unsigned char dribblerState, unsigned long worldNumber)
     : id{static_cast<int>(copy.id())},
       team{team},
       pos{copy.pos().x(), copy.pos().y()},
@@ -31,13 +30,11 @@ Robot::Robot(const proto::WorldRobot &copy, rtt::world::Team team, std::optional
     }
 
     if (team == Team::us) {
-        if(copy.has_feedbackinfo()){
+        if (copy.has_feedbackinfo()) {
             updateFromFeedback(copy.feedbackinfo());
         }
         updateHasBallMap(ball);
     }
-
-
 }
 
 int Robot::getId() const noexcept { return id; }
@@ -121,7 +118,7 @@ unsigned long Robot::getLastUpdatedWorldNumber() const noexcept { return lastUpd
 void Robot::setLastUpdatedWorldNumber(unsigned long _lastUpdatedWorldNumber) noexcept { Robot::lastUpdatedWorldNumber = _lastUpdatedWorldNumber; }
 
 void Robot::updateFromFeedback(const proto::RobotProcessedFeedback &feedback) noexcept {
-    //TODO: add processing of more of the fields of feedback
+    // TODO: add processing of more of the fields of feedback
     if (ai::Constants::FEEDBACK_ENABLED()) {
         setWorkingBallSensor(feedback.ball_sensor_is_working());
         setBatteryLow(feedback.battery_level() < 22);  // TODO: Define what is considered a 'low' voltage
@@ -131,7 +128,7 @@ void Robot::updateFromFeedback(const proto::RobotProcessedFeedback &feedback) no
     }
 }
 
-void Robot::updateHasBallMap(std::optional<view::BallView>& ball) {
+void Robot::updateHasBallMap(std::optional<view::BallView> &ball) {
     if (!ball) return;
 
     // On the field, use data from the dribbler and vision to determine if we have the ball
@@ -141,14 +138,18 @@ void Robot::updateHasBallMap(std::optional<view::BallView>& ball) {
         auto hasBallAccordingToVision = distanceToBall < hasBallDist && angleDiffToBall < ai::Constants::HAS_BALL_ANGLE();
 
         // Increase the hasBall score depending on how sure we are that we have the ball
-        if (hasBallAccordingToVision && dribblerSeesBall) hasBallUpdateMap[id].score += 2;
-        else if (hasBallAccordingToVision && !dribblerSeesBall) hasBallUpdateMap[id].score += 1;
-        else if (!hasBallAccordingToVision && dribblerSeesBall && distanceToBall < ai::Constants::HAS_BALL_DISTANCE() * 1.5 && angleDiffToBall < ai::Constants::HAS_BALL_ANGLE() * 1.5)
+        if (hasBallAccordingToVision && dribblerSeesBall)
+            hasBallUpdateMap[id].score += 2;
+        else if (hasBallAccordingToVision && !dribblerSeesBall)
             hasBallUpdateMap[id].score += 1;
-        else hasBallUpdateMap[id].score -= 2;
+        else if (!hasBallAccordingToVision && dribblerSeesBall && distanceToBall < ai::Constants::HAS_BALL_DISTANCE() * 1.5 &&
+                 angleDiffToBall < ai::Constants::HAS_BALL_ANGLE() * 1.5)
+            hasBallUpdateMap[id].score += 1;
+        else
+            hasBallUpdateMap[id].score -= 2;
 
         // TODO when we have working ballsensors: Use the ballsensor as well to determine if we have the ball
-        //if (workingBallSensor) hasBallUpdateMap[id].score += (ballSensorSeesBall ? 1 : -1);
+        // if (workingBallSensor) hasBallUpdateMap[id].score += (ballSensorSeesBall ? 1 : -1);
     } else {
         // In the sim, for our team, we only use the ballsensor (since its very accurate)
         hasBallUpdateMap[id].score += (ballSensorSeesBall ? 2 : -2);
@@ -160,7 +161,8 @@ void Robot::updateHasBallMap(std::optional<view::BallView>& ball) {
     // If we previously had the ball, we do not have the ball if the score gets below 4
     if (hasBallUpdateMap[id].hasBall && hasBallUpdateMap[id].score < 4) hasBallUpdateMap[id].hasBall = false;
     // If we did not have the ball yet, we have the ball if the score gets over 20
-    else if (hasBallUpdateMap[id].score > 20) hasBallUpdateMap[id].hasBall = true;
+    else if (hasBallUpdateMap[id].score > 20)
+        hasBallUpdateMap[id].hasBall = true;
 
     setHasBall(hasBallUpdateMap[id].hasBall);
 


### PR DESCRIPTION
### Comments for the reviewer
Since we initialize robots from both teams with the same ID, we need to check which team the robot belongs to before updating the hasBallMap.

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
