### PR TITLE
de-hardcode distance for BlockRobot tactic

### DIFF
--- a/src/stp/tactics/passive/BlockRobot.cpp
+++ b/src/stp/tactics/passive/BlockRobot.cpp
@@ -1,13 +1,8 @@
-//
 // Created by jessevw on 12.03.20.
 /// Places a robot between a given TARGET and a given ENEMY at a distance from the the ENEMY
-/// TODO-Max de-hardcode the distance (with speed of the enemy? Standstill is block really close?)
-
 /// PASSIVE
-//
 
 #include "stp/tactics/passive/BlockRobot.h"
-
 #include "stp/computations/PositionComputations.h"
 #include "stp/skills/GoToPos.h"
 
@@ -41,26 +36,27 @@ double BlockRobot::calculateAngle(const world::view::RobotView enemy, const Vect
     return lineEnemyToTarget.angle();
 }
 
+/// TODO: fine tune distance
 Vector2 BlockRobot::calculateDesiredRobotPosition(BlockDistance blockDistance, const world::view::RobotView enemy, const Vector2 &targetLocation, double enemyDistance) {
-    auto lineEnemyToTarget = targetLocation - enemy->getPos();
-    double distance;
+    auto lineEnemyToTarget = targetLocation - enemy->getPos(); // predicted trajectory of enemy robot to target
+    double distance; // distance from the enemy robot to blocking position
 
     switch (blockDistance) {
         case BlockDistance::CLOSE:
-            distance = 0.5;
+            distance = 3 * control_constants::ROBOT_RADIUS + enemy->getVel().length(); // get as close to the enemy robot as possible without colliding
             break;
         case BlockDistance::HALFWAY:
-            distance = lineEnemyToTarget.length() / 2;
+            distance = lineEnemyToTarget.length() / 2 + 0.5 * enemy->getVel().length(); // get in the middle of enemy robot and target location
             break;
         case BlockDistance::FAR:
-            distance = lineEnemyToTarget.length() - 4 * control_constants::ROBOT_RADIUS;
+            distance = lineEnemyToTarget.length() - 4 * control_constants::ROBOT_RADIUS; // get close to the target location
             break;
         default:
-            distance = lineEnemyToTarget.length() / 2;
+            distance = lineEnemyToTarget.length() / 2 + 0.5 * enemy->getVel().length(); // default BlockDistance is HALFWAY
             break;
     }
 
-    if (distance < 4 * control_constants::ROBOT_RADIUS || enemyDistance < distance) {
+    if (distance < 4 * control_constants::ROBOT_RADIUS || enemyDistance < distance) { // if enemy is closer to target position
         distance = lineEnemyToTarget.length() / 2;
     }
 


### PR DESCRIPTION
distance from enemy robot to blocking position was hardcoded in BlockRobot.cpp, changed it, so now it is relative to the velocity of the velocity of the robot still requires fine tuning

### Comments for the reviewer
- changed the way distance is calculated but requires fine tuning so will probably have unwanted behaviour

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
