### PR TITLE
Fix formation before half starts

### DIFF
--- a/include/roboteam_ai/STPManager.h
+++ b/include/roboteam_ai/STPManager.h
@@ -28,7 +28,7 @@ class STPManager {
      * Function that decides whether to change plays given a world and field.
      * @param _world the current world state
      */
-    void decidePlay(world::World* _world);
+    void decidePlay(world::World* _world, const proto::SSL_Referee_Stage& stage);
 
    public:
     void start();

--- a/src/stp/plays/offensive/Attack.cpp
+++ b/src/stp/plays/offensive/Attack.cpp
@@ -72,7 +72,7 @@ void Attack::calculateInfoForRoles() noexcept {
     calculateInfoForAttackers();
     calculateInfoForDefenders();
     calculateInfoForBlocker();
-    calculateInfoForMidfielders()
+    calculateInfoForMidfielders();
 
     // Keeper
     stpInfos["keeper"].setPositionToMoveTo(field.getOurGoalCenter());


### PR DESCRIPTION
This, untested but low risk, puts robot into formation before the half time starts

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
