### PR TITLE
Fix ball placement

### DIFF
--- a/src/control/positionControl/BBTrajectories/WorldObjects.cpp
+++ b/src/control/positionControl/BBTrajectories/WorldObjects.cpp
@@ -3,10 +3,7 @@
 //
 #include "control/positionControl/BBTrajectories/WorldObjects.h"
 
-#include <roboteam_utils/Tube.h>
-
 #include <algorithm>
-#include <utility>
 
 #include "world/World.hpp"
 #include "world/WorldData.hpp"

--- a/src/control/positionControl/BBTrajectories/WorldObjects.cpp
+++ b/src/control/positionControl/BBTrajectories/WorldObjects.cpp
@@ -3,6 +3,8 @@
 //
 #include "control/positionControl/BBTrajectories/WorldObjects.h"
 
+#include <roboteam_utils/Tube.h>
+
 #include <algorithm>
 #include <utility>
 
@@ -87,28 +89,23 @@ void WorldObjects::calculateDefenseAreaCollisions(const rtt::world::Field &field
 }
 
 void WorldObjects::calculateBallCollisions(const rtt::world::World *world, std::vector<CollisionData> &collisionDatas, std::vector<Vector2> pathPoints, double timeStep) {
-    if (ruleset.minDistanceToBall > 0) {
-        auto startPositionBall = world->getWorld()->getBall()->get()->position;
-        auto VelocityBall = world->getWorld()->getBall()->get()->velocity;
-        std::vector<Vector2> ballTrajectory;
+    auto startPositionBall = world->getWorld()->getBall()->get()->position;
+    auto VelocityBall = world->getWorld()->getBall()->get()->velocity;
+    std::vector<Vector2> ballTrajectory;
 
-        // TODO: improve ball trajectory approximation
-        // Current approximation assumes it continues on the same path with the same velocity, and we check 1 second deep
-        double time = 0;
-        double ballAvoidanceTime = 1;
-        while (pathPoints.size() * timeStep > time && time < ballAvoidanceTime) {
-            ballTrajectory.emplace_back(startPositionBall + VelocityBall * time);
-            time += timeStep;
-        }
+    // TODO: improve ball trajectory approximation
+    // Current approximation assumes it continues on the same path with the same velocity, and we check 1 second deep
+    double time = 0;
+    double ballAvoidanceTime = 1;
+    while (pathPoints.size() * timeStep > time && time < ballAvoidanceTime) {
+        ballTrajectory.emplace_back(startPositionBall + VelocityBall * time);
+        time += timeStep;
+    }
 
-        // Check each timeStep for a collision with the ball, or during ball placement if its too close to the 'ballTube'
-        auto ballTube = LineSegment(startPositionBall, rtt::ai::GameStateManager::getRefereeDesignatedPosition());
-        for (size_t i = 0; i < ballTrajectory.size(); i++) {
-            if (ruleset.minDistanceToBall > (pathPoints[i] - ballTrajectory[i]).length() ||
-                (gameState.getStrategyName() == "ball_placement_them" && ruleset.minDistanceToBall > ballTube.distanceToLine(pathPoints[i]))) {
-                insertCollisionData(collisionDatas, CollisionData{ballTrajectory[i], pathPoints[i], i * timeStep, "BallCollision"});
-                return;
-            }
+    for (size_t i = 1; i < ballTrajectory.size(); i++) {
+        if (pathPoints[i].dist(ballTrajectory[i]) < ai::stp::control_constants::ROBOT_RADIUS * 2.0){
+            insertCollisionData(collisionDatas, CollisionData{ballTrajectory[i], pathPoints[i], i * timeStep, "BallCollision"});
+            return;
         }
     }
 }

--- a/src/stp/tactics/active/DriveWithBall.cpp
+++ b/src/stp/tactics/active/DriveWithBall.cpp
@@ -26,10 +26,9 @@ std::optional<StpInfo> DriveWithBall::calculateInfoForSkill(StpInfo const& info)
 
     if (!skillStpInfo.getPositionToMoveTo() || !skillStpInfo.getBall()) return std::nullopt;
 
-    if (skills.current_num() == 0){
+    if (skills.current_num() == 0) {
         skillStpInfo.setAngle((info.getPositionToShootAt().value() - info.getRobot()->get()->getPos()).angle());
-    }
-    else {
+    } else {
         double angleToBall = (info.getPositionToMoveTo().value() - info.getBall()->get()->position).angle();
         skillStpInfo.setAngle(angleToBall);
     }
@@ -46,7 +45,7 @@ bool DriveWithBall::isTacticFailing(const StpInfo& info) noexcept {
 
 bool DriveWithBall::shouldTacticReset(const StpInfo& info) noexcept {
     // Should reset if the angle the robot is at is no longer correct after doing rotate
-    return skills.current_num() == 1 && info.getRobot()->get()->getAngle().shortestAngleDiff(info.getAngle()) > control_constants::GO_TO_POS_ANGLE_ERROR_MARGIN * M_PI;
+    return skills.current_num() == 1 && info.getRobot()->get()->getAngle().shortestAngleDiff(info.getAngle()) > Constants::HAS_BALL_ANGLE();
 }
 
 bool DriveWithBall::isEndTactic() noexcept {

--- a/src/stp/tactics/passive/AvoidBall.cpp
+++ b/src/stp/tactics/passive/AvoidBall.cpp
@@ -50,7 +50,7 @@ std::optional<StpInfo> AvoidBall::calculateInfoForSkill(StpInfo const& info) noe
     }
 
     skillStpInfo.setPositionToMoveTo(targetPos);
-
+    skillStpInfo.setShouldAvoidBall(true);
     return skillStpInfo;
 }
 

--- a/src/stp/tactics/passive/AvoidBall.cpp
+++ b/src/stp/tactics/passive/AvoidBall.cpp
@@ -45,7 +45,7 @@ std::optional<StpInfo> AvoidBall::calculateInfoForSkill(StpInfo const& info) noe
         if (FieldComputations::pointIsValidPosition(info.getField().value(), projectedPos))
             targetPos = projectedPos;
         else {
-            targetPos = calculateNewPosition(targetPos, info.getField().value(), avoidShape);
+            targetPos = calculateNewPosition(ballPosition, info.getField().value(), avoidShape);
         }
     }
 
@@ -63,19 +63,19 @@ bool AvoidBall::isTacticFailing(const StpInfo& info) noexcept {
 
 bool AvoidBall::shouldTacticReset(const StpInfo& info) noexcept { return false; }
 
-Vector2 AvoidBall::calculateNewPosition(Vector2 targetPos, const rtt::world::Field& field, const std::unique_ptr<Shape>& avoidShape) {
-    Vector2 newTarget = targetPos;  // The new position to go to
+Vector2 AvoidBall::calculateNewPosition(Vector2 ballPos, const rtt::world::Field& field, const std::unique_ptr<Shape>& avoidShape) {
+    Vector2 newTarget = ballPos;  // The new position to go to
     bool pointFound = false;
     for (int distanceSteps = 0; distanceSteps < 5; ++distanceSteps) {
         // Use a larger grid each iteration in case no valid point is found
         auto distance = 3 * control_constants::AVOID_BALL_DISTANCE + distanceSteps * control_constants::AVOID_BALL_DISTANCE / 2.0;
-        auto possiblePoints = Grid(targetPos.x - distance / 2.0, targetPos.y - distance / 2.0, distance, distance, 3, 3).getPoints();
+        auto possiblePoints = Grid(ballPos.x - distance / 2.0, ballPos.y - distance / 2.0, distance, distance, 3, 3).getPoints();
         double dist = 1e3;
         for (auto& pointVector : possiblePoints) {
             for (auto& point : pointVector) {
                 if (FieldComputations::pointIsValidPosition(field, point) && !avoidShape->contains(point)) {
-                    if (targetPos.dist(point) < dist) {
-                        dist = targetPos.dist(point);
+                    if (ballPos.dist(point) < dist) {
+                        dist = ballPos.dist(point);
                         newTarget = point;
                         pointFound = true;
                     }
@@ -84,7 +84,7 @@ Vector2 AvoidBall::calculateNewPosition(Vector2 targetPos, const rtt::world::Fie
         }
         if (pointFound) break;  // As soon as a valid point is found, don't look at more points further away
     }
-    if (newTarget == targetPos) RTT_WARNING("Could not find good position to avoid ball");
+    if (newTarget == ballPos) RTT_WARNING("Could not find good position to avoid ball");
     return newTarget;
 }
 

--- a/src/stp/tactics/passive/BallStandBack.cpp
+++ b/src/stp/tactics/passive/BallStandBack.cpp
@@ -2,11 +2,8 @@
 // Created by agata on 29/06/2022.
 //
 
-#include "stp/tactics/passive/BallStandBack.h"
-
-#include <stp/constants/ControlConstants.h>
-
 #include "stp/skills/GoToPos.h"
+#include "stp/tactics/passive/BallStandBack.h"
 
 namespace rtt::ai::stp::tactic {
 

--- a/src/stp/tactics/passive/BallStandBack.cpp
+++ b/src/stp/tactics/passive/BallStandBack.cpp
@@ -21,9 +21,9 @@ std::optional<StpInfo> BallStandBack::calculateInfoForSkill(StpInfo const &info)
     if (!info.getPositionToMoveTo() || !skillStpInfo.getBall() || !skillStpInfo.getRobot()) return std::nullopt;
 
     Vector2 targetPos;
-    if (standStillCounter > 60){
+    if (standStillCounter > 60) {
         auto moveVector = info.getRobot()->get()->getPos() - info.getBall()->get()->position;
-        targetPos = info.getBall()->get()->position + moveVector.stretchToLength(control_constants::AVOID_BALL_DISTANCE);
+        targetPos = info.getBall()->get()->position + moveVector.stretchToLength(0.30);
     } else {
         standStillCounter++;
         targetPos = info.getRobot()->get()->getPos();
@@ -35,7 +35,7 @@ std::optional<StpInfo> BallStandBack::calculateInfoForSkill(StpInfo const &info)
 
     // Be 100% sure the dribbler is off during the BallStandBack
     skillStpInfo.setDribblerSpeed(0);
-
+    skillStpInfo.setShouldAvoidBall(true);
     return skillStpInfo;
 }
 
@@ -45,7 +45,7 @@ bool BallStandBack::isTacticFailing(const StpInfo &info) noexcept {
 }
 
 bool BallStandBack::shouldTacticReset(const StpInfo &info) noexcept {
-    bool shouldReset = (info.getRobot()->get()->getPos() - info.getBall()->get()->position).length() < control_constants::AVOID_BALL_DISTANCE;
+    bool shouldReset = (info.getRobot()->get()->getPos() - info.getBall()->get()->position).length() < 0.15;
     if (!shouldReset) standStillCounter = 0;
     return shouldReset;
 }


### PR DESCRIPTION
### Comments for the reviewer
This PR improves ball placement by making the following changes:
- Only use ballStandback to move away from the ball by 15cm, since avoidBall should be used to actually go to a good ball avoiding position. BallStandBack is only used to make sure stop dribbling the ball after we place it.
- Changing when DriveWithBall to only reset when the angle to the ball > hasBallAngle instead of GoToPosAngleErrorMargin. The latter is a much smaller margin, which can quite easily be exceeded when driving with the ball even when nothing goes wrong.
- Make sure we actually avoid ball collisions if we set shouldAvoidBall to true

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
