### PR TITLE
Keeper should not chase ball outside defense area

### DIFF
--- a/src/stp/plays/defensive/KeeperKickBall.cpp
+++ b/src/stp/plays/defensive/KeeperKickBall.cpp
@@ -118,6 +118,9 @@ bool KeeperKickBall::shouldEndPlay() noexcept {
             1.05 * stp::PositionScoring::scorePosition(passInfo.passLocation, gen::AttackingPass, field, world).score)
         return true;
 
+    // If the ball is outside our defense area the keeper should not go after it so we should stop this play
+    if (FieldComputations::pointIsInOurDefenseArea(field, world->getWorld()->getBall()->get()->position)) return true;
+
     return false;
 }
 const char* KeeperKickBall::getName() { return "Keeper Kick Ball"; }


### PR DESCRIPTION
keeper would chase the ball even outside our defense area when the play KeeperKickBall is active. changed it so the play terminates when the ball is not in our defense area

### Comments for the reviewer
- 

### Pre pull request checklist:

###### Code Quality
- [ ] Is the code is understandable and easy to read
- [ ] Changes to the code comply with set clang-format rules
- [ ] No use of manual memory control (e.g new/malloc/colloc etc)
- [ ] Are (only) smart pointers used?

###### Testing
- [ ] All tests are passing.
- [ ] I _added new / changed existing_ tests to reflect code changes (state why not otherwise!)
- [ ] I tested my changes manually (Describe how, to what extent etc.)

###### Commit Messages
- [ ] Commit message is saying what has been changed, **why** it was changed? Remember other developers might not know
  what the problem you are fixing was. Note also negative _decision_ (e.g., why did you not do particular thing)
  **TLDR: Commit message are comprehensive**
- [ ] Commit messages follows the rules of https://chris.beams.io/posts/git-commit/
