### PR TITLE
Fix BBT path-point being more than 0.1s away from the robot

### DIFF
--- a/include/roboteam_ai/control/positionControl/PositionControl.h
+++ b/include/roboteam_ai/control/positionControl/PositionControl.h
@@ -49,7 +49,8 @@ class PositionControl {
      * @param targetPosition the desired position that the robot has to reachsho
      * @return Boolean that is 1 if the path needs to be recalculated
      */
-    bool shouldRecalculateTrajectory(const rtt::world::World *world, const rtt::world::Field &field, int robotId, Vector2 targetPosition, ai::stp::AvoidObjects);
+    bool shouldRecalculateTrajectory(const rtt::world::World *world, const rtt::world::Field &field, int robotId, Vector2 targetPosition, const Vector2 &currentPosition,
+                                     ai::stp::AvoidObjects);
 
    public:
     /**


### PR DESCRIPTION
### Comments for the reviewer
Please verify this works on the field. I cannot replicate the issues in the simulator now. The constant *might need* to be tuned. 

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
