### PR TITLE
Feature/roles with ball control

### DIFF
--- a/include/roboteam_ai/utilities/Constants.h
+++ b/include/roboteam_ai/utilities/Constants.h
@@ -130,9 +130,11 @@ class Constants {
 
     static std::map<int, bool> ROBOTS_WITH_WORKING_DRIBBLER();
     static std::map<int, bool> ROBOTS_WITH_WORKING_BALL_SENSOR();
+    static std::map<int, bool> ROBOTS_WITH_WORKING_DRIBBLER_ENCODER();
 
     static bool ROBOT_HAS_WORKING_DRIBBLER(int id);
     static bool ROBOT_HAS_WORKING_BALL_SENSOR(int id);
+    static bool ROBOT_HAS_WORKING_DRIBBLER_ENCODER(int id); // Needed to detect if we have the ball
 
     static QColor FIELD_COLOR();
     static QColor FIELD_LINE_COLOR();

--- a/include/roboteam_ai/utilities/Dealer.h
+++ b/include/roboteam_ai/utilities/Dealer.h
@@ -33,7 +33,8 @@ enum class DealerFlagTitle {
     NOT_IMPORTANT,
     READY_TO_INTERCEPT_GOAL_SHOT,
     KEEPER,
-    CLOSEST_TO_BALL
+    CLOSEST_TO_BALL,
+    CAN_DETECT_BALL // Has a ballSensor and/or dribblerEncoder
 };
 
 /// Generalization for Priority of a role

--- a/src/stp/plays/contested/GetBallPossession.cpp
+++ b/src/stp/plays/contested/GetBallPossession.cpp
@@ -92,12 +92,12 @@ void GetBallPossession::calculateInfoForRoles() noexcept {
 Dealer::FlagMap GetBallPossession::decideRoleFlags() const noexcept {
     Dealer::FlagMap flagMap;
 
-    Dealer::DealerFlag ballGetterFlag(DealerFlagTitle::CLOSE_TO_BALL, DealerFlagPriority::REQUIRED);
-    Dealer::DealerFlag closeToOurGoalFlag(DealerFlagTitle::CLOSE_TO_OUR_GOAL, DealerFlagPriority::MEDIUM_PRIORITY);
-    Dealer::DealerFlag closeToTheirGoalFlag(DealerFlagTitle::CLOSE_TO_THEIR_GOAL, DealerFlagPriority::MEDIUM_PRIORITY);
+    Dealer::DealerFlag keeperFlag(DealerFlagTitle::KEEPER, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag canDetectBallFlag(DealerFlagTitle::CAN_DETECT_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag closeToBallFlag(DealerFlagTitle::CLOSE_TO_BALL, DealerFlagPriority::HIGH_PRIORITY);
 
-    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {}}});
-    flagMap.insert({"ball_getter", {DealerFlagPriority::REQUIRED, {ballGetterFlag}}});
+    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {keeperFlag}}});
+    flagMap.insert({"ball_getter", {DealerFlagPriority::REQUIRED, {canDetectBallFlag, closeToBallFlag}}});
     flagMap.insert({"defender_0", {DealerFlagPriority::HIGH_PRIORITY, {}}});
     flagMap.insert({"defender_1", {DealerFlagPriority::HIGH_PRIORITY, {}}});
     flagMap.insert({"defender_2", {DealerFlagPriority::HIGH_PRIORITY, {}}});

--- a/src/stp/plays/defensive/DefendPass.cpp
+++ b/src/stp/plays/defensive/DefendPass.cpp
@@ -50,12 +50,13 @@ uint8_t DefendPass::score(const rtt::world::Field& field) noexcept {
 Dealer::FlagMap DefendPass::decideRoleFlags() const noexcept {
     Dealer::FlagMap flagMap;
 
+    Dealer::DealerFlag keeperFlag(DealerFlagTitle::KEEPER, DealerFlagPriority::KEEPER);
     Dealer::DealerFlag closeToOurGoalFlag(DealerFlagTitle::CLOSE_TO_OUR_GOAL, DealerFlagPriority::HIGH_PRIORITY);
     Dealer::DealerFlag closestToBallFlag(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::HIGH_PRIORITY);
     Dealer::DealerFlag closeToTheirGoalFlag(DealerFlagTitle::CLOSE_TO_THEIR_GOAL, DealerFlagPriority::HIGH_PRIORITY);
     Dealer::DealerFlag notImportant(DealerFlagTitle::NOT_IMPORTANT, DealerFlagPriority::LOW_PRIORITY);
 
-    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {}}});
+    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {keeperFlag}}});
     flagMap.insert({"robot_defender", {DealerFlagPriority::HIGH_PRIORITY, {closestToBallFlag}}});
     flagMap.insert({"defender_1", {DealerFlagPriority::HIGH_PRIORITY, {closeToOurGoalFlag}}});
     flagMap.insert({"defender_2", {DealerFlagPriority::HIGH_PRIORITY, {closeToOurGoalFlag}}});

--- a/src/stp/plays/offensive/Attack.cpp
+++ b/src/stp/plays/offensive/Attack.cpp
@@ -46,18 +46,19 @@ uint8_t Attack::score(const rtt::world::Field& field) noexcept {
 Dealer::FlagMap Attack::decideRoleFlags() const noexcept {
     Dealer::FlagMap flagMap;
     Dealer::DealerFlag keeperFlag(DealerFlagTitle::KEEPER, DealerFlagPriority::KEEPER);
-    Dealer::DealerFlag strikerFlag(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag canDetectBallFlag(DealerFlagTitle::CAN_DETECT_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag closeToBallFlag(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::REQUIRED);
 
     flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {keeperFlag}}});
-    flagMap.insert({"striker", {DealerFlagPriority::REQUIRED, {strikerFlag}}});
-    flagMap.insert({"attacker_1", {DealerFlagPriority::HIGH_PRIORITY, {}}});
-    flagMap.insert({"attacker_2", {DealerFlagPriority::HIGH_PRIORITY, {}}});
+    flagMap.insert({"striker", {DealerFlagPriority::REQUIRED, {canDetectBallFlag, closeToBallFlag}}});
+    flagMap.insert({"attacker_1", {DealerFlagPriority::HIGH_PRIORITY, {canDetectBallFlag}}});
+    flagMap.insert({"attacker_2", {DealerFlagPriority::HIGH_PRIORITY, {canDetectBallFlag}}});
     flagMap.insert({"midfielder_left", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"midfielder_mid", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"midfielder_right", {DealerFlagPriority::LOW_PRIORITY, {}}});
-    flagMap.insert({"attacking_midfielder", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"attacking_midfielder", {DealerFlagPriority::MEDIUM_PRIORITY, {canDetectBallFlag}}});
     flagMap.insert({"defender_left", {DealerFlagPriority::LOW_PRIORITY, {}}});
-    flagMap.insert({"defender_mid", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
+    flagMap.insert({"defender_mid", {DealerFlagPriority::MEDIUM_PRIORITY, {canDetectBallFlag}}});
     flagMap.insert({"defender_right", {DealerFlagPriority::LOW_PRIORITY, {}}});
 
     return flagMap;

--- a/src/stp/plays/offensive/Attack.cpp
+++ b/src/stp/plays/offensive/Attack.cpp
@@ -47,7 +47,7 @@ Dealer::FlagMap Attack::decideRoleFlags() const noexcept {
     Dealer::FlagMap flagMap;
     Dealer::DealerFlag keeperFlag(DealerFlagTitle::KEEPER, DealerFlagPriority::KEEPER);
     Dealer::DealerFlag canDetectBallFlag(DealerFlagTitle::CAN_DETECT_BALL, DealerFlagPriority::REQUIRED);
-    Dealer::DealerFlag closeToBallFlag(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag closeToBallFlag(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::HIGH_PRIORITY);
 
     flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {keeperFlag}}});
     flagMap.insert({"striker", {DealerFlagPriority::REQUIRED, {canDetectBallFlag, closeToBallFlag}}});

--- a/src/stp/plays/referee_specific/BallPlacementUs.cpp
+++ b/src/stp/plays/referee_specific/BallPlacementUs.cpp
@@ -56,10 +56,11 @@ void BallPlacementUs::calculateInfoForRoles() noexcept {
 
 Dealer::FlagMap BallPlacementUs::decideRoleFlags() const noexcept {
     Dealer::FlagMap flagMap;
-    Dealer::DealerFlag ballPlacement(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag ballPlacementPriority(DealerFlagTitle::CAN_DETECT_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag ballPlacementPreference(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::HIGH_PRIORITY);
 
     flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {}}});
-    flagMap.insert({"ball_placer", {DealerFlagPriority::REQUIRED, {ballPlacement}}});
+    flagMap.insert({"ball_placer", {DealerFlagPriority::REQUIRED, {ballPlacementPriority, ballPlacementPreference}}});
     flagMap.insert({"ball_avoider_0", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"ball_avoider_1", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"ball_avoider_2", {DealerFlagPriority::LOW_PRIORITY, {}}});

--- a/src/stp/plays/referee_specific/FreeKickUsAtGoal.cpp
+++ b/src/stp/plays/referee_specific/FreeKickUsAtGoal.cpp
@@ -41,10 +41,12 @@ uint8_t FreeKickUsAtGoal::score(const rtt::world::Field& field) noexcept {
 Dealer::FlagMap FreeKickUsAtGoal::decideRoleFlags() const noexcept {
     Dealer::FlagMap flagMap;
     Dealer::DealerFlag keeperFlag(DealerFlagTitle::KEEPER, DealerFlagPriority::KEEPER);
-    Dealer::DealerFlag freeKickTakerFlag(DealerFlagTitle::CLOSE_TO_BALL, DealerFlagPriority::REQUIRED);
+
+    Dealer::DealerFlag freeKickTakerPriority(DealerFlagTitle::CAN_DETECT_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag freeKickTakerPreference(DealerFlagTitle::CLOSE_TO_BALL, DealerFlagPriority::HIGH_PRIORITY);
 
     flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {keeperFlag}}});
-    flagMap.insert({"free_kick_taker", {DealerFlagPriority::REQUIRED, {freeKickTakerFlag}}});
+    flagMap.insert({"free_kick_taker", {DealerFlagPriority::REQUIRED, {freeKickTakerPriority, freeKickTakerPreference}}});
     flagMap.insert({"attacker_1", {DealerFlagPriority::HIGH_PRIORITY, {}}});
     flagMap.insert({"attacker_2", {DealerFlagPriority::HIGH_PRIORITY, {}}});
     flagMap.insert({"midfielder_left", {DealerFlagPriority::LOW_PRIORITY, {}}});

--- a/src/stp/plays/referee_specific/KickOffUs.cpp
+++ b/src/stp/plays/referee_specific/KickOffUs.cpp
@@ -68,11 +68,15 @@ void KickOffUs::calculateInfoForRoles() noexcept {
 
 Dealer::FlagMap KickOffUs::decideRoleFlags() const noexcept {
     Dealer::FlagMap flagMap;
-    Dealer::DealerFlag kickerFlag(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::REQUIRED);
 
-    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {}}});
-    flagMap.insert({"kick_off_taker", {DealerFlagPriority::REQUIRED, {kickerFlag}}});
-    flagMap.insert({"receiver", {DealerFlagPriority::HIGH_PRIORITY, {}}});
+    Dealer::DealerFlag keeperFlag(DealerFlagTitle::KEEPER, DealerFlagPriority::KEEPER);
+    Dealer::DealerFlag kickerPriority(DealerFlagTitle::CAN_DETECT_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag kickerPreference(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::HIGH_PRIORITY);
+    Dealer::DealerFlag receiverFlag(DealerFlagTitle::CAN_DETECT_BALL, DealerFlagPriority::HIGH_PRIORITY);
+
+    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {keeperFlag}}});
+    flagMap.insert({"kick_off_taker", {DealerFlagPriority::REQUIRED, {kickerPriority, kickerPreference}}});
+    flagMap.insert({"receiver", {DealerFlagPriority::HIGH_PRIORITY, {receiverFlag}}});
     flagMap.insert({"halt_0", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"halt_1", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"halt_2", {DealerFlagPriority::LOW_PRIORITY, {}}});

--- a/src/stp/plays/referee_specific/KickOffUsPrepare.cpp
+++ b/src/stp/plays/referee_specific/KickOffUsPrepare.cpp
@@ -86,7 +86,7 @@ Dealer::FlagMap KickOffUsPrepare::decideRoleFlags() const noexcept {
     flagMap.insert({"midfielder_left", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
     flagMap.insert({"midfielder_mid", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"midfielder_right", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
-    flagMap.insert({"attacker_left", {DealerFlagPriority::HIGH_PRIORITY, {}}});
+    flagMap.insert({"attacker_left", {DealerFlagPriority::HIGH_PRIORITY, {kickerPriority}}});
     flagMap.insert({"attacker_mid", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"attacker_right", {DealerFlagPriority::MEDIUM_PRIORITY, {}}});
 

--- a/src/stp/plays/referee_specific/KickOffUsPrepare.cpp
+++ b/src/stp/plays/referee_specific/KickOffUsPrepare.cpp
@@ -73,11 +73,13 @@ void KickOffUsPrepare::calculateInfoForRoles() noexcept {
 
 Dealer::FlagMap KickOffUsPrepare::decideRoleFlags() const noexcept {
     Dealer::FlagMap flagMap;
-    Dealer::DealerFlag kickerFlag(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::REQUIRED);
-    Dealer::DealerFlag closeToBallFlag(DealerFlagTitle::CLOSE_TO_BALL, DealerFlagPriority::HIGH_PRIORITY);
+    Dealer::DealerFlag keeperFlag(DealerFlagTitle::KEEPER, DealerFlagPriority::KEEPER);
 
-    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {}}});
-    flagMap.insert({"kicker", {DealerFlagPriority::REQUIRED, {kickerFlag}}});
+    Dealer::DealerFlag kickerPriority(DealerFlagTitle::CAN_DETECT_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag kickerPreference(DealerFlagTitle::CLOSEST_TO_BALL, DealerFlagPriority::HIGH_PRIORITY);
+
+    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {keeperFlag}}});
+    flagMap.insert({"kicker", {DealerFlagPriority::REQUIRED, {kickerPriority, kickerPreference}}});
     flagMap.insert({"defender_left", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"defender_mid", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"defender_right", {DealerFlagPriority::LOW_PRIORITY, {}}});

--- a/src/stp/plays/referee_specific/PenaltyUs.cpp
+++ b/src/stp/plays/referee_specific/PenaltyUs.cpp
@@ -35,11 +35,13 @@ Dealer::FlagMap PenaltyUs::decideRoleFlags() const noexcept {
     Dealer::FlagMap flagMap;  // DONT TOUCH.
 
     /// Flags that have a factor and a weight linked to it, can be given to a role
-    Dealer::DealerFlag kickerFlag(DealerFlagTitle::CLOSE_TO_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag keeperFlag(DealerFlagTitle::KEEPER, DealerFlagPriority::KEEPER);
+    Dealer::DealerFlag kickerPriority(DealerFlagTitle::CAN_DETECT_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag kickerPreference(DealerFlagTitle::CLOSE_TO_BALL, DealerFlagPriority::HIGH_PRIORITY);
 
     /// Creation flagMap. Linking roles to role-priority and the above created flags, can also force ID {roleName, {priority, flags, forceID}}
-    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {}}});
-    flagMap.insert({"kicker", {DealerFlagPriority::REQUIRED, {kickerFlag}}});
+    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {keeperFlag}}});
+    flagMap.insert({"kicker", {DealerFlagPriority::REQUIRED, {kickerPriority, kickerPreference}}});
     flagMap.insert({"halt_0", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"halt_1", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"halt_2", {DealerFlagPriority::LOW_PRIORITY, {}}});

--- a/src/stp/plays/referee_specific/PenaltyUsPrepare.cpp
+++ b/src/stp/plays/referee_specific/PenaltyUsPrepare.cpp
@@ -71,10 +71,13 @@ void PenaltyUsPrepare::calculateInfoForRoles() noexcept {
 
 Dealer::FlagMap PenaltyUsPrepare::decideRoleFlags() const noexcept {
     Dealer::FlagMap flagMap;
-    Dealer::DealerFlag kickerFormationFlag(DealerFlagTitle::CLOSE_TO_BALL, DealerFlagPriority::REQUIRED);
 
-    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {}}});
-    flagMap.insert({"kicker_formation", {DealerFlagPriority::REQUIRED, {kickerFormationFlag}}});
+    Dealer::DealerFlag keeperFlag(DealerFlagTitle::KEEPER, DealerFlagPriority::KEEPER);
+    Dealer::DealerFlag kickerPriority(DealerFlagTitle::CAN_DETECT_BALL, DealerFlagPriority::REQUIRED);
+    Dealer::DealerFlag kickerPreference(DealerFlagTitle::CLOSE_TO_BALL, DealerFlagPriority::HIGH_PRIORITY);
+
+    flagMap.insert({"keeper", {DealerFlagPriority::KEEPER, {keeperFlag}}});
+    flagMap.insert({"kicker_formation", {DealerFlagPriority::REQUIRED, {kickerPriority, kickerPreference}}});
     flagMap.insert({"formation_0", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"formation_1", {DealerFlagPriority::LOW_PRIORITY, {}}});
     flagMap.insert({"formation_2", {DealerFlagPriority::LOW_PRIORITY, {}}});

--- a/src/utilities/Constants.cpp
+++ b/src/utilities/Constants.cpp
@@ -191,6 +191,7 @@ std::map<int, bool> Constants::ROBOTS_WITH_WORKING_DRIBBLER() {
     return workingDribblerRobots;
 }
 
+// TODO: Make robot send this information instead of us hardcoding these values
 std::map<int, bool> Constants::ROBOTS_WITH_WORKING_BALL_SENSOR() {
     static std::map<int, bool> workingBallSensorRobots;
     workingBallSensorRobots[0] = false;
@@ -212,9 +213,36 @@ std::map<int, bool> Constants::ROBOTS_WITH_WORKING_BALL_SENSOR() {
 
     return workingBallSensorRobots;
 }
+
+// With the dribbler encoder, we can detect if the robot has the ball
+std::map<int, bool> Constants::ROBOTS_WITH_WORKING_DRIBBLER_ENCODER() {
+    static std::map<int, bool> workingDribblerEncoderRobots;
+    workingDribblerEncoderRobots[0] = true;
+    workingDribblerEncoderRobots[1] = true;
+    workingDribblerEncoderRobots[2] = true;
+    workingDribblerEncoderRobots[3] = true;
+    workingDribblerEncoderRobots[4] = true;
+    workingDribblerEncoderRobots[5] = true;
+    workingDribblerEncoderRobots[6] = true;
+    workingDribblerEncoderRobots[7] = true;
+    workingDribblerEncoderRobots[8] = true;
+    workingDribblerEncoderRobots[9] = true;
+    workingDribblerEncoderRobots[10] = true;
+    workingDribblerEncoderRobots[11] = true;
+    workingDribblerEncoderRobots[12] = true;
+    workingDribblerEncoderRobots[13] = true;
+    workingDribblerEncoderRobots[14] = true;
+    workingDribblerEncoderRobots[15] = true;
+
+    return workingDribblerEncoderRobots;
+}
+
 bool Constants::ROBOT_HAS_WORKING_BALL_SENSOR(int id) { return ROBOTS_WITH_WORKING_BALL_SENSOR()[id]; }
 
 bool Constants::ROBOT_HAS_WORKING_DRIBBLER(int id) { return ROBOTS_WITH_WORKING_DRIBBLER()[id]; }
+
+bool Constants::ROBOT_HAS_WORKING_DRIBBLER_ENCODER(int id) { return ROBOTS_WITH_WORKING_DRIBBLER_ENCODER()[id]; }
+
 QColor Constants::FIELD_COLOR() { return GRSIM() ? QColor(30, 30, 30, 255) : QColor(50, 0, 0, 255); }
 
 QColor Constants::FIELD_LINE_COLOR() { return Qt::white; }

--- a/src/utilities/Dealer.cpp
+++ b/src/utilities/Dealer.cpp
@@ -363,9 +363,17 @@ double Dealer::getDefaultFlagScores(const v::RobotView &robot, const Dealer::Dea
             return costForProperty(robot->getId() == world.getRobotClosestToBall(rtt::world::us)->get()->getId());
         case DealerFlagTitle::NOT_IMPORTANT:
             return 0;
+        case DealerFlagTitle::CAN_DETECT_BALL: {
+            bool hasWorkingBallSensor = Constants::ROBOT_HAS_WORKING_BALL_SENSOR(robot->getId());
+            bool hasDribblerEncoder = Constants::ROBOT_HAS_WORKING_DRIBBLER_ENCODER(robot->getId());
+            return costForProperty(hasWorkingBallSensor || hasDribblerEncoder);
+        }
+
+        default: {
+            RTT_WARNING("Unhandled dealerflag!")
+            return 0;
+        }
     }
-    RTT_WARNING("Unhandled dealerflag!")
-    return 0;
 }
 
 void Dealer::setGameStateRoleIds(std::unordered_map<std::string, v::RobotView> output) {

--- a/src/utilities/GameStateManager.cpp
+++ b/src/utilities/GameStateManager.cpp
@@ -218,9 +218,9 @@ void GameStateManager::updateInterfaceGameState(const char* name) {
     } else if (strcmp(name, "Ball Placement Them") == 0) {
         interface::Output::setInterfaceGameState(GameState("ball_placement_them", "ballplacement_them"));
     } else if (strcmp(name, "Kick Off Them Prepare") == 0) {
-        interface::Output::setInterfaceGameState(GameState("kick_off_them_prepare", "kickoff"));
+        interface::Output::setInterfaceGameState(GameState("kickoff_them_prepare", "kickoff"));
     } else if (strcmp(name, "Kick Off Us Prepare") == 0) {
-        interface::Output::setInterfaceGameState(GameState("kick_off_us_prepare", "kickoff"));
+        interface::Output::setInterfaceGameState(GameState("kickoff_us_prepare", "kickoff"));
     } else if (strcmp(name, "Kick Off Them") == 0) {
         interface::Output::setInterfaceGameState(GameState("kickoff_them", "default"));
     } else if (strcmp(name, "Kick Off Us") == 0) {


### PR DESCRIPTION
Dribbler encoders and ball sensors do not always work. When dividing roles that require ball manipulation, it is beneficial to exclude robots that cannot detect whether they have the ball.
This PR introduces a Dealer flag called CAN_DETECT_BALL, which is used by a few plays, accompanied by a Constants function that keeps track of hard-coded booleans indicating a working ball sensor and dribbler encoder.

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
