### PR TITLE
Ignore waller collisions when close to targetPos

### DIFF
--- a/include/roboteam_ai/stp/StpInfo.h
+++ b/include/roboteam_ai/stp/StpInfo.h
@@ -93,6 +93,9 @@ struct StpInfo {
     bool getShouldAvoidOutOfField() const { return avoidObjects.shouldAvoidOutOfField; }
     void setShouldAvoidOutOfField(bool shouldAvoidOutOfField) { avoidObjects.shouldAvoidOutOfField = shouldAvoidOutOfField; }
 
+    bool getShouldAvoidOurRobots() const { return avoidObjects.shouldAvoidOurRobots; }
+    void setShouldAvoidOurRobots(bool shouldAvoidOurRobots) { avoidObjects.shouldAvoidOurRobots = shouldAvoidOurRobots; }
+
    private:
     /**
      * Current world pointer

--- a/include/roboteam_ai/utilities/StpInfoEnums.h
+++ b/include/roboteam_ai/utilities/StpInfoEnums.h
@@ -38,6 +38,7 @@ struct AvoidObjects {
     bool shouldAvoidBall = false;
     bool shouldAvoidDefenseArea = true;
     bool shouldAvoidOutOfField = true;
+    bool shouldAvoidOurRobots = true;
 };
 }  // namespace rtt::ai::stp
 #endif  // RTT_STPINFOENUMS_H

--- a/src/control/positionControl/BBTrajectories/WorldObjects.cpp
+++ b/src/control/positionControl/BBTrajectories/WorldObjects.cpp
@@ -48,7 +48,9 @@ std::optional<CollisionData> WorldObjects::getFirstCollision(const rtt::world::W
     calculateEnemyRobotCollisions(world, Trajectory, collisionDatas, pathPoints, timeStep, timeStepsDone);
 
     // For each path already calculated, check if this path collides with those paths
-    calculateOurRobotCollisions(world, collisionDatas, pathPoints, computedPaths, robotId, timeStep, timeStepsDone);
+    if (avoidObjects.shouldAvoidOurRobots) {
+        calculateOurRobotCollisions(world, collisionDatas, pathPoints, computedPaths, robotId, timeStep, timeStepsDone);
+    }
 
     if (!collisionDatas.empty()) {
         return collisionDatas[0];

--- a/src/stp/computations/PositionComputations.cpp
+++ b/src/stp/computations/PositionComputations.cpp
@@ -41,7 +41,7 @@ std::vector<Vector2> PositionComputations::determineWallPositions(const rtt::wor
 
     double radius = control_constants::ROBOT_RADIUS;
     double spacingRobots = radius * 0.5;
-    double spaceBetweenDefenseArea = 2 * radius;
+    double spaceBetweenDefenseArea = 6 * radius;
 
     Vector2 ballPos = FieldComputations::projectPointInField(field, world->getWorld().value().getBall()->get()->position);
 

--- a/src/stp/plays/defensive/DefendShot.cpp
+++ b/src/stp/plays/defensive/DefendShot.cpp
@@ -66,21 +66,19 @@ void DefendShot::calculateInfoForRoles() noexcept {
 }
 
 void DefendShot::calculateInfoForWallers() noexcept {
-    stpInfos["waller_1"].setAngle((world->getWorld()->getBall()->get()->position - field.getOurGoalCenter()).angle());
-    stpInfos["waller_2"].setAngle((world->getWorld()->getBall()->get()->position - field.getOurGoalCenter()).angle());
-    stpInfos["waller_3"].setAngle((world->getWorld()->getBall()->get()->position - field.getOurGoalCenter()).angle());
-    stpInfos["waller_4"].setAngle((world->getWorld()->getBall()->get()->position - field.getOurGoalCenter()).angle());
+    for (int i = 1; i <= 4; ++i) {
+        // For each waller, stand in the right wall position and look at the ball
+        auto positionToMoveTo = PositionComputations::getWallPosition(i - 1, 4, field, world);
+        stpInfos["waller_" + std::to_string(i)].setPositionToMoveTo(positionToMoveTo);
+        stpInfos["waller_" + std::to_string(i)].setAngle((world->getWorld()->getBall()->get()->position - field.getOurGoalCenter()).angle());
 
-    stpInfos["waller_1"].setPositionToMoveTo(PositionComputations::getWallPosition(0, 4, field, world));
-    stpInfos["waller_2"].setPositionToMoveTo(PositionComputations::getWallPosition(1, 4, field, world));
-    stpInfos["waller_3"].setPositionToMoveTo(PositionComputations::getWallPosition(2, 4, field, world));
-    stpInfos["waller_4"].setPositionToMoveTo(PositionComputations::getWallPosition(3, 4, field, world));
-
-    stpInfos["waller_1"].setShouldAvoidOurRobots(false);
-    stpInfos["waller_2"].setShouldAvoidOurRobots(false);
-    stpInfos["waller_3"].setShouldAvoidOurRobots(false);
-    stpInfos["waller_4"].setShouldAvoidOurRobots(false);
-
+        // If the waller is close to its target, ignore collisions
+        constexpr double IGNORE_COLLISIONS_DISTANCE = 1.0;
+        if (stpInfos["waller_" + std::to_string(i)].getRobot()) {
+            if ((stpInfos["waller_" + std::to_string(i)].getRobot()->get()->getPos() - positionToMoveTo).length() < IGNORE_COLLISIONS_DISTANCE)
+                stpInfos["waller_" + std::to_string(i)].setShouldAvoidOurRobots(false);
+        }
+    }
 }
 
 void DefendShot::calculateInfoForDefenders() noexcept {

--- a/src/stp/plays/defensive/DefendShot.cpp
+++ b/src/stp/plays/defensive/DefendShot.cpp
@@ -75,6 +75,12 @@ void DefendShot::calculateInfoForWallers() noexcept {
     stpInfos["waller_2"].setPositionToMoveTo(PositionComputations::getWallPosition(1, 4, field, world));
     stpInfos["waller_3"].setPositionToMoveTo(PositionComputations::getWallPosition(2, 4, field, world));
     stpInfos["waller_4"].setPositionToMoveTo(PositionComputations::getWallPosition(3, 4, field, world));
+
+    stpInfos["waller_1"].setShouldAvoidOurRobots(false);
+    stpInfos["waller_2"].setShouldAvoidOurRobots(false);
+    stpInfos["waller_3"].setShouldAvoidOurRobots(false);
+    stpInfos["waller_4"].setShouldAvoidOurRobots(false);
+
 }
 
 void DefendShot::calculateInfoForDefenders() noexcept {


### PR DESCRIPTION
This should prevent the wallers from making very weird paths to avoid collisions, at the cost of probably bumping into our robots more

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
